### PR TITLE
Adding duplicate field validation support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,30 +22,20 @@ Each header field specification can verify one of the following:
 
 Thus the following JSON field specification requests no field verification:
 
-```json
-  [
-      "X-Forwarded-For",
-      "10.10.10.2"
-  ],
+```YAML
+  - [ X-Forwarded-For, 10.10.10.2 ]
 ```
 
 The following specifies that the HTTP field `X-Forwarded-For` _with any value_ should not have been sent by the proxy:
 
-```json
-  [
-      "X-Forwarded-For",
-      "10.10.10.2",
-      "absent"
-  ],
+```YAML
+  - [ X-Forwarded-For, 10.10.10.2, absent ]
 ```
 
 The following specifies that `X-Forwarded-For` should have been received from the proxy with the exact value "10.10.10.2":
-```json
-  [
-      "X-Forwarded-For",
-      "10.10.10.1",
-      "equal"
-  ],
+
+```YAML
+  - [ X-Forwarded-For, 10.10.10.2, equal ]
 ```
 
 ## Install

--- a/test/autests/gold_tests/field_parsing/gold/duplicate_fields_client.gold
+++ b/test/autests/gold_tests/field_parsing/gold/duplicate_fields_client.gold
@@ -1,11 +1,14 @@
 ``
 ``Headers:
-- "uuid": "1"
-- "content-length": "16"
 - "x-test-response": "first"
 - "x-test-response": "second"
 - "x-test-response": "third"
+- "content-length": "16"
 - "content-type": "text/html"
+- "uuid": "1"
+- "x-response-sequence": "first"
+- "x-response-sequence": "second"
+- "x-response-sequence": "third"
 
    [0]: Status: "200"
 ``

--- a/test/autests/gold_tests/field_parsing/gold/duplicate_fields_proxy.gold
+++ b/test/autests/gold_tests/field_parsing/gold/duplicate_fields_proxy.gold
@@ -1,13 +1,18 @@
 ``
 GET http://example.one/config/settings.yaml HTTP/1.1
 uuid: 1
+host: example.one
+x-request-sequence: second
+x-request-sequence: first
 x-test-request: second
 x-test-request: first
-host: example.one
 
 
 HTTP/1.1 200 OK
 uuid: 1
+x-response-sequence: third
+x-response-sequence: second
+x-response-sequence: first
 content-type: text/html
 content-length: 16
 x-test-response: third

--- a/test/autests/gold_tests/field_parsing/gold/duplicate_fields_server.gold
+++ b/test/autests/gold_tests/field_parsing/gold/duplicate_fields_server.gold
@@ -1,10 +1,12 @@
 ``
 ``Responding to request /config/settings.yaml with status 200.
 ``Headers:
-- "host": "example.one"
 - "Accept-Encoding": "identity"
 - "uuid": "1"
+- "host": "example.one"
 - "x-test-request": "first"
 - "x-test-request": "second"
+- "x-request-sequence": "first"
+- "x-request-sequence": "second"
 
 ``

--- a/test/autests/gold_tests/field_verification/http_replay_files/duplicate_fields/duplicate_field_verification.yaml
+++ b/test/autests/gold_tests/field_verification/http_replay_files/duplicate_fields/duplicate_field_verification.yaml
@@ -4,7 +4,12 @@ meta:
 sessions:
 - protocol: [ ipv4, tcp ]
   transactions:
-  - client-request:
+  - all:
+      headers:
+        fields:
+        - [ uuid, 1 ]
+
+    client-request:
       version: "1.1"
       scheme: "http"
       method: "GET"
@@ -12,10 +17,10 @@ sessions:
       headers:
         fields:
         - [ Host, example.one ]
-        - [ x-test-request, first ]
-        - [ x-test-request, second ]
-        - [ x-request-sequence, [ first, second] ]
-        - [ uuid, 1 ]
+        - [ X-Test-Request, [ first_data, second_data ] ]
+        - [ X-Test-Present, [ also, here ] ]
+        - [ X-Test-Equal, [ theSe, thE, values ] ]
+        - [ X-Test-Another, [ sOme, valuEs ] ]
     proxy-request:
       version: "1.1"
       scheme: "http"
@@ -24,10 +29,10 @@ sessions:
       headers:
         fields:
         - [ Host, example.one ]
-        - [ x-test-request, first ]
-        - [ x-test-request, second ]
-        - [ x-request-sequence, [ first, second] ]
-        - [ uuid, 1 ]
+        - [ X-Test-Request, [ second_data, first_data ], equal ]
+        - [ X-Test-Present, [ alsohere ], absent ]
+        - [ X-Test-Equal, [ theSe, thE, values ], equal ]
+        - [ X-Test-Another, [ who, cares ], present ]
     server-response:
       status: 200
       reason: OK
@@ -37,11 +42,7 @@ sessions:
         fields:
         - [ Content-Type, text/html ]
         - [ Content-Length, 16 ]
-        - [ x-test-response, first ]
-        - [ x-test-response, second ]
-        - [ x-test-response, third ]
-        - [ x-response-sequence, [ first, second, third] ]
-        - [ uuid, 1 ]
+        - [ Set-Cookie, [ ABCD, EFG ] ]
     proxy-response:
       status: 200
       reason: OK
@@ -51,8 +52,6 @@ sessions:
         fields:
         - [ Content-Type, text/html ]
         - [ Content-Length, 16 ]
-        - [ x-test-response, first ]
-        - [ x-test-response, second ]
-        - [ x-test-response, third ]
-        - [ x-response-sequence, [ first, second, third] ]
-        - [ uuid, 1 ]
+        - [ Set-Cookie, [ ABCD ], equal ]
+        - [ X-Not-A-Header, [ not, here ], absent ]
+        - [ X-Does-Not-Exist, [ also, not, here ], present ]


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

- Changes the _rules member variable to be a multimap so that it can support duplicate field verification. 
- Updates the Rules classes to support duplicate fields.
- Updates the YAML parser to support field value sequences as a way to express duplicate fields.

This address issue: https://github.com/yahoo/proxy-verifier/issues/5