### PR TITLE
Initialize variables and warn on transactions that that longer than 2 seconds

### DIFF
--- a/local/src/client/verifier-client.cc
+++ b/local/src/client/verifier-client.cc
@@ -263,7 +263,7 @@ swoc::Errata Run_Session(Ssn const &ssn, swoc::IPEndpoint const &target,
                          swoc::IPEndpoint const &target_https) {
   swoc::Errata errata;
   std::unique_ptr<Session> session;
-  const swoc::IPEndpoint *real_target;
+  const swoc::IPEndpoint *real_target = nullptr;
 
   errata.diag(R"(Starting session "{}":{} protocol={}.)", ssn._path,
               ssn._line_no, ssn.is_h2 ? "h2" : (ssn.is_tls ? "https" : "http"));

--- a/test/autests/gold_tests/field_parsing/gold/duplicate_fields_client.gold
+++ b/test/autests/gold_tests/field_parsing/gold/duplicate_fields_client.gold
@@ -1,4 +1,5 @@
 ``
+``Status: "200"
 ``Headers:
 - "x-test-response": "first"
 - "x-test-response": "second"
@@ -10,5 +11,4 @@
 - "x-response-sequence": "second"
 - "x-response-sequence": "third"
 
-   [0]: Status: "200"
 ``

--- a/test/autests/gold_tests/field_parsing/gold/empty_proxy_client.gold
+++ b/test/autests/gold_tests/field_parsing/gold/empty_proxy_client.gold
@@ -1,10 +1,10 @@
 ``
-``Reading response body offset=0000000 0000001 .
+``Status: "200"
 ``Headers:
 - "content-type": "text/html"
 - "content-length": "16"
 - "x-response": "testResponse"
 - "uuid": "1"
 
-``Status: "200"
+``Reading response body offset=0000000 0000001 .
 ``

--- a/test/autests/gold_tests/field_parsing/gold/empty_proxy_server.gold
+++ b/test/autests/gold_tests/field_parsing/gold/empty_proxy_server.gold
@@ -5,5 +5,5 @@
 - "x-request": "testRequest"
 - "Accept-Encoding": "identity"
 
-``Validating request with url: /config/settings.yaml
+``Handling request with url: /config/settings.yaml
 ``

--- a/test/autests/gold_tests/field_parsing/gold/yaml_specified_client.gold
+++ b/test/autests/gold_tests/field_parsing/gold/yaml_specified_client.gold
@@ -2,23 +2,23 @@
 ``Absence Success: Key: "1", Name: "x-test-different"
 ``Presence Success: Key: "1", Name: "x-test-header", Value: "backAtYou"
 ``
-``Absence Violation: Present. Key: "2", Name: "x-another-response", Value: "response"
-``
-``Reading response body offset=0000000 0000001 .
+``Status: "200"
 ``Headers:
 - "content-type": "text/html"
 - "content-length": "16"
 - "uuid": "1"
 - "x-test-header": "backAtYou"
 
-``Status: "200"
+``Reading response body offset=0000000 0000001 .
 ``
-``Reading response body offset=0000000 0000001 0000002 0000003 .
+``Absence Violation: Present. Key: "2", Name: "x-another-response", Value: "response"
 ``
 - "content-type": "text/html"
 - "content-length": "32"
 - "uuid": "2"
 - "x-another-response": "response"
+``
+``Reading response body offset=0000000 0000001 0000002 0000003 .
 ``
 ``2 transactions in 1 sessions``
 ``

--- a/test/autests/gold_tests/https/gold/single_transaction_server.gold
+++ b/test/autests/gold_tests/https/gold/single_transaction_server.gold
@@ -13,5 +13,5 @@
 - "accept-encoding": "gzip"
 - "content-type": "application/json; charset=utf-8"
 ``
-``Validating request with url: /a/path
+``Handling request with url: /a/path
 ``


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.


This addresses random EINVAL errors I was seeing on accept(). Also, adding a warning for transactions that take longer than 2 seconds to process. It took me a while to find that one response out of some 100,000 transactions without a content-length nor chunked encoded body took 30 seconds to time out. This will hopefully help track such issues down.