### PR TITLE
Adding HTTP/2 timestamp and fix a leak

### DIFF
--- a/local/src/client/verifier-client.cc
+++ b/local/src/client/verifier-client.cc
@@ -197,7 +197,7 @@ swoc::Errata ClientReplayFileHandler::txn_open(YAML::Node const &node) {
 
 swoc::Errata ClientReplayFileHandler::client_request(YAML::Node const &node) {
   if (!Use_Proxy_Request_Directives) {
-    _txn._req.load(node);
+    return _txn._req.load(node);
   }
   return {};
 }


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.



- This adds logging of delayed HTTP/2 transactions.
- It also adds cleanup of the H2StreamState instances.