### PR TITLE
Original could would not find the original root slash and so not set the :path psuedo header

### DIFF
--- a/local/src/core/ProxyVerifier.cc
+++ b/local/src/core/ProxyVerifier.cc
@@ -1655,7 +1655,7 @@ HttpHeader::parse_url(TextView url)
     }
   }
   _authority = this->localize(_url.substr(auth_start, end_host - auth_start));
-  std::size_t path_start = _url.find("/", end_host + 1);
+  std::size_t path_start = _url.find("/", end_host);
   if (path_start != std::string::npos) {
     _path = this->localize(_url.substr(path_start));
   }


### PR DESCRIPTION

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
