### PR TITLE
'-Wall', ASan leak fixes, connection close on unspecified bodies

### DIFF
--- a/Sconstruct
+++ b/Sconstruct
@@ -37,7 +37,7 @@ if path_nghttp2 is not None:
   custom_rpath.append(path_nghttp2 + "/lib")
 SetOptionDefault("RPATH",  custom_rpath)
 
-Part("swoc++/swoc++.part",vcs_type=VcsGit(server="github.com", repository="SolidWallOfCode/libswoc", tag="1.1.0"), package_group="proxy-verifier")
+Part("code/libswoc.part",vcs_type=VcsGit(server="github.com", repository="SolidWallOfCode/libswoc", tag="1.2.3"), package_group="proxy-verifier")
 
 
 Part("local/parts/proxy-verifier.part", package_group="proxy-verifier")

--- a/local/include/core/ArgParser.h
+++ b/local/include/core/ArgParser.h
@@ -230,7 +230,7 @@ public:
   /** Main parsing function
       @return The Arguments object available for program using
   */
-  Arguments parse(const char **argv);
+  Arguments parse(char const **argv);
   // Add the usage to global_usage for help_message(). Something like:
   // traffic_blabla [--SWITCH [ARG]]
   void add_global_usage(std::string const &usage);

--- a/local/include/core/ProxyVerifier.h
+++ b/local/include/core/ProxyVerifier.h
@@ -10,8 +10,8 @@
 #include <string>
 #include <unordered_set>
 
-#include <condition_variable>
 #include <chrono>
+#include <condition_variable>
 #include <deque>
 #include <memory>
 #include <nghttp2/nghttp2.h>
@@ -61,7 +61,7 @@ static const std::string YAML_HTTP_METHOD_KEY{"method"};
 static const std::string YAML_HTTP_SCHEME_KEY{"scheme"};
 static const std::string YAML_HTTP_URL_KEY{"url"};
 static const std::string YAML_CONTENT_KEY{"content"};
-static const std::string YAML_CONTENT_LENGTH_KEY{"size"};
+static const std::string YAML_CONTENT_SIZE_KEY{"size"};
 static const std::string YAML_CONTENT_DATA_KEY{"data"};
 static const std::string YAML_CONTENT_ENCODING_KEY{"encoding"};
 static const std::string YAML_CONTENT_TRANSFER_KEY{"transfer"};
@@ -193,12 +193,15 @@ class RuleCheck {
                ///< given rule type ("equals", "presence", or "absence")
 
   using MakeDuplicateFieldRuleFunction =
-      std::function<std::shared_ptr<RuleCheck>(swoc::TextView, std::list<swoc::TextView>&&)>;
+      std::function<std::shared_ptr<RuleCheck>(swoc::TextView,
+                                               std::list<swoc::TextView> &&)>;
   using DuplicateFieldRuleOptions =
-      std::unordered_map<swoc::TextView, MakeDuplicateFieldRuleFunction, Hash, Hash>;
+      std::unordered_map<swoc::TextView, MakeDuplicateFieldRuleFunction, Hash,
+                         Hash>;
   static DuplicateFieldRuleOptions
-      duplicate_field_options; ///< Returns function to construct a RuleCheck child class for a
-               ///< given duplicate field rule type ("equals", "presence", or "absence")
+      duplicate_field_options; ///< Returns function to construct a RuleCheck
+                               ///< child class for a given duplicate field rule
+                               ///< type ("equals", "presence", or "absence")
 
 protected:
   /// Name the expects_duplicate_fields parameter to the Rule constructors.
@@ -224,18 +227,17 @@ public:
    * @return A pointer to the RuleCheck instance generated, holding a key (and
    * potentially value) TextView for the rule to compare inputs to
    */
-  static std::shared_ptr<RuleCheck> make_rule_check(
-      swoc::TextView localized_name,
-      swoc::TextView localized_value,
-      swoc::TextView rule_type);
+  static std::shared_ptr<RuleCheck>
+  make_rule_check(swoc::TextView localized_name, swoc::TextView localized_value,
+                  swoc::TextView rule_type);
 
   /**
    * @param values The values of the field. This should be localized.
    */
-  static std::shared_ptr<RuleCheck> make_rule_check(
-      swoc::TextView localized_name,
-      std::list<swoc::TextView> &&localized_values,
-      swoc::TextView rule_type);
+  static std::shared_ptr<RuleCheck>
+  make_rule_check(swoc::TextView localized_name,
+                  std::list<swoc::TextView> &&localized_values,
+                  swoc::TextView rule_type);
 
   /** Generate @a EqualityCheck, invoked by the factory function when the
    * "equals" flag is present.
@@ -246,16 +248,14 @@ public:
    * @return A pointer to the EqualityCheck instance generated, holding key and
    * value TextViews for the rule to compare inputs to
    */
-  static std::shared_ptr<RuleCheck> make_equality(
-      swoc::TextView name,
-      swoc::TextView value);
+  static std::shared_ptr<RuleCheck> make_equality(swoc::TextView name,
+                                                  swoc::TextView value);
 
   /**
    * @param values The list of values to expect in the response.
    */
-  static std::shared_ptr<RuleCheck> make_equality(
-      swoc::TextView name,
-      std::list<swoc::TextView> &&values);
+  static std::shared_ptr<RuleCheck>
+  make_equality(swoc::TextView name, std::list<swoc::TextView> &&values);
 
   /** Generate @a PresenceCheck, invoked by the factory function when the
    * "absence" flag is present.
@@ -266,16 +266,14 @@ public:
    * @return A pointer to the Presence instance generated, holding a name
    * TextView for the rule to compare inputs to
    */
-  static std::shared_ptr<RuleCheck> make_presence(
-      swoc::TextView name,
-      swoc::TextView value);
+  static std::shared_ptr<RuleCheck> make_presence(swoc::TextView name,
+                                                  swoc::TextView value);
 
   /**
    * @param values (unused) The list of values specified in the YAML node.
    */
-  static std::shared_ptr<RuleCheck> make_presence(
-      swoc::TextView name,
-      std::list<swoc::TextView> &&values);
+  static std::shared_ptr<RuleCheck>
+  make_presence(swoc::TextView name, std::list<swoc::TextView> &&values);
 
   /** Generate @a AbsenceCheck, invoked by the factory function when the
    * "absence" flag is present.
@@ -286,16 +284,14 @@ public:
    * @return A pointer to the AbsenceCheck instance generated, holding a name
    * TextView for the rule to compare inputs to
    */
-  static std::shared_ptr<RuleCheck> make_absence(
-      swoc::TextView name,
-      swoc::TextView value);
+  static std::shared_ptr<RuleCheck> make_absence(swoc::TextView name,
+                                                 swoc::TextView value);
 
   /**
    * @param values (unused) The list of values specified in the YAML node.
    */
-  static std::shared_ptr<RuleCheck> make_absence(
-      swoc::TextView name,
-      std::list<swoc::TextView> &&values);
+  static std::shared_ptr<RuleCheck>
+  make_absence(swoc::TextView name, std::list<swoc::TextView> &&values);
 
   /** Pure virtual function to test whether the input name and value fulfill the
    * rules for the test
@@ -362,19 +358,23 @@ public:
    * @return Whether the check was successful or not
    */
   bool test(swoc::TextView key, swoc::TextView name,
-            const std::list<swoc::TextView> &values) const override;
+            std::list<swoc::TextView> const &values) const override;
 
   /** Whether this Rule is configured for duplicate fields.
    *
    * @return True of the Rule is configured for duplicate fields, false
    * otherwise.
    */
-  bool expects_duplicate_fields() const override { return _expects_duplicate_fields; }
+  bool expects_duplicate_fields() const override {
+    return _expects_duplicate_fields;
+  }
 
 private:
   swoc::TextView _value; ///< Only EqualityChecks require value comparisons.
-  std::list<swoc::TextView> _values; ///< Only EqualityChecks require value comparisons.
-  bool _expects_duplicate_fields = false; ///< Whether the Rule is configured for duplicate fields.
+  std::list<swoc::TextView>
+      _values; ///< Only EqualityChecks require value comparisons.
+  bool _expects_duplicate_fields =
+      false; ///< Whether the Rule is configured for duplicate fields.
 };
 
 class PresenceCheck : public RuleCheck {
@@ -382,7 +382,8 @@ public:
   /** Construct @a PresenceCheck with a given name.
    *
    * @param name The name of the target field
-   * @param expects_duplicate_fields Whether the rule should be configured for duplicate fields.
+   * @param expects_duplicate_fields Whether the rule should be configured for
+   * duplicate fields.
    */
   PresenceCheck(swoc::TextView name, bool expects_duplicate_fields);
 
@@ -403,14 +404,16 @@ public:
    * if not found)
    */
   bool test(swoc::TextView key, swoc::TextView name,
-            const std::list<swoc::TextView> &values) const override;
+            std::list<swoc::TextView> const &values) const override;
 
   /** Whether this Rule is configured for duplicate fields.
    *
    * @return True of the Rule is configured for duplicate fields, false
    * otherwise.
    */
-  bool expects_duplicate_fields() const override { return _expects_duplicate_fields; }
+  bool expects_duplicate_fields() const override {
+    return _expects_duplicate_fields;
+  }
 
 private:
   /** Whether this Rule is configured for duplicate fields. */
@@ -422,7 +425,8 @@ public:
   /** Construct @a AbsenceCheck with a given name.
    *
    * @param name The name of the target field
-   * @param expects_duplicate_fields Whether the rule should be configured for duplicate fields.
+   * @param expects_duplicate_fields Whether the rule should be configured for
+   * duplicate fields.
    */
   AbsenceCheck(swoc::TextView name, bool expects_duplicate_fields);
 
@@ -444,14 +448,16 @@ public:
    * if not found)
    */
   bool test(swoc::TextView key, swoc::TextView name,
-            const std::list<swoc::TextView> &values) const override;
+            std::list<swoc::TextView> const &values) const override;
 
   /** Whether this Rule is configured for duplicate fields.
    *
    * @return True of the Rule is configured for duplicate fields, false
    * otherwise.
    */
-  bool expects_duplicate_fields() const override { return _expects_duplicate_fields; }
+  bool expects_duplicate_fields() const override {
+    return _expects_duplicate_fields;
+  }
 
 private:
   /** Whether this Rule is configured for duplicate fields. */
@@ -461,8 +467,8 @@ private:
 class HttpFields {
   using self_type = HttpFields;
   /// Contains the RuleChecks for given field names.
-  using Rules = std::unordered_multimap<swoc::TextView, std::shared_ptr<RuleCheck>,
-                                        Hash, Hash>;
+  using Rules = std::unordered_multimap<swoc::TextView,
+                                        std::shared_ptr<RuleCheck>, Hash, Hash>;
   using Fields =
       std::unordered_multimap<swoc::TextView, std::string, Hash, Hash>;
 
@@ -573,7 +579,7 @@ public:
    * @param rules_ HeaderRules to iterate over, contains RuleCheck objects
    * @return Whether any rules were violated
    */
-  bool verify_headers(swoc::TextView key, const HttpFields &rules_) const;
+  bool verify_headers(swoc::TextView key, HttpFields const &rules_) const;
 
   unsigned _status = 0;
   TextView _reason;
@@ -597,9 +603,9 @@ public:
   std::shared_ptr<HttpFields> _fields_rules = nullptr;
 
   /// Body is chunked.
-  unsigned _chunked_p : 1;
+  bool _chunked_p = false;
   /// No Content-Length - close after sending body.
-  unsigned _content_length_p : 1;
+  bool _content_length_p = false;
 
   /// Format string to generate a key from a transaction.
   static std::string _key_format;
@@ -631,7 +637,7 @@ protected:
      * only override this method.
      */
     BufferWriter &operator()(BufferWriter &w,
-                             const swoc::bwf::Spec &spec) const override;
+                             swoc::bwf::Spec const &spec) const override;
 
   protected:
     HttpHeader const &_hdr;
@@ -789,14 +795,18 @@ public:
    *
    * @param[in] hdr The headers which specify how many body bytes to read.
    *
+   * @param[in] expected_content_size The response's content-length value
+   * or, failing that, the content:size value from the dumped response.
+   *
    * @param[in] initial The body already read from the socket.
    *
    * @return The number of bytes drained and an errata with messaging.
    */
   virtual swoc::Rv<size_t> drain_body(HttpHeader const &hdr,
+                                      size_t expected_content_size,
                                       swoc::TextView initial);
 
-  virtual swoc::Errata do_connect(const swoc::IPEndpoint *real_target);
+  virtual swoc::Errata do_connect(swoc::IPEndpoint const *real_target);
 
   /** Write the content in data to the socket.
    *
@@ -831,11 +841,14 @@ public:
 
   static swoc::Errata init();
 
-  virtual swoc::Errata run_transactions(const std::list<Txn> &txn,
-                                        const swoc::IPEndpoint *real_target);
-  virtual swoc::Errata run_transaction(const Txn &txn);
+  virtual swoc::Errata run_transactions(std::list<Txn> const &txn,
+                                        swoc::IPEndpoint const *real_target);
+  virtual swoc::Errata run_transaction(Txn const &json_txn);
 
 private:
+  virtual swoc::Rv<size_t> drain_body_internal(HttpHeader &hdr,
+                                               Txn const &json_txn,
+                                               swoc::TextView initial);
   int _fd = -1; ///< Socket.
 };
 
@@ -889,10 +902,10 @@ public:
   int32_t _stream_id = 0;
   int _data_to_recv = 0;
   size_t _send_body_offset = 0;
-  const char *_send_body = nullptr;
+  char const *_send_body = nullptr;
   size_t _send_body_length = 0;
-  const HttpHeader *_req = nullptr;
-  const HttpHeader *_resp = nullptr;
+  HttpHeader const *_req = nullptr;
+  HttpHeader const *_resp = nullptr;
   bool _wait_for_continue = false;
   std::string _key;
   std::chrono::time_point<std::chrono::system_clock> _stream_start;
@@ -902,10 +915,10 @@ class H2Session : public TLSSession {
 public:
   using super_type = TLSSession;
   H2Session();
+  ~H2Session();
   swoc::Rv<ssize_t> read(swoc::MemSpan<char> span) override;
   swoc::Rv<ssize_t> write(swoc::TextView data) override;
   virtual swoc::Rv<ssize_t> write(HttpHeader const &hdr);
-  ~H2Session() override = default;
 
   swoc::Errata connect() override;
   static swoc::Errata init(SSL_CTX *&srv_ctx, SSL_CTX *&clt_ctx);
@@ -914,9 +927,9 @@ public:
   }
   swoc::Errata session_init();
   swoc::Errata send_client_connection_header();
-  swoc::Errata run_transactions(const std::list<Txn> &txn,
-                                const swoc::IPEndpoint *real_target) override;
-  swoc::Errata run_transaction(const Txn &txn) override;
+  swoc::Errata run_transactions(std::list<Txn> const &txn,
+                                swoc::IPEndpoint const *real_target) override;
+  swoc::Errata run_transaction(Txn const &txn) override;
 
   nghttp2_session *get_session() { return _session; }
 
@@ -924,7 +937,8 @@ public:
 
 protected:
   nghttp2_session *_session;
-  nghttp2_session_callbacks *callbacks;
+  nghttp2_session_callbacks *_callbacks;
+  nghttp2_option *_options;
 
   static SSL_CTX *h2_server_ctx;
   static SSL_CTX *h2_client_ctx;
@@ -932,7 +946,7 @@ protected:
 private:
   swoc::Errata pack_headers(HttpHeader const &hdr, nghttp2_nv *&nv_hdr,
                             int &hdr_count);
-  nghttp2_nv tv_to_nv(const char *name, swoc::TextView v);
+  nghttp2_nv tv_to_nv(char const *name, swoc::TextView v);
 };
 
 class ChunkCodex {
@@ -946,7 +960,11 @@ public:
   /// where in the actual chunk the particular piece in @a chunk is placed.
   using ChunkCallback =
       std::function<bool(swoc::TextView chunk, size_t offset, size_t size)>;
-  enum Result { CONTINUE, DONE, ERROR };
+  enum Result {
+    CONTINUE, ///< The parser expects more bytes.
+    DONE,     ///< The final done chunk is completed.
+    ERROR     ///< A parsing error has ocurred.
+  };
 
   /** Parse @a data as chunked encoded.
    *
@@ -994,7 +1012,7 @@ protected:
 
 // YAML support utilities.
 namespace swoc {
-inline BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec,
+inline BufferWriter &bwformat(BufferWriter &w, bwf::Spec const & /* spec */,
                               YAML::Mark const &mark) {
   return w.print("line {}", mark.line);
 }
@@ -1017,7 +1035,7 @@ public:
     return {};
   }
   virtual swoc::Errata file_close() { return {}; }
-  virtual swoc::Errata ssn_open(YAML::Node const &node) { return {}; }
+  virtual swoc::Errata ssn_open(YAML::Node const & /* node */) { return {}; }
   virtual swoc::Errata ssn_close() { return {}; }
 
   /** Open the transaction node.
@@ -1028,14 +1046,23 @@ public:
    * This is required to do any base validation of the transaction such as
    * verifying required keys.
    */
-  virtual swoc::Errata txn_open(YAML::Node const &node) { return {}; }
+  virtual swoc::Errata txn_open(YAML::Node const & /* node */) { return {}; }
 
   virtual swoc::Errata txn_close() { return {}; }
-  virtual swoc::Errata client_request(YAML::Node const &node) { return {}; }
-  virtual swoc::Errata proxy_request(YAML::Node const &node) { return {}; }
-  virtual swoc::Errata server_response(YAML::Node const &node) { return {}; }
-  virtual swoc::Errata proxy_response(YAML::Node const &node) { return {}; }
-  virtual swoc::Errata apply_to_all_messages(HttpFields const &all_headers) {
+  virtual swoc::Errata client_request(YAML::Node const & /* node */) {
+    return {};
+  }
+  virtual swoc::Errata proxy_request(YAML::Node const & /* node */) {
+    return {};
+  }
+  virtual swoc::Errata server_response(YAML::Node const & /* node */) {
+    return {};
+  }
+  virtual swoc::Errata proxy_response(YAML::Node const & /* node */) {
+    return {};
+  }
+  virtual swoc::Errata
+  apply_to_all_messages(HttpFields const & /* all_headers */) {
     return {};
   }
 
@@ -1060,13 +1087,6 @@ swoc::Errata parse_ips(std::string arg, std::deque<swoc::IPEndpoint> &target);
 swoc::Errata resolve_ips(std::string arg, std::deque<swoc::IPEndpoint> &target);
 swoc::Rv<swoc::IPEndpoint> Resolve_FQDN(swoc::TextView host);
 
-namespace swoc {
-inline BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec,
-                              swoc::file::path const &path) {
-  return bwformat(w, spec, path.string());
-}
-} // namespace swoc
-
 class ThreadInfo {
 public:
   std::thread *_thread = nullptr;
@@ -1089,5 +1109,5 @@ protected:
   std::deque<ThreadInfo *> _threadPool;
   std::condition_variable _threadPoolCvar;
   std::mutex _threadPoolMutex;
-  const int max_threads = 2000;
+  const size_t max_threads = 2000;
 };

--- a/local/src/client/verifier-client.part
+++ b/local/src/client/verifier-client.part
@@ -10,7 +10,7 @@ env.DependsOn([
 ])
 
 env.AppendUnique(
-    CCFLAGS=['-std=c++17', '-g'],
+    CCFLAGS=['-std=c++17', '-g', '-Wall', '-Wextra', '-Werror'],
 )
 
 env.InstallBin(

--- a/local/src/core/ArgParser.cc
+++ b/local/src/core/ArgParser.cc
@@ -150,7 +150,7 @@ Arguments ArgParser::parse(const char **argv) {
   // if there is anything left, then output usage
   if (!args.empty()) {
     std::string msg = "Unknown command, option or args:";
-    for (const auto &it : args) {
+    for (auto const &it : args) {
       msg = msg + " '" + it + "'";
     }
     // find the correct level to output help message
@@ -190,7 +190,7 @@ ArgParser::Command::Command(std::string const &name,
 // check if this is a valid option before adding
 void ArgParser::Command::check_option(std::string const &long_option,
                                       std::string const &short_option,
-                                      std::string const &key) const {
+                                      std::string const & /* key */) const {
   if (long_option.size() < 3 || long_option[0] != '-' ||
       long_option[1] != '-') {
     // invalid name
@@ -219,7 +219,7 @@ void ArgParser::Command::check_option(std::string const &long_option,
 
 // check if this is a valid command before adding
 void ArgParser::Command::check_command(std::string const &name,
-                                       std::string const &key) const {
+                                       std::string const & /* key */) const {
   if (name.empty()) {
     // invalid name
     std::cerr << "Error: empty command cannot be added" << std::endl;
@@ -299,14 +299,14 @@ void ArgParser::Command::output_command(std::ostream &out,
     }
   }
   // recursive call
-  for (const auto &it : _subcommand_list) {
+  for (auto const &it : _subcommand_list) {
     it.second.output_command(out, "  " + prefix);
   }
 }
 
 // a nicely formatted way to output option message for help.
 void ArgParser::Command::output_option() const {
-  for (const auto &it : _option_list) {
+  for (auto const &it : _option_list) {
     std::string msg;
     if (!it.second.short_option.empty()) {
       msg = it.second.short_option + ", ";
@@ -455,7 +455,7 @@ void ArgParser::Command::append_option_data(Arguments &ret, AP_StrVec &args,
     }
   }
   // check for wrong number of arguments for --arg=...
-  for (const auto &it : check_map) {
+  for (auto const &it : check_map) {
     unsigned num = _option_list.at(it.first).arg_num;
     if (num != it.second && num < MORE_THAN_ONE_ARG_N) {
       help_message(std::to_string(_option_list.at(it.first).arg_num) +
@@ -463,7 +463,7 @@ void ArgParser::Command::append_option_data(Arguments &ret, AP_StrVec &args,
     }
   }
   // put in the default value of options
-  for (const auto &it : _option_list) {
+  for (auto const &it : _option_list) {
     if (!it.second.default_value.empty() && ret.get(it.second.key).empty()) {
       std::istringstream ss(it.second.default_value);
       std::string token;
@@ -558,11 +558,11 @@ void Arguments::set_env(std::string const &key, std::string const &value) {
 }
 
 void Arguments::show_all_configuration() const {
-  for (const auto &it : _data_map) {
+  for (auto const &it : _data_map) {
     std::cout << "name: " + it.first << std::endl;
     std::string msg;
     msg = "args value:";
-    for (const auto &it_data : it.second._values) {
+    for (auto const &it_data : it.second._values) {
       msg += " " + it_data;
     }
     std::cout << msg << std::endl;

--- a/local/src/core/core.part
+++ b/local/src/core/core.part
@@ -10,7 +10,7 @@ env.DependsOn([
 
 env.AppendUnique(
     CPPPATH=["${CHECK_OUT_DIR}/local/include"],
-    CCFLAGS=['-std=c++17', '-g'],
+    CCFLAGS=['-std=c++17', '-g', '-Wall', '-Wextra', '-Werror'],
 )
 
 env.SdkInclude(

--- a/local/src/server/verifier-server.part
+++ b/local/src/server/verifier-server.part
@@ -9,7 +9,7 @@ env.DependsOn([
 ])
 
 env.AppendUnique(
-    CCFLAGS=['-std=c++17', '-g'],
+    CCFLAGS=['-std=c++17', '-g', '-Wall', '-Wextra', '-Werror'],
 )
 
 env.InstallBin(

--- a/test/autests/gold_tests/field_parsing/gold/empty_proxy_client.gold
+++ b/test/autests/gold_tests/field_parsing/gold/empty_proxy_client.gold
@@ -6,5 +6,5 @@
 - "x-response": "testResponse"
 - "uuid": "1"
 
-``Reading response body offset=0000000 0000001 .
+``Reading response body: 0000000 0000001 .
 ``

--- a/test/autests/gold_tests/field_parsing/gold/yaml_specified_client.gold
+++ b/test/autests/gold_tests/field_parsing/gold/yaml_specified_client.gold
@@ -9,7 +9,7 @@
 - "uuid": "1"
 - "x-test-header": "backAtYou"
 
-``Reading response body offset=0000000 0000001 .
+``Reading response body: 0000000 0000001 .
 ``
 ``Absence Violation: Present. Key: "2", Name: "x-another-response", Value: "response"
 ``
@@ -18,7 +18,7 @@
 - "uuid": "2"
 - "x-another-response": "response"
 ``
-``Reading response body offset=0000000 0000001 0000002 0000003 .
+``Reading response body: 0000000 0000001 0000002 0000003 .
 ``
 ``2 transactions in 1 sessions``
 ``

--- a/test/autests/gold_tests/https/gold/single_transaction_client.gold
+++ b/test/autests/gold_tests/https/gold/single_transaction_client.gold
@@ -1,9 +1,10 @@
 ``
 ``Headers:
-- "date": "Sat, 16 Mar 2019 01:33:27 GMT"
-- "content-type": "multipart/form-data;snoopy=123456"
 - "age": "1"
 - "uuid": "cb9b4e94-5d42-43d4-8545-320033298ba2-214279439"
+- "content-length": "12"
+- "content-type": "multipart/form-data;snoopy=123456"
+- "date": "Sat, 16 Mar 2019 01:33:27 GMT"
 
 ``Status: "200"
 ``

--- a/test/autests/gold_tests/https/gold/single_transaction_proxy.gold
+++ b/test/autests/gold_tests/https/gold/single_transaction_proxy.gold
@@ -3,22 +3,16 @@ Client SNI: test_sni
 ``
 POST https://example.data.com/a/path HTTP/1.1
 uuid: cb9b4e94-5d42-43d4-8545-320033298ba2-214279439
-accept-encoding: gzip
-content-type: application/json; charset=utf-8
+``
 content-length: 10
-host: example.com
-
-
+``
 ==== REQUEST BODY ====
 b'0000000 00'
 
 HTTP/1.1 200 OK
 uuid: cb9b4e94-5d42-43d4-8545-320033298ba2-214279439
-content-type: multipart/form-data;snoopy=123456
-date: Sat, 16 Mar 2019 01:33:27 GMT
-age: 1
-
-
+content-length: 12
+``
 ==== RESPONSE BODY ====
 b'0000000 0000'
 ``

--- a/test/autests/gold_tests/https/replay_files/single_transaction/single_http_transaction.yaml
+++ b/test/autests/gold_tests/https/replay_files/single_transaction/single_http_transaction.yaml
@@ -57,6 +57,7 @@ sessions:
         - [ Date, "Sat, 16 Mar 2019 01:33:27 GMT" ]
         - [ Age, '1' ]
         - [ Connection, keep-alive ]
+        - [ Content-Length, '12' ]
 
     proxy-response:
       status: 200
@@ -72,5 +73,4 @@ sessions:
         - [ Age, '2' ]
         - [ Transfer-Encoding, chunked ]
         - [ Connection, keep-alive ]
-
-
+        - [ Content-Length, '12' ]

--- a/test/unit_tests/test_ProxyVerifier.cc
+++ b/test/unit_tests/test_ProxyVerifier.cc
@@ -70,12 +70,12 @@ TEST_CASE("RuleChecks of non-duplicate fields", "[RuleCheck]") {
 TEST_CASE("RuleChecks of duplicate fields", "[RuleCheck]") {
   swoc::TextView test_name("testName");
   std::list<swoc::TextView> expected_values_arg{
-    "first_value",
-    "second_value",
+      "first_value",
+      "second_value",
   };
   std::list<swoc::TextView> expected_values{
-    "first_value",
-    "second_value",
+      "first_value",
+      "second_value",
   };
   swoc::TextView empty_name;
   std::list<swoc::TextView> empty_values_arg;
@@ -84,20 +84,20 @@ TEST_CASE("RuleChecks of duplicate fields", "[RuleCheck]") {
   RuleCheck::options_init();
 
   SECTION("presence checks") {
-    std::shared_ptr<RuleCheck> present_check =
-        RuleCheck::make_rule_check(test_name, std::move(expected_values_arg), "present");
+    std::shared_ptr<RuleCheck> present_check = RuleCheck::make_rule_check(
+        test_name, std::move(expected_values_arg), "present");
     REQUIRE(present_check);
 
     CHECK_FALSE(present_check->test(key, empty_name, empty_values));
     CHECK_FALSE(present_check->test(key, empty_name, expected_values));
     CHECK(present_check->test(key, test_name, empty_values));
     CHECK(present_check->test(key, test_name, expected_values));
-    CHECK(present_check->test(key, test_name, {"some", "non-test",  "values"}));
+    CHECK(present_check->test(key, test_name, {"some", "non-test", "values"}));
   }
 
   SECTION("absence checks") {
-    std::shared_ptr<RuleCheck> absent_check =
-        RuleCheck::make_rule_check(test_name, std::move(expected_values_arg), "absent");
+    std::shared_ptr<RuleCheck> absent_check = RuleCheck::make_rule_check(
+        test_name, std::move(expected_values_arg), "absent");
     REQUIRE(absent_check);
 
     CHECK(absent_check->test(key, empty_name, empty_values));
@@ -108,7 +108,8 @@ TEST_CASE("RuleChecks of duplicate fields", "[RuleCheck]") {
 
   SECTION("equal checks") {
     std::shared_ptr<RuleCheck> equal_check_not_blank =
-        RuleCheck::make_rule_check(test_name, std::move(expected_values_arg), "equal");
+        RuleCheck::make_rule_check(test_name, std::move(expected_values_arg),
+                                   "equal");
     REQUIRE(equal_check_not_blank);
 
     CHECK_FALSE(equal_check_not_blank->test(key, empty_name, empty_values));
@@ -118,21 +119,22 @@ TEST_CASE("RuleChecks of duplicate fields", "[RuleCheck]") {
 
     // Subsets of the expected values are not enough.
     std::list<swoc::TextView> subset_values{
-      "first_value",
+        "first_value",
     };
     CHECK_FALSE(equal_check_not_blank->test(key, test_name, subset_values));
 
     // Order matters.
     std::list<swoc::TextView> re_arranged_values{
-      "second_value",
-      "first_value",
+        "second_value",
+        "first_value",
     };
-    CHECK_FALSE(equal_check_not_blank->test(key, test_name, re_arranged_values));
+    CHECK_FALSE(
+        equal_check_not_blank->test(key, test_name, re_arranged_values));
   }
 
   SECTION("equal checks with no values in the rule") {
-    std::shared_ptr<RuleCheck> equal_check_blank =
-        RuleCheck::make_rule_check(test_name, std::move(empty_values_arg), "equal");
+    std::shared_ptr<RuleCheck> equal_check_blank = RuleCheck::make_rule_check(
+        test_name, std::move(empty_values_arg), "equal");
     REQUIRE(equal_check_blank);
 
     swoc::TextView non_empty_values = {"some", "values"};
@@ -160,7 +162,8 @@ TEST_CASE("Test path parsing", "[ParseUrl]") {
     CHECK(header._authority == "example-ab.candy.com");
   }
   SECTION("Verify URL parsing with a port") {
-    std::string url = "http://example-ab.candy.com:8080/xy?zab=123456789:98765432";
+    std::string url =
+        "http://example-ab.candy.com:8080/xy?zab=123456789:98765432";
     header.parse_url(url);
     CHECK(header._scheme == "http");
     CHECK(header._path == "/xy?zab=123456789:98765432");

--- a/test/unit_tests/test_chunk_parsing.cc
+++ b/test/unit_tests/test_chunk_parsing.cc
@@ -1,0 +1,104 @@
+/** @file
+ * Unit tests for HttpReplay.h.
+ *
+ * Copyright 2020, Verizon Media
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "catch.hpp"
+#include "core/ProxyVerifier.h"
+
+using swoc::TextView;
+
+TEST_CASE("Check parsing of a chunked body", "[RuleCheck]") {
+  size_t num_body_bytes = 0;
+  ChunkCodex codex;
+  std::string accumulated_body;
+  ChunkCodex::ChunkCallback cb{
+      [&num_body_bytes, &accumulated_body](TextView block, size_t offset,
+                                           size_t size) -> bool {
+        num_body_bytes += block.size();
+        accumulated_body += block;
+        return true;
+      }};
+
+  REQUIRE(ChunkCodex::CONTINUE == codex.parse("1", cb));
+  REQUIRE(num_body_bytes == 0);
+  REQUIRE(accumulated_body.empty());
+
+  REQUIRE(ChunkCodex::CONTINUE == codex.parse("0", cb));
+  REQUIRE(num_body_bytes == 0);
+  REQUIRE(accumulated_body.empty());
+
+  // Keep in mind that chunk length is in hex, so 10 means 0x10 which is 16
+  // bytes.
+
+  REQUIRE(ChunkCodex::CONTINUE == codex.parse("\r", cb));
+  REQUIRE(num_body_bytes == 0);
+  REQUIRE(accumulated_body.empty());
+
+  REQUIRE(ChunkCodex::CONTINUE == codex.parse("\n", cb));
+  REQUIRE(num_body_bytes == 0);
+  REQUIRE(accumulated_body.empty());
+
+  REQUIRE(ChunkCodex::CONTINUE == codex.parse("1", cb));
+  REQUIRE(num_body_bytes == 1);
+  REQUIRE(accumulated_body == "1");
+
+  REQUIRE(ChunkCodex::CONTINUE == codex.parse("2", cb));
+  REQUIRE(num_body_bytes == 2);
+  REQUIRE(accumulated_body == "12");
+
+  REQUIRE(ChunkCodex::CONTINUE == codex.parse("3456", cb));
+  REQUIRE(num_body_bytes == 6);
+  REQUIRE(accumulated_body == "123456");
+
+  REQUIRE(ChunkCodex::CONTINUE == codex.parse("78901234", cb));
+  REQUIRE(num_body_bytes == 14);
+  REQUIRE(accumulated_body == "12345678901234");
+
+  REQUIRE(ChunkCodex::CONTINUE == codex.parse("5", cb));
+  REQUIRE(num_body_bytes == 15);
+  REQUIRE(accumulated_body == "123456789012345");
+
+  REQUIRE(ChunkCodex::CONTINUE == codex.parse("6", cb));
+  REQUIRE(num_body_bytes == 16);
+  REQUIRE(accumulated_body == "1234567890123456");
+
+  REQUIRE(ChunkCodex::CONTINUE == codex.parse("\r", cb));
+  REQUIRE(num_body_bytes == 16);
+  REQUIRE(accumulated_body == "1234567890123456");
+
+  REQUIRE(ChunkCodex::CONTINUE == codex.parse("\n", cb));
+  REQUIRE(num_body_bytes == 16);
+  REQUIRE(accumulated_body == "1234567890123456");
+
+  // Add a second chunk.
+  REQUIRE(ChunkCodex::CONTINUE == codex.parse("5\r\n78901\r\n", cb));
+  REQUIRE(num_body_bytes == 21);
+  REQUIRE(accumulated_body == "123456789012345678901");
+
+  // This will represent a header for a new chunk. We'll make it the final
+  // chunk by specifying a zero-length header.
+  REQUIRE(ChunkCodex::CONTINUE == codex.parse("0", cb));
+  REQUIRE(num_body_bytes == 21);
+  REQUIRE(accumulated_body == "123456789012345678901");
+
+  REQUIRE(ChunkCodex::CONTINUE == codex.parse("\r", cb));
+  REQUIRE(num_body_bytes == 21);
+  REQUIRE(accumulated_body == "123456789012345678901");
+
+  REQUIRE(ChunkCodex::CONTINUE == codex.parse("\n", cb));
+  REQUIRE(num_body_bytes == 21);
+  REQUIRE(accumulated_body == "123456789012345678901");
+
+  REQUIRE(ChunkCodex::CONTINUE == codex.parse("\r", cb));
+  REQUIRE(num_body_bytes == 21);
+  REQUIRE(accumulated_body == "123456789012345678901");
+
+  // Only now, after this very final linefeed is sent, should the parser tell
+  // us that the chunked content is done.
+  REQUIRE(ChunkCodex::DONE == codex.parse("\n", cb));
+  REQUIRE(num_body_bytes == 21);
+  REQUIRE(accumulated_body == "123456789012345678901");
+}

--- a/test/unit_tests/unit_tests.part
+++ b/test/unit_tests/unit_tests.part
@@ -15,6 +15,7 @@ env.AppendUnique(
 files = [
     "unit_test_main.cc",
     "test_ProxyVerifier.cc",
+    "test_chunk_parsing.cc",
 ]
 env.UnitTest(
     "tests",


### PR DESCRIPTION
This adds '-Wall', '-Wextra', '-Werror' compiler flags and fixes the
associated warnings.

It also fixes a few leaks detected by ASan.

It also adds unit tests to chunked-encoded parsing and makes some
adjustements accordingly. I don't believe, in the end, this changed much
behaviorally, but it could in theory make the client read the entire
final chunk (the zero-body one) when, before, it could have stopped
reading that after the entire expected body was received. But any
previous "bad" behavior would require specific read behavior such that
the final chunk was on a different read than the rest, which maybe is
unlikely. And even then, I'm not sure if something bad would have
happened.

The big behavioral change is having the server close the connection
after the entire writing of the body is done and there is no
content-length. This prevents timeouts from the client (generally, the
proxy actually) as it waits for the unspecified body.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
