### PR TITLE
Updating the parsing of HTTP/2 pseudo header fields.

### DIFF
--- a/local/include/core/ProxyVerifier.h
+++ b/local/include/core/ProxyVerifier.h
@@ -53,6 +53,7 @@ static const std::string YAML_HTTP_VERSION_KEY{"version"};
 static const std::string YAML_HTTP_STATUS_KEY{"status"};
 static const std::string YAML_HTTP_REASON_KEY{"reason"};
 static const std::string YAML_HTTP_METHOD_KEY{"method"};
+static const std::string YAML_HTTP_SCHEME_KEY{"scheme"};
 static const std::string YAML_HTTP_URL_KEY{"url"};
 static const std::string YAML_CONTENT_KEY{"content"};
 static const std::string YAML_CONTENT_LENGTH_KEY{"size"};
@@ -423,6 +424,7 @@ public:
   /// @{
   static TextView FIELD_CONTENT_LENGTH;
   static TextView FIELD_TRANSFER_ENCODING;
+  static TextView FIELD_HOST;
   /// @}
 
   /// Mark which status codes have no content by default.
@@ -435,6 +437,7 @@ public:
   self_type &operator=(self_type &&that) = default;
 
   swoc::Errata load(YAML::Node const &node);
+  swoc::Errata parse_url(TextView url);
 
   swoc::Rv<ParseResult> parse_request(TextView data);
   swoc::Rv<ParseResult> parse_response(TextView data);


### PR DESCRIPTION
Before this change, we assumed that the url YAML element had the scheme, authority, and path from which we populated the HTTP/2 pseudo header fields. However, the url element may just have the path. This updates the parser to also look for the scheme from the YAML element and, if the url doesn't have it, grabs the authority from the Host header field.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
