### PR TITLE
Clang formatting with a clang-format file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,137 @@
+---
+Language:        Cpp
+AccessModifierOffset: -2
+AlignAfterOpenBracket: AlwaysBreak
+AlignConsecutiveMacros: false
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: false
+AllowAllConstructorInitializersOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: All
+AlwaysBreakAfterReturnType: AllDefinitions
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: MultiLine
+BinPackArguments: false
+BinPackParameters: false
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      true
+  AfterControlStatement: MultiLine
+  AfterEnum:       false
+  AfterFunction:   true
+  AfterNamespace:  true
+  AfterObjCDeclaration: false
+  AfterStruct:     true
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakInheritanceList: BeforeComma
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializers: BeforeComma
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     100
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 2
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - forv_Vec
+  - for_Vec
+  - forp_Vec
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '^(<|"(gtest|isl|json)/)'
+    Priority:        3
+    SortPriority:    0
+  - Regex:           '.*'
+    Priority:        1
+    SortPriority:    0
+IncludeIsMainRegex: '$'
+IncludeIsMainSourceRegex: ''
+IndentCaseLabels: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: false
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 30000
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Right
+ReflowComments:  true
+SortIncludes:    false
+SortUsingDeclarations: false
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+Standard:        Latest
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseCRLF:         false
+UseTab:          Never
+...
+

--- a/local/include/core/ArgParser.h
+++ b/local/include/core/ArgParser.h
@@ -22,15 +22,24 @@ constexpr unsigned MORE_THAN_ONE_ARG_N = ~0 - 1;
 constexpr int INDENT_ONE = 32;
 constexpr int INDENT_TWO = 46;
 
-namespace ts {
+namespace ts
+{
 using AP_StrVec = std::vector<std::string>;
 // The class holding both the ENV and String arguments
-class ArgumentData {
+class ArgumentData
+{
 public:
   // bool to check if certain command/option is called
-  operator bool() const noexcept { return _is_called; }
+  operator bool() const noexcept
+  {
+    return _is_called;
+  }
   // index accessing []
-  std::string const &operator[](int x) const { return _values.at(x); }
+  std::string const &
+  operator[](int x) const
+  {
+    return _values.at(x);
+  }
   // return the Environment variable
   std::string const &env() const noexcept;
   // iterator for arguments
@@ -56,7 +65,8 @@ private:
 };
 
 // The class holding all the parsed data after ArgParser::parse()
-class Arguments {
+class Arguments
+{
 public:
   Arguments();
   ~Arguments();
@@ -89,13 +99,15 @@ private:
 };
 
 // Class of the ArgParser
-class ArgParser {
+class ArgParser
+{
   using Function = std::function<void()>;
 
 public:
   // Option structure: e.x. --arg -a
   // Contains all information about certain option(--switch)
-  struct Option {
+  struct Option
+  {
     std::string long_option;   // long option: --arg
     std::string short_option;  // short option: -a
     std::string description;   // help description
@@ -106,7 +118,8 @@ public:
   };
 
   // Class for commands in a nested way
-  class Command {
+  class Command
+  {
   public:
     // Constructor and destructor
     Command();
@@ -114,25 +127,30 @@ public:
     /** Add an option to current command
         @return The Option object.
     */
-    Command &add_option(std::string const &long_option,
-                        std::string const &short_option,
-                        std::string const &description,
-                        std::string const &envvar = "", unsigned arg_num = 0,
-                        std::string const &default_value = "",
-                        std::string const &key = "");
+    Command &add_option(
+        std::string const &long_option,
+        std::string const &short_option,
+        std::string const &description,
+        std::string const &envvar = "",
+        unsigned arg_num = 0,
+        std::string const &default_value = "",
+        std::string const &key = "");
 
     /** Two ways of adding a sub-command to current command:
         @return The new sub-command instance.
     */
-    Command &add_command(std::string const &cmd_name,
-                         std::string const &cmd_description,
-                         Function const &f = nullptr,
-                         std::string const &key = "");
-    Command &add_command(std::string const &cmd_name,
-                         std::string const &cmd_description,
-                         std::string const &cmd_envvar, unsigned cmd_arg_num,
-                         Function const &f = nullptr,
-                         std::string const &key = "");
+    Command &add_command(
+        std::string const &cmd_name,
+        std::string const &cmd_description,
+        Function const &f = nullptr,
+        std::string const &key = "");
+    Command &add_command(
+        std::string const &cmd_name,
+        std::string const &cmd_description,
+        std::string const &cmd_envvar,
+        unsigned cmd_arg_num,
+        Function const &f = nullptr,
+        std::string const &key = "");
     /** Add an example usage of current command for the help message
         @return The Command instance for chained calls.
     */
@@ -148,13 +166,18 @@ public:
 
   protected:
     // Main constructor called by add_command()
-    Command(std::string const &name, std::string const &description,
-            std::string const &envvar, unsigned arg_num, Function const &f,
-            std::string const &key = "");
+    Command(
+        std::string const &name,
+        std::string const &description,
+        std::string const &envvar,
+        unsigned arg_num,
+        Function const &f,
+        std::string const &key = "");
     // Helper method for add_option to check the validity of option
-    void check_option(std::string const &long_option,
-                      std::string const &short_option,
-                      std::string const &key) const;
+    void check_option(
+        std::string const &long_option,
+        std::string const &short_option,
+        std::string const &key) const;
     // Helper method for add_command to check the validity of command
     void check_command(std::string const &name, std::string const &key) const;
     // Helper method for ArgParser::help_message
@@ -199,32 +222,41 @@ public:
   };
   // Base class constructors and destructor
   ArgParser();
-  ArgParser(std::string const &name, std::string const &description,
-            std::string const &envvar, unsigned arg_num, Function const &f);
+  ArgParser(
+      std::string const &name,
+      std::string const &description,
+      std::string const &envvar,
+      unsigned arg_num,
+      Function const &f);
   ~ArgParser();
 
   /** Add an option to current command with arguments
       @return The Option object.
   */
-  Command &add_option(std::string const &long_option,
-                      std::string const &short_option,
-                      std::string const &description,
-                      std::string const &envvar = "", unsigned arg_num = 0,
-                      std::string const &default_value = "",
-                      std::string const &key = "");
+  Command &add_option(
+      std::string const &long_option,
+      std::string const &short_option,
+      std::string const &description,
+      std::string const &envvar = "",
+      unsigned arg_num = 0,
+      std::string const &default_value = "",
+      std::string const &key = "");
 
   /** Two ways of adding command to the parser:
       @return The new command instance.
   */
-  Command &add_command(std::string const &cmd_name,
-                       std::string const &cmd_description,
-                       Function const &f = nullptr,
-                       std::string const &key = "");
-  Command &add_command(std::string const &cmd_name,
-                       std::string const &cmd_description,
-                       std::string const &cmd_envvar, unsigned cmd_arg_num,
-                       Function const &f = nullptr,
-                       std::string const &key = "");
+  Command &add_command(
+      std::string const &cmd_name,
+      std::string const &cmd_description,
+      Function const &f = nullptr,
+      std::string const &key = "");
+  Command &add_command(
+      std::string const &cmd_name,
+      std::string const &cmd_description,
+      std::string const &cmd_envvar,
+      unsigned cmd_arg_num,
+      Function const &f = nullptr,
+      std::string const &key = "");
   // give a defaut command to this parser
   void set_default_command(std::string const &cmd);
   /** Main parsing function

--- a/local/include/core/ProxyVerifier.h
+++ b/local/include/core/ProxyVerifier.h
@@ -104,25 +104,26 @@ swoc::Rv<int> block_sigpipe();
  */
 swoc::Errata configure_logging(const std::string_view verbose_argument);
 
-namespace swoc {
-BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec,
-                       HttpHeader const &h);
+namespace swoc
+{
+BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, HttpHeader const &h);
 
-namespace bwf {
+namespace bwf
+{
 /** Format wrapper for @c errno.
  * This stores a copy of the argument or @c errno if an argument isn't provided.
  * The output is then formatted with the short, long, and numeric value of @c
  * errno. If the format specifier is type 'd' then just the numeric value is
  * printed.
  */
-struct SSLError {
+struct SSLError
+{
   unsigned long _e;
-  explicit SSLError(int e = ERR_peek_last_error()) : _e(e) {}
+  explicit SSLError(int e = ERR_peek_last_error()) : _e(e) { }
 };
 } // namespace bwf
 
-BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec,
-                       bwf::SSLError const &error);
+BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, bwf::SSLError const &error);
 } // namespace swoc
 
 /**
@@ -172,32 +173,33 @@ BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec,
  * Session::run_transaction verifies that the proxy returns the expected
  * response status code as recorded in the replay file.
  */
-struct Hash {
-  swoc::Hash64FNV1a::value_type operator()(swoc::TextView view) const {
-    return swoc::Hash64FNV1a{}.hash_immediate(
-        swoc::transform_view_of(&tolower, view));
+struct Hash
+{
+  swoc::Hash64FNV1a::value_type
+  operator()(swoc::TextView view) const
+  {
+    return swoc::Hash64FNV1a{}.hash_immediate(swoc::transform_view_of(&tolower, view));
   }
-  bool operator()(swoc::TextView const &lhs, swoc::TextView const &rhs) const {
+  bool
+  operator()(swoc::TextView const &lhs, swoc::TextView const &rhs) const
+  {
     return 0 == strcasecmp(lhs, rhs);
   }
 };
 
-class RuleCheck {
+class RuleCheck
+{
   /// References the make_* functions below.
   using MakeRuleFunction =
       std::function<std::shared_ptr<RuleCheck>(swoc::TextView, swoc::TextView)>;
-  using RuleOptions =
-      std::unordered_map<swoc::TextView, MakeRuleFunction, Hash, Hash>;
-  static RuleOptions
-      options; ///< Returns function to construct a RuleCheck child class for a
-               ///< given rule type ("equals", "presence", or "absence")
+  using RuleOptions = std::unordered_map<swoc::TextView, MakeRuleFunction, Hash, Hash>;
+  static RuleOptions options; ///< Returns function to construct a RuleCheck child class for a
+                              ///< given rule type ("equals", "presence", or "absence")
 
   using MakeDuplicateFieldRuleFunction =
-      std::function<std::shared_ptr<RuleCheck>(swoc::TextView,
-                                               std::list<swoc::TextView> &&)>;
+      std::function<std::shared_ptr<RuleCheck>(swoc::TextView, std::list<swoc::TextView> &&)>;
   using DuplicateFieldRuleOptions =
-      std::unordered_map<swoc::TextView, MakeDuplicateFieldRuleFunction, Hash,
-                         Hash>;
+      std::unordered_map<swoc::TextView, MakeDuplicateFieldRuleFunction, Hash, Hash>;
   static DuplicateFieldRuleOptions
       duplicate_field_options; ///< Returns function to construct a RuleCheck
                                ///< child class for a given duplicate field rule
@@ -211,7 +213,7 @@ protected:
   swoc::TextView _name;
 
 public:
-  virtual ~RuleCheck() {}
+  virtual ~RuleCheck() { }
 
   /** Initialize options with std::functions for creating RuleChecks.
    *
@@ -227,17 +229,18 @@ public:
    * @return A pointer to the RuleCheck instance generated, holding a key (and
    * potentially value) TextView for the rule to compare inputs to
    */
-  static std::shared_ptr<RuleCheck>
-  make_rule_check(swoc::TextView localized_name, swoc::TextView localized_value,
-                  swoc::TextView rule_type);
+  static std::shared_ptr<RuleCheck> make_rule_check(
+      swoc::TextView localized_name,
+      swoc::TextView localized_value,
+      swoc::TextView rule_type);
 
   /**
    * @param values The values of the field. This should be localized.
    */
-  static std::shared_ptr<RuleCheck>
-  make_rule_check(swoc::TextView localized_name,
-                  std::list<swoc::TextView> &&localized_values,
-                  swoc::TextView rule_type);
+  static std::shared_ptr<RuleCheck> make_rule_check(
+      swoc::TextView localized_name,
+      std::list<swoc::TextView> &&localized_values,
+      swoc::TextView rule_type);
 
   /** Generate @a EqualityCheck, invoked by the factory function when the
    * "equals" flag is present.
@@ -248,14 +251,14 @@ public:
    * @return A pointer to the EqualityCheck instance generated, holding key and
    * value TextViews for the rule to compare inputs to
    */
-  static std::shared_ptr<RuleCheck> make_equality(swoc::TextView name,
-                                                  swoc::TextView value);
+  static std::shared_ptr<RuleCheck> make_equality(swoc::TextView name, swoc::TextView value);
 
   /**
    * @param values The list of values to expect in the response.
    */
-  static std::shared_ptr<RuleCheck>
-  make_equality(swoc::TextView name, std::list<swoc::TextView> &&values);
+  static std::shared_ptr<RuleCheck> make_equality(
+      swoc::TextView name,
+      std::list<swoc::TextView> &&values);
 
   /** Generate @a PresenceCheck, invoked by the factory function when the
    * "absence" flag is present.
@@ -266,14 +269,14 @@ public:
    * @return A pointer to the Presence instance generated, holding a name
    * TextView for the rule to compare inputs to
    */
-  static std::shared_ptr<RuleCheck> make_presence(swoc::TextView name,
-                                                  swoc::TextView value);
+  static std::shared_ptr<RuleCheck> make_presence(swoc::TextView name, swoc::TextView value);
 
   /**
    * @param values (unused) The list of values specified in the YAML node.
    */
-  static std::shared_ptr<RuleCheck>
-  make_presence(swoc::TextView name, std::list<swoc::TextView> &&values);
+  static std::shared_ptr<RuleCheck> make_presence(
+      swoc::TextView name,
+      std::list<swoc::TextView> &&values);
 
   /** Generate @a AbsenceCheck, invoked by the factory function when the
    * "absence" flag is present.
@@ -284,14 +287,14 @@ public:
    * @return A pointer to the AbsenceCheck instance generated, holding a name
    * TextView for the rule to compare inputs to
    */
-  static std::shared_ptr<RuleCheck> make_absence(swoc::TextView name,
-                                                 swoc::TextView value);
+  static std::shared_ptr<RuleCheck> make_absence(swoc::TextView name, swoc::TextView value);
 
   /**
    * @param values (unused) The list of values specified in the YAML node.
    */
-  static std::shared_ptr<RuleCheck>
-  make_absence(swoc::TextView name, std::list<swoc::TextView> &&values);
+  static std::shared_ptr<RuleCheck> make_absence(
+      swoc::TextView name,
+      std::list<swoc::TextView> &&values);
 
   /** Pure virtual function to test whether the input name and value fulfill the
    * rules for the test
@@ -301,11 +304,13 @@ public:
    * @param value The value of the target field (null if not found).
    * @return Whether the check was successful.
    */
-  virtual bool test(swoc::TextView transaction_key, swoc::TextView name,
-                    swoc::TextView value) const = 0;
+  virtual bool test(swoc::TextView transaction_key, swoc::TextView name, swoc::TextView value)
+      const = 0;
 
-  virtual bool test(swoc::TextView transaction_key, swoc::TextView name,
-                    const std::list<swoc::TextView> &values) const = 0;
+  virtual bool test(
+      swoc::TextView transaction_key,
+      swoc::TextView name,
+      const std::list<swoc::TextView> &values) const = 0;
 
   /** Indicate whether this RuleCheck needs to inspect field values.
    *
@@ -314,9 +319,10 @@ public:
   virtual bool expects_duplicate_fields() const = 0;
 };
 
-class EqualityCheck : public RuleCheck {
+class EqualityCheck : public RuleCheck
+{
 public:
-  ~EqualityCheck() {}
+  ~EqualityCheck() { }
 
   /** Construct @a EqualityCheck with a given name and value.
    *
@@ -344,8 +350,7 @@ public:
    * @param value The value of the target field (null if not found)
    * @return Whether the check was successful or not
    */
-  bool test(swoc::TextView key, swoc::TextView name,
-            swoc::TextView value) const override;
+  bool test(swoc::TextView key, swoc::TextView name, swoc::TextView value) const override;
 
   /** Test whether the name and values both match the expected name and values
    * per the values instantiated in construction.
@@ -357,27 +362,28 @@ public:
    * @param values The values of the target field (null if not found)
    * @return Whether the check was successful or not
    */
-  bool test(swoc::TextView key, swoc::TextView name,
-            std::list<swoc::TextView> const &values) const override;
+  bool test(swoc::TextView key, swoc::TextView name, std::list<swoc::TextView> const &values)
+      const override;
 
   /** Whether this Rule is configured for duplicate fields.
    *
    * @return True of the Rule is configured for duplicate fields, false
    * otherwise.
    */
-  bool expects_duplicate_fields() const override {
+  bool
+  expects_duplicate_fields() const override
+  {
     return _expects_duplicate_fields;
   }
 
 private:
-  swoc::TextView _value; ///< Only EqualityChecks require value comparisons.
-  std::list<swoc::TextView>
-      _values; ///< Only EqualityChecks require value comparisons.
-  bool _expects_duplicate_fields =
-      false; ///< Whether the Rule is configured for duplicate fields.
+  swoc::TextView _value;                  ///< Only EqualityChecks require value comparisons.
+  std::list<swoc::TextView> _values;      ///< Only EqualityChecks require value comparisons.
+  bool _expects_duplicate_fields = false; ///< Whether the Rule is configured for duplicate fields.
 };
 
-class PresenceCheck : public RuleCheck {
+class PresenceCheck : public RuleCheck
+{
 public:
   /** Construct @a PresenceCheck with a given name.
    *
@@ -396,22 +402,23 @@ public:
    * @param value (unused) The value of the target field (null if not found)
    * @return Whether the check was successful or not
    */
-  bool test(swoc::TextView key, swoc::TextView name,
-            swoc::TextView value) const override;
+  bool test(swoc::TextView key, swoc::TextView name, swoc::TextView value) const override;
 
   /**
    * @param values (unused) The valuas of the target field (null
    * if not found)
    */
-  bool test(swoc::TextView key, swoc::TextView name,
-            std::list<swoc::TextView> const &values) const override;
+  bool test(swoc::TextView key, swoc::TextView name, std::list<swoc::TextView> const &values)
+      const override;
 
   /** Whether this Rule is configured for duplicate fields.
    *
    * @return True of the Rule is configured for duplicate fields, false
    * otherwise.
    */
-  bool expects_duplicate_fields() const override {
+  bool
+  expects_duplicate_fields() const override
+  {
     return _expects_duplicate_fields;
   }
 
@@ -420,7 +427,8 @@ private:
   bool _expects_duplicate_fields = false;
 };
 
-class AbsenceCheck : public RuleCheck {
+class AbsenceCheck : public RuleCheck
+{
 public:
   /** Construct @a AbsenceCheck with a given name.
    *
@@ -440,22 +448,23 @@ public:
    * if not found)
    * @return Whether the check was successful or not
    */
-  bool test(swoc::TextView key, swoc::TextView name,
-            swoc::TextView value) const override;
+  bool test(swoc::TextView key, swoc::TextView name, swoc::TextView value) const override;
 
   /**
    * @param values (unused) The value of the target field (null
    * if not found)
    */
-  bool test(swoc::TextView key, swoc::TextView name,
-            std::list<swoc::TextView> const &values) const override;
+  bool test(swoc::TextView key, swoc::TextView name, std::list<swoc::TextView> const &values)
+      const override;
 
   /** Whether this Rule is configured for duplicate fields.
    *
    * @return True of the Rule is configured for duplicate fields, false
    * otherwise.
    */
-  bool expects_duplicate_fields() const override {
+  bool
+  expects_duplicate_fields() const override
+  {
     return _expects_duplicate_fields;
   }
 
@@ -464,13 +473,12 @@ private:
   bool _expects_duplicate_fields = false;
 };
 
-class HttpFields {
+class HttpFields
+{
   using self_type = HttpFields;
   /// Contains the RuleChecks for given field names.
-  using Rules = std::unordered_multimap<swoc::TextView,
-                                        std::shared_ptr<RuleCheck>, Hash, Hash>;
-  using Fields =
-      std::unordered_multimap<swoc::TextView, std::string, Hash, Hash>;
+  using Rules = std::unordered_multimap<swoc::TextView, std::shared_ptr<RuleCheck>, Hash, Hash>;
+  using Fields = std::unordered_multimap<swoc::TextView, std::string, Hash, Hash>;
 
 public:
   Rules _rules;   ///< Maps field names to functors.
@@ -512,8 +520,7 @@ public:
    *   absence of another verification rule.
    * @return swoc::Errata holding any encountered errors
    */
-  swoc::Errata parse_fields_and_rules(YAML::Node const &node,
-                                      bool assume_equality_rule);
+  swoc::Errata parse_fields_and_rules(YAML::Node const &node, bool assume_equality_rule);
   static constexpr bool ASSUME_EQUALITY_RULE = true;
 
   /** Convert _fields into nghttp2_nv and add them to the vector provided
@@ -525,11 +532,13 @@ public:
   friend class HttpHeader;
 };
 
-struct VerificationConfig {
+struct VerificationConfig
+{
   std::shared_ptr<HttpFields> txn_rules;
 };
 
-class HttpHeader {
+class HttpHeader
+{
   using self_type = HttpHeader;
   using TextView = swoc::TextView;
 
@@ -621,11 +630,12 @@ public:
   static swoc::MemSpan<char> _content;
 
 protected:
-  class Binding : public swoc::bwf::NameBinding {
+  class Binding : public swoc::bwf::NameBinding
+  {
     using BufferWriter = swoc::BufferWriter;
 
   public:
-    Binding(HttpHeader const &hdr) : _hdr(hdr) {}
+    Binding(HttpHeader const &hdr) : _hdr(hdr) { }
     /** Override of virtual method to provide an implementation.
      *
      * @param w Output.
@@ -636,8 +646,7 @@ protected:
      * specifier. Subclasses that need to handle name dispatch differently need
      * only override this method.
      */
-    BufferWriter &operator()(BufferWriter &w,
-                             swoc::bwf::Spec const &spec) const override;
+    BufferWriter &operator()(BufferWriter &w, swoc::bwf::Spec const &spec) const override;
 
   protected:
     HttpHeader const &_hdr;
@@ -721,14 +730,16 @@ private:
   static TextView localize_helper(TextView text, bool should_lower);
 };
 
-struct Txn {
-  Txn(bool verify_strictly) : _req{verify_strictly}, _rsp{verify_strictly} {}
+struct Txn
+{
+  Txn(bool verify_strictly) : _req{verify_strictly}, _rsp{verify_strictly} { }
 
   HttpHeader _req; ///< Request to send.
   HttpHeader _rsp; ///< Rules for response to expect.
 };
 
-struct Ssn {
+struct Ssn
+{
   std::list<Txn> _transactions;
   swoc::file::path _path;
   unsigned _line_no = 0;
@@ -743,7 +754,8 @@ struct Ssn {
  * the socket. The goal is to enable a read operation that waits for data but
  * returns as soon as any data is available.
  */
-class Session {
+class Session
+{
 public:
   Session();
   virtual ~Session();
@@ -765,7 +777,11 @@ public:
    *
    * @return Any relevant messaging.
    */
-  virtual swoc::Errata accept() { return swoc::Errata{}; }
+  virtual swoc::Errata
+  accept()
+  {
+    return swoc::Errata{};
+  }
 
   /** Initiate the security layer handshakes.
    *
@@ -802,9 +818,8 @@ public:
    *
    * @return The number of bytes drained and an errata with messaging.
    */
-  virtual swoc::Rv<size_t> drain_body(HttpHeader const &hdr,
-                                      size_t expected_content_size,
-                                      swoc::TextView initial);
+  virtual swoc::Rv<size_t>
+  drain_body(HttpHeader const &hdr, size_t expected_content_size, swoc::TextView initial);
 
   virtual swoc::Errata do_connect(swoc::IPEndpoint const *real_target);
 
@@ -841,21 +856,30 @@ public:
 
   static swoc::Errata init();
 
-  virtual swoc::Errata run_transactions(std::list<Txn> const &txn,
-                                        swoc::IPEndpoint const *real_target);
+  virtual swoc::Errata run_transactions(
+      std::list<Txn> const &txn,
+      swoc::IPEndpoint const *real_target);
   virtual swoc::Errata run_transaction(Txn const &json_txn);
 
 private:
-  virtual swoc::Rv<size_t> drain_body_internal(HttpHeader &hdr,
-                                               Txn const &json_txn,
-                                               swoc::TextView initial);
+  virtual swoc::Rv<size_t>
+  drain_body_internal(HttpHeader &hdr, Txn const &json_txn, swoc::TextView initial);
   int _fd = -1; ///< Socket.
 };
 
-inline int Session::get_fd() const { return _fd; }
-inline bool Session::is_closed() const { return _fd < 0; }
+inline int
+Session::get_fd() const
+{
+  return _fd;
+}
+inline bool
+Session::is_closed() const
+{
+  return _fd < 0;
+}
 
-class TLSSession : public Session {
+class TLSSession : public Session
+{
 public:
   using super_type = Session;
 
@@ -864,8 +888,9 @@ public:
   /** @see Session::write */
   swoc::Rv<ssize_t> write(swoc::TextView data) override;
   TLSSession() = default;
-  TLSSession(swoc::TextView const &client_sni) : _client_sni(client_sni) {}
-  ~TLSSession() override {
+  TLSSession(swoc::TextView const &client_sni) : _client_sni(client_sni) { }
+  ~TLSSession() override
+  {
     if (_ssl)
       SSL_free(_ssl);
   }
@@ -878,13 +903,19 @@ public:
   swoc::Errata connect() override;
   swoc::Errata connect(SSL_CTX *ctx);
   static swoc::Errata init(SSL_CTX *&srv_ctx, SSL_CTX *&clt_ctx);
-  static swoc::Errata init() {
+  static swoc::Errata
+  init()
+  {
     return TLSSession::init(server_ctx, client_ctx);
   }
   static swoc::file::path certificate_file;
   static swoc::file::path privatekey_file;
 
-  SSL *get_ssl() { return _ssl; }
+  SSL *
+  get_ssl()
+  {
+    return _ssl;
+  }
 
 protected:
   SSL *_ssl = nullptr;
@@ -893,7 +924,8 @@ protected:
   static SSL_CTX *client_ctx;
 };
 
-class H2StreamState {
+class H2StreamState
+{
 public:
   H2StreamState();
   H2StreamState(int32_t stream_id);
@@ -911,7 +943,8 @@ public:
   std::chrono::time_point<std::chrono::system_clock> _stream_start;
 };
 
-class H2Session : public TLSSession {
+class H2Session : public TLSSession
+{
 public:
   using super_type = TLSSession;
   H2Session();
@@ -922,16 +955,22 @@ public:
 
   swoc::Errata connect() override;
   static swoc::Errata init(SSL_CTX *&srv_ctx, SSL_CTX *&clt_ctx);
-  static swoc::Errata init() {
+  static swoc::Errata
+  init()
+  {
     return H2Session::init(h2_server_ctx, h2_client_ctx);
   }
   swoc::Errata session_init();
   swoc::Errata send_client_connection_header();
-  swoc::Errata run_transactions(std::list<Txn> const &txn,
-                                swoc::IPEndpoint const *real_target) override;
+  swoc::Errata run_transactions(std::list<Txn> const &txn, swoc::IPEndpoint const *real_target)
+      override;
   swoc::Errata run_transaction(Txn const &txn) override;
 
-  nghttp2_session *get_session() { return _session; }
+  nghttp2_session *
+  get_session()
+  {
+    return _session;
+  }
 
   std::map<int32_t, std::unique_ptr<H2StreamState>> _stream_map;
 
@@ -944,12 +983,12 @@ protected:
   static SSL_CTX *h2_client_ctx;
 
 private:
-  swoc::Errata pack_headers(HttpHeader const &hdr, nghttp2_nv *&nv_hdr,
-                            int &hdr_count);
+  swoc::Errata pack_headers(HttpHeader const &hdr, nghttp2_nv *&nv_hdr, int &hdr_count);
   nghttp2_nv tv_to_nv(char const *name, swoc::TextView v);
 };
 
-class ChunkCodex {
+class ChunkCodex
+{
 public:
   /// The callback when a chunk is decoded.
   /// @param chunk Data for the chunk in the provided view.
@@ -958,8 +997,7 @@ public:
   /// Because the data provided might not contain the entire chunk, a chunk can
   /// come back piecemeal in the callbacks. The @a offset and @a size specify
   /// where in the actual chunk the particular piece in @a chunk is placed.
-  using ChunkCallback =
-      std::function<bool(swoc::TextView chunk, size_t offset, size_t size)>;
+  using ChunkCallback = std::function<bool(swoc::TextView chunk, size_t offset, size_t size)>;
   enum Result {
     CONTINUE, ///< The parser expects more bytes.
     DONE,     ///< The final done chunk is completed.
@@ -992,8 +1030,7 @@ public:
 
 protected:
   size_t _size = 0; ///< Size of the current chunking being decoded.
-  size_t _off =
-      0; ///< Number of bytes in the current chunk already sent to the callback.
+  size_t _off = 0;  ///< Number of bytes in the current chunk already sent to the callback.
   /// Buffer to hold size text in case it falls across @c parse call boundaries.
   swoc::LocalBufferWriter<16> _size_text;
 
@@ -1011,9 +1048,11 @@ protected:
 };
 
 // YAML support utilities.
-namespace swoc {
-inline BufferWriter &bwformat(BufferWriter &w, bwf::Spec const & /* spec */,
-                              YAML::Mark const &mark) {
+namespace swoc
+{
+inline BufferWriter &
+bwformat(BufferWriter &w, bwf::Spec const & /* spec */, YAML::Mark const &mark)
+{
   return w.print("line {}", mark.line);
 }
 } // namespace swoc
@@ -1022,7 +1061,8 @@ inline BufferWriter &bwformat(BufferWriter &w, bwf::Spec const & /* spec */,
  * The client and server are expected subclass this an provide an
  * implementation.
  */
-class ReplayFileHandler {
+class ReplayFileHandler
+{
 public:
   ReplayFileHandler() = default;
   virtual ~ReplayFileHandler() = default;
@@ -1030,13 +1070,27 @@ public:
   /** The rules associated with YAML_GLOBALS_KEY. */
   VerificationConfig global_config;
 
-  virtual swoc::Errata file_open(swoc::file::path const &path) {
+  virtual swoc::Errata
+  file_open(swoc::file::path const &path)
+  {
     _path = path.string();
     return {};
   }
-  virtual swoc::Errata file_close() { return {}; }
-  virtual swoc::Errata ssn_open(YAML::Node const & /* node */) { return {}; }
-  virtual swoc::Errata ssn_close() { return {}; }
+  virtual swoc::Errata
+  file_close()
+  {
+    return {};
+  }
+  virtual swoc::Errata
+  ssn_open(YAML::Node const & /* node */)
+  {
+    return {};
+  }
+  virtual swoc::Errata
+  ssn_close()
+  {
+    return {};
+  }
 
   /** Open the transaction node.
    *
@@ -1046,23 +1100,40 @@ public:
    * This is required to do any base validation of the transaction such as
    * verifying required keys.
    */
-  virtual swoc::Errata txn_open(YAML::Node const & /* node */) { return {}; }
+  virtual swoc::Errata
+  txn_open(YAML::Node const & /* node */)
+  {
+    return {};
+  }
 
-  virtual swoc::Errata txn_close() { return {}; }
-  virtual swoc::Errata client_request(YAML::Node const & /* node */) {
-    return {};
-  }
-  virtual swoc::Errata proxy_request(YAML::Node const & /* node */) {
-    return {};
-  }
-  virtual swoc::Errata server_response(YAML::Node const & /* node */) {
-    return {};
-  }
-  virtual swoc::Errata proxy_response(YAML::Node const & /* node */) {
+  virtual swoc::Errata
+  txn_close()
+  {
     return {};
   }
   virtual swoc::Errata
-  apply_to_all_messages(HttpFields const & /* all_headers */) {
+  client_request(YAML::Node const & /* node */)
+  {
+    return {};
+  }
+  virtual swoc::Errata
+  proxy_request(YAML::Node const & /* node */)
+  {
+    return {};
+  }
+  virtual swoc::Errata
+  server_response(YAML::Node const & /* node */)
+  {
+    return {};
+  }
+  virtual swoc::Errata
+  proxy_response(YAML::Node const & /* node */)
+  {
+    return {};
+  }
+  virtual swoc::Errata
+  apply_to_all_messages(HttpFields const & /* all_headers */)
+  {
     return {};
   }
 
@@ -1075,19 +1146,19 @@ protected:
   swoc::file::path _path;
 };
 
-swoc::Errata Load_Replay_File(swoc::file::path const &path,
-                              ReplayFileHandler &handler);
+swoc::Errata Load_Replay_File(swoc::file::path const &path, ReplayFileHandler &handler);
 
-swoc::Errata
-Load_Replay_Directory(swoc::file::path const &path,
-                      swoc::Errata (*loader)(swoc::file::path const &),
-                      int n_threads = 10);
+swoc::Errata Load_Replay_Directory(
+    swoc::file::path const &path,
+    swoc::Errata (*loader)(swoc::file::path const &),
+    int n_threads = 10);
 
 swoc::Errata parse_ips(std::string arg, std::deque<swoc::IPEndpoint> &target);
 swoc::Errata resolve_ips(std::string arg, std::deque<swoc::IPEndpoint> &target);
 swoc::Rv<swoc::IPEndpoint> Resolve_FQDN(swoc::TextView host);
 
-class ThreadInfo {
+class ThreadInfo
+{
 public:
   std::thread *_thread = nullptr;
   std::condition_variable _cvar;
@@ -1096,7 +1167,8 @@ public:
 };
 
 // This must be a list so that iterators / pointers to elements do not go stale.
-class ThreadPool {
+class ThreadPool
+{
 public:
   void wait_for_work(ThreadInfo *info);
   ThreadInfo *get_worker();

--- a/local/include/core/yaml_util.h
+++ b/local/include/core/yaml_util.h
@@ -11,46 +11,61 @@
 // Structured binding support for nodes. E.g.
 // YAML::Node node;
 // for ( auto const& [ key, value ] : node ] { ... }
-namespace std {
+namespace std
+{
 template <>
-class tuple_size<YAML::const_iterator::value_type>
-    : public std::integral_constant<size_t, 2> {};
-template <> class tuple_element<0, YAML::const_iterator::value_type> {
+class tuple_size<YAML::const_iterator::value_type> : public std::integral_constant<size_t, 2>
+{
+};
+template <> class tuple_element<0, YAML::const_iterator::value_type>
+{
 public:
   using type = const YAML::Node;
 };
-template <> class tuple_element<1, YAML::const_iterator::value_type> {
+template <> class tuple_element<1, YAML::const_iterator::value_type>
+{
 public:
   using type = const YAML::Node;
 };
-template <>
-class tuple_size<YAML::iterator::value_type>
-    : public std::integral_constant<size_t, 2> {};
-template <> class tuple_element<0, YAML::iterator::value_type> {
+template <> class tuple_size<YAML::iterator::value_type> : public std::integral_constant<size_t, 2>
+{
+};
+template <> class tuple_element<0, YAML::iterator::value_type>
+{
 public:
   using type = YAML::Node;
 };
-template <> class tuple_element<1, YAML::iterator::value_type> {
+template <> class tuple_element<1, YAML::iterator::value_type>
+{
 public:
   using type = YAML::Node;
 };
 } // namespace std
 
-template <size_t IDX>
-YAML::Node const &get(YAML::const_iterator::value_type const &v);
+template <size_t IDX> YAML::Node const &get(YAML::const_iterator::value_type const &v);
 template <>
-inline YAML::Node const &get<0>(YAML::const_iterator::value_type const &v) {
+inline YAML::Node const &
+get<0>(YAML::const_iterator::value_type const &v)
+{
   return v.first;
 }
 template <>
-inline YAML::Node const &get<1>(YAML::const_iterator::value_type const &v) {
+inline YAML::Node const &
+get<1>(YAML::const_iterator::value_type const &v)
+{
   return v.second;
 }
 template <size_t IDX> YAML::Node &get(YAML::iterator::value_type &v);
-template <> inline YAML::Node &get<0>(YAML::iterator::value_type &v) {
+template <>
+inline YAML::Node &
+get<0>(YAML::iterator::value_type &v)
+{
   return v.first;
 }
-template <> inline YAML::Node &get<1>(YAML::iterator::value_type &v) {
+template <>
+inline YAML::Node &
+get<1>(YAML::iterator::value_type &v)
+{
   return v.second;
 }
 
@@ -58,7 +73,9 @@ template <> inline YAML::Node &get<1>(YAML::iterator::value_type &v) {
  */
 static const std::string YAML_MERGE_KEY{"<<"};
 
-YAML::Node yaml_merge(YAML::Node &root) {
+YAML::Node
+yaml_merge(YAML::Node &root)
+{
   static constexpr auto flatten = [](YAML::Node &dst, YAML::Node &src) -> void {
     if (src.IsMap()) {
       for (auto const &[key, value] : src) {

--- a/local/src/core/ArgParser.cc
+++ b/local/src/core/ArgParser.cc
@@ -19,57 +19,78 @@ std::string default_command;
 // if -h or --help is called specifically, return 0
 int usage_return_code = EX_USAGE;
 
-namespace ts {
-ArgParser::ArgParser() {}
+namespace ts
+{
+ArgParser::ArgParser() { }
 
-ArgParser::ArgParser(std::string const &name, std::string const &description,
-                     std::string const &envvar, unsigned arg_num,
-                     Function const &f) {
+ArgParser::ArgParser(
+    std::string const &name,
+    std::string const &description,
+    std::string const &envvar,
+    unsigned arg_num,
+    Function const &f)
+{
   // initialize _top_level_command according to the provided message
-  _top_level_command =
-      ArgParser::Command(name, description, envvar, arg_num, f);
+  _top_level_command = ArgParser::Command(name, description, envvar, arg_num, f);
 }
 
-ArgParser::~ArgParser() {}
+ArgParser::~ArgParser() { }
 
 // add new options with args
-ArgParser::Command &ArgParser::add_option(
-    std::string const &long_option, std::string const &short_option,
-    std::string const &description, std::string const &envvar, unsigned arg_num,
-    std::string const &default_value, std::string const &key) {
-  return _top_level_command.add_option(long_option, short_option, description,
-                                       envvar, arg_num, default_value, key);
+ArgParser::Command &
+ArgParser::add_option(
+    std::string const &long_option,
+    std::string const &short_option,
+    std::string const &description,
+    std::string const &envvar,
+    unsigned arg_num,
+    std::string const &default_value,
+    std::string const &key)
+{
+  return _top_level_command
+      .add_option(long_option, short_option, description, envvar, arg_num, default_value, key);
 }
 
 // add sub-command with only function
-ArgParser::Command &ArgParser::add_command(std::string const &cmd_name,
-                                           std::string const &cmd_description,
-                                           Function const &f,
-                                           std::string const &key) {
+ArgParser::Command &
+ArgParser::add_command(
+    std::string const &cmd_name,
+    std::string const &cmd_description,
+    Function const &f,
+    std::string const &key)
+{
   return _top_level_command.add_command(cmd_name, cmd_description, f, key);
 }
 
 // add sub-command without args and function
-ArgParser::Command &ArgParser::add_command(std::string const &cmd_name,
-                                           std::string const &cmd_description,
-                                           std::string const &cmd_envvar,
-                                           unsigned cmd_arg_num,
-                                           Function const &f,
-                                           std::string const &key) {
-  return _top_level_command.add_command(cmd_name, cmd_description, cmd_envvar,
-                                        cmd_arg_num, f, key);
+ArgParser::Command &
+ArgParser::add_command(
+    std::string const &cmd_name,
+    std::string const &cmd_description,
+    std::string const &cmd_envvar,
+    unsigned cmd_arg_num,
+    Function const &f,
+    std::string const &key)
+{
+  return _top_level_command.add_command(cmd_name, cmd_description, cmd_envvar, cmd_arg_num, f, key);
 }
 
-void ArgParser::add_global_usage(std::string const &usage) {
+void
+ArgParser::add_global_usage(std::string const &usage)
+{
   global_usage = usage;
 }
 
-void ArgParser::help_message(std::string_view err) const {
+void
+ArgParser::help_message(std::string_view err) const
+{
   _top_level_command.help_message(err);
 }
 
 // a graceful way to output help message
-void ArgParser::Command::help_message(std::string_view err) const {
+void
+ArgParser::Command::help_message(std::string_view err) const
+{
   if (!err.empty()) {
     std::cout << "Error: " << err << std::endl;
   }
@@ -78,9 +99,7 @@ void ArgParser::Command::help_message(std::string_view err) const {
     std::cout << "\nUsage: " + global_usage << std::endl;
   }
   // output subcommands
-  std::cout
-      << "\nCommands ---------------------- Description -----------------------"
-      << std::endl;
+  std::cout << "\nCommands ---------------------- Description -----------------------" << std::endl;
   std::string prefix = "";
   output_command(std::cout, prefix);
   // output options
@@ -98,28 +117,33 @@ void ArgParser::Command::help_message(std::string_view err) const {
   exit(usage_return_code);
 }
 
-void ArgParser::Command::version_message() const {
+void
+ArgParser::Command::version_message() const
+{
   std::cout << "Version 1.0 of Replay Client" << std::endl;
   exit(0);
 }
 
-void ArgParser::set_default_command(std::string const &cmd) {
+void
+ArgParser::set_default_command(std::string const &cmd)
+{
   if (default_command.empty()) {
-    if (_top_level_command._subcommand_list.find(cmd) ==
-        _top_level_command._subcommand_list.end()) {
+    if (_top_level_command._subcommand_list.find(cmd) == _top_level_command._subcommand_list.end())
+    {
       std::cerr << "Error: Default command " << cmd << "not found" << std::endl;
       exit(1);
     }
     default_command = cmd;
   } else if (cmd != default_command) {
-    std::cerr << "Error: Default command " << default_command
-              << "already existed" << std::endl;
+    std::cerr << "Error: Default command " << default_command << "already existed" << std::endl;
     exit(1);
   }
 }
 
 // Top level call of parsing
-Arguments ArgParser::parse(const char **argv) {
+Arguments
+ArgParser::parse(const char **argv)
+{
   // deal with argv first
   int size = 0;
   _argv.clear();
@@ -167,59 +191,76 @@ Arguments ArgParser::parse(const char **argv) {
   return ret;
 }
 
-ArgParser::Command &ArgParser::require_commands() {
+ArgParser::Command &
+ArgParser::require_commands()
+{
   return _top_level_command.require_commands();
 }
 
-void ArgParser::set_error(std::string e) { _error_msg = e; }
+void
+ArgParser::set_error(std::string e)
+{
+  _error_msg = e;
+}
 
-std::string ArgParser::get_error() const { return _error_msg; }
+std::string
+ArgParser::get_error() const
+{
+  return _error_msg;
+}
 
 //=========================== Command class ================================
-ArgParser::Command::Command() {}
+ArgParser::Command::Command() { }
 
-ArgParser::Command::~Command() {}
+ArgParser::Command::~Command() { }
 
-ArgParser::Command::Command(std::string const &name,
-                            std::string const &description,
-                            std::string const &envvar, unsigned arg_num,
-                            Function const &f, std::string const &key)
-    : _name(name), _description(description), _arg_num(arg_num),
-      _envvar(envvar), _f(f), _key(key) {}
+ArgParser::Command::Command(
+    std::string const &name,
+    std::string const &description,
+    std::string const &envvar,
+    unsigned arg_num,
+    Function const &f,
+    std::string const &key)
+  : _name(name)
+  , _description(description)
+  , _arg_num(arg_num)
+  , _envvar(envvar)
+  , _f(f)
+  , _key(key)
+{
+}
 
 // check if this is a valid option before adding
-void ArgParser::Command::check_option(std::string const &long_option,
-                                      std::string const &short_option,
-                                      std::string const & /* key */) const {
-  if (long_option.size() < 3 || long_option[0] != '-' ||
-      long_option[1] != '-') {
+void
+ArgParser::Command::check_option(
+    std::string const &long_option,
+    std::string const &short_option,
+    std::string const & /* key */) const
+{
+  if (long_option.size() < 3 || long_option[0] != '-' || long_option[1] != '-') {
     // invalid name
-    std::cerr << "Error: invalid long option added: '" + long_option + "'"
-              << std::endl;
+    std::cerr << "Error: invalid long option added: '" + long_option + "'" << std::endl;
     exit(1);
   }
-  if (short_option.size() > 2 ||
-      (short_option.size() > 0 && short_option[0] != '-')) {
+  if (short_option.size() > 2 || (short_option.size() > 0 && short_option[0] != '-')) {
     // invalid short option
-    std::cerr << "Error: invalid short option added: '" + short_option + "'"
-              << std::endl;
+    std::cerr << "Error: invalid short option added: '" + short_option + "'" << std::endl;
     exit(1);
   }
   // find if existing in option list
   if (_option_list.find(long_option) != _option_list.end()) {
-    std::cerr << "Error: long option '" + long_option + "' already existed"
-              << std::endl;
+    std::cerr << "Error: long option '" + long_option + "' already existed" << std::endl;
     exit(1);
   } else if (_option_map.find(short_option) != _option_map.end()) {
-    std::cerr << "Error: short option '" + short_option + "' already existed"
-              << std::endl;
+    std::cerr << "Error: short option '" + short_option + "' already existed" << std::endl;
     exit(1);
   }
 }
 
 // check if this is a valid command before adding
-void ArgParser::Command::check_command(std::string const &name,
-                                       std::string const & /* key */) const {
+void
+ArgParser::Command::check_command(std::string const &name, std::string const & /* key */) const
+{
   if (name.empty()) {
     // invalid name
     std::cerr << "Error: empty command cannot be added" << std::endl;
@@ -233,16 +274,25 @@ void ArgParser::Command::check_command(std::string const &name,
 }
 
 // add new options with args
-ArgParser::Command &ArgParser::Command::add_option(
-    std::string const &long_option, std::string const &short_option,
-    std::string const &description, std::string const &envvar, unsigned arg_num,
-    std::string const &default_value, std::string const &key) {
+ArgParser::Command &
+ArgParser::Command::add_option(
+    std::string const &long_option,
+    std::string const &short_option,
+    std::string const &description,
+    std::string const &envvar,
+    unsigned arg_num,
+    std::string const &default_value,
+    std::string const &key)
+{
   std::string lookup_key = key.empty() ? long_option.substr(2) : key;
   check_option(long_option, short_option, lookup_key);
   _option_list[long_option] = {
-      long_option, short_option == "-" ? "" : short_option,
-      description, envvar,
-      arg_num,     default_value,
+      long_option,
+      short_option == "-" ? "" : short_option,
+      description,
+      envvar,
+      arg_num,
+      default_value,
       lookup_key};
   if (short_option != "-" && !short_option.empty()) {
     _option_map[short_option] = long_option;
@@ -252,37 +302,46 @@ ArgParser::Command &ArgParser::Command::add_option(
 
 // add sub-command with only function
 ArgParser::Command &
-ArgParser::Command::add_command(std::string const &cmd_name,
-                                std::string const &cmd_description,
-                                Function const &f, std::string const &key) {
+ArgParser::Command::add_command(
+    std::string const &cmd_name,
+    std::string const &cmd_description,
+    Function const &f,
+    std::string const &key)
+{
   std::string lookup_key = key.empty() ? cmd_name : key;
   check_command(cmd_name, lookup_key);
-  _subcommand_list[cmd_name] =
-      ArgParser::Command(cmd_name, cmd_description, "", 0, f, lookup_key);
+  _subcommand_list[cmd_name] = ArgParser::Command(cmd_name, cmd_description, "", 0, f, lookup_key);
   return _subcommand_list[cmd_name];
 }
 
 // add sub-command without args and function
-ArgParser::Command &ArgParser::Command::add_command(
-    std::string const &cmd_name, std::string const &cmd_description,
-    std::string const &cmd_envvar, unsigned cmd_arg_num, Function const &f,
-    std::string const &key) {
+ArgParser::Command &
+ArgParser::Command::add_command(
+    std::string const &cmd_name,
+    std::string const &cmd_description,
+    std::string const &cmd_envvar,
+    unsigned cmd_arg_num,
+    Function const &f,
+    std::string const &key)
+{
   std::string lookup_key = key.empty() ? cmd_name : key;
   check_command(cmd_name, lookup_key);
-  _subcommand_list[cmd_name] = ArgParser::Command(
-      cmd_name, cmd_description, cmd_envvar, cmd_arg_num, f, lookup_key);
+  _subcommand_list[cmd_name] =
+      ArgParser::Command(cmd_name, cmd_description, cmd_envvar, cmd_arg_num, f, lookup_key);
   return _subcommand_list[cmd_name];
 }
 
 ArgParser::Command &
-ArgParser::Command::add_example_usage(std::string const &usage) {
+ArgParser::Command::add_example_usage(std::string const &usage)
+{
   _example_usage = usage;
   return *this;
 }
 
 // method used by help_message()
-void ArgParser::Command::output_command(std::ostream &out,
-                                        std::string const &prefix) const {
+void
+ArgParser::Command::output_command(std::ostream &out, std::string const &prefix) const
+{
   if (_name != parser_program_name) {
     // a nicely formated way to output command usage
     std::string msg = prefix + _name;
@@ -290,11 +349,9 @@ void ArgParser::Command::output_command(std::ostream &out,
     if (!_description.empty()) {
       if (INDENT_ONE - static_cast<int>(msg.size()) < 0) {
         // if the command msg is too long
-        std::cout << msg << "\n"
-                  << std::string(INDENT_ONE, ' ') << _description << std::endl;
+        std::cout << msg << "\n" << std::string(INDENT_ONE, ' ') << _description << std::endl;
       } else {
-        std::cout << msg << std::string(INDENT_ONE - msg.size(), ' ')
-                  << _description << std::endl;
+        std::cout << msg << std::string(INDENT_ONE - msg.size(), ' ') << _description << std::endl;
       }
     }
   }
@@ -305,7 +362,9 @@ void ArgParser::Command::output_command(std::ostream &out,
 }
 
 // a nicely formatted way to output option message for help.
-void ArgParser::Command::output_option() const {
+void
+ArgParser::Command::output_option() const
+{
   for (auto const &it : _option_list) {
     std::string msg;
     if (!it.second.short_option.empty()) {
@@ -326,21 +385,18 @@ void ArgParser::Command::output_option() const {
     }
     if (!it.second.default_value.empty()) {
       if (INDENT_ONE - static_cast<int>(msg.size()) < 0) {
-        msg =
-            msg + "\n" + std::string(INDENT_ONE, ' ') + it.second.default_value;
+        msg = msg + "\n" + std::string(INDENT_ONE, ' ') + it.second.default_value;
       } else {
-        msg = msg + std::string(INDENT_ONE - msg.size(), ' ') +
-              it.second.default_value;
+        msg = msg + std::string(INDENT_ONE - msg.size(), ' ') + it.second.default_value;
       }
     }
     if (!it.second.description.empty()) {
       if (INDENT_TWO - static_cast<int>(msg.size()) < 0) {
         std::cout << msg << "\n"
-                  << std::string(INDENT_TWO, ' ') << it.second.description
-                  << std::endl;
+                  << std::string(INDENT_TWO, ' ') << it.second.description << std::endl;
       } else {
-        std::cout << msg << std::string(INDENT_TWO - msg.size(), ' ')
-                  << it.second.description << std::endl;
+        std::cout << msg << std::string(INDENT_TWO - msg.size(), ' ') << it.second.description
+                  << std::endl;
       }
     }
   }
@@ -348,9 +404,14 @@ void ArgParser::Command::output_option() const {
 
 // helper method to handle the arguments and put them nicely in arguments
 // can be switched to ts::errata
-static std::string handle_args(Arguments &ret, AP_StrVec &args,
-                               std::string const &name, unsigned arg_num,
-                               unsigned &index) {
+static std::string
+handle_args(
+    Arguments &ret,
+    AP_StrVec &args,
+    std::string const &name,
+    unsigned arg_num,
+    unsigned &index)
+{
   ArgumentData data;
   ret.append(name, data);
   // handle the args
@@ -380,13 +441,13 @@ static std::string handle_args(Arguments &ret, AP_StrVec &args,
 
 // Append the args of option to parsed data. Return true if there is any option
 // called
-void ArgParser::Command::append_option_data(Arguments &ret, AP_StrVec &args,
-                                            int index) {
+void
+ArgParser::Command::append_option_data(Arguments &ret, AP_StrVec &args, int index)
+{
   std::map<std::string, unsigned> check_map;
   for (unsigned i = index; i < args.size(); i++) {
     // find matches of the arg
-    if (args[i][0] == '-' && args[i][1] == '-' &&
-        args[i].find('=') != std::string::npos) {
+    if (args[i][0] == '-' && args[i][1] == '-' && args[i].find('=') != std::string::npos) {
       // deal with --args=
       std::string option_name = args[i].substr(0, args[i].find_first_of('='));
       std::string value = args[i].substr(args[i].find_last_of('=') + 1);
@@ -398,9 +459,9 @@ void ArgParser::Command::append_option_data(Arguments &ret, AP_StrVec &args,
         ArgParser::Option cur_option = it->second;
         // handle environment variable
         if (!cur_option.envvar.empty()) {
-          ret.set_env(cur_option.key, getenv(cur_option.envvar.c_str())
-                                          ? getenv(cur_option.envvar.c_str())
-                                          : "");
+          ret.set_env(
+              cur_option.key,
+              getenv(cur_option.envvar.c_str()) ? getenv(cur_option.envvar.c_str()) : "");
         }
         ret.append_arg(cur_option.key, value);
         check_map[cur_option.long_option] += 1;
@@ -410,7 +471,8 @@ void ArgParser::Command::append_option_data(Arguments &ret, AP_StrVec &args,
     } else {
       // output version message
       if ((args[i] == "--version" || args[i] == "-V") &&
-          _option_list.find("--version") != _option_list.end()) {
+          _option_list.find("--version") != _option_list.end())
+      {
         version_message();
       }
       // output help message
@@ -440,16 +502,15 @@ void ArgParser::Command::append_option_data(Arguments &ret, AP_StrVec &args,
           cur_option = _option_list.at(short_it->second);
         }
         // handle the arguments
-        std::string err =
-            handle_args(ret, args, cur_option.key, cur_option.arg_num, i);
+        std::string err = handle_args(ret, args, cur_option.key, cur_option.arg_num, i);
         if (!err.empty()) {
           help_message(err);
         }
         // handle environment variable
         if (!cur_option.envvar.empty()) {
-          ret.set_env(cur_option.key, getenv(cur_option.envvar.c_str())
-                                          ? getenv(cur_option.envvar.c_str())
-                                          : "");
+          ret.set_env(
+              cur_option.key,
+              getenv(cur_option.envvar.c_str()) ? getenv(cur_option.envvar.c_str()) : "");
         }
       }
     }
@@ -458,8 +519,8 @@ void ArgParser::Command::append_option_data(Arguments &ret, AP_StrVec &args,
   for (auto const &it : check_map) {
     unsigned num = _option_list.at(it.first).arg_num;
     if (num != it.second && num < MORE_THAN_ONE_ARG_N) {
-      help_message(std::to_string(_option_list.at(it.first).arg_num) +
-                   " arguments expected by " + it.first);
+      help_message(
+          std::to_string(_option_list.at(it.first).arg_num) + " arguments expected by " + it.first);
     }
   }
   // put in the default value of options
@@ -475,7 +536,9 @@ void ArgParser::Command::append_option_data(Arguments &ret, AP_StrVec &args,
 }
 
 // Main recursive logic of Parsing
-bool ArgParser::Command::parse(Arguments &ret, AP_StrVec &args) {
+bool
+ArgParser::Command::parse(Arguments &ret, AP_StrVec &args)
+{
   bool command_called = false;
   // iterate through all arguments
   for (unsigned i = 0; i < args.size(); i++) {
@@ -493,8 +556,7 @@ bool ArgParser::Command::parse(Arguments &ret, AP_StrVec &args) {
       }
       // set ENV var
       if (!_envvar.empty()) {
-        ret.set_env(_key,
-                    getenv(_envvar.c_str()) ? getenv(_envvar.c_str()) : "");
+        ret.set_env(_key, getenv(_envvar.c_str()) ? getenv(_envvar.c_str()) : "");
       }
       break;
     }
@@ -520,22 +582,28 @@ bool ArgParser::Command::parse(Arguments &ret, AP_StrVec &args) {
   return command_called;
 }
 
-ArgParser::Command &ArgParser::Command::require_commands() {
+ArgParser::Command &
+ArgParser::Command::require_commands()
+{
   _command_required = true;
   return *this;
 }
 
-ArgParser::Command &ArgParser::Command::set_default() {
+ArgParser::Command &
+ArgParser::Command::set_default()
+{
   default_command = _name;
   return *this;
 }
 
 //=========================== Arguments class ================================
 
-Arguments::Arguments() {}
-Arguments::~Arguments() {}
+Arguments::Arguments() { }
+Arguments::~Arguments() { }
 
-ArgumentData Arguments::get(std::string const &name) {
+ArgumentData
+Arguments::get(std::string const &name)
+{
   if (_data_map.find(name) != _data_map.end()) {
     _data_map[name]._is_called = true;
     return _data_map[name];
@@ -543,21 +611,29 @@ ArgumentData Arguments::get(std::string const &name) {
   return ArgumentData();
 }
 
-void Arguments::append(std::string const &key, ArgumentData const &value) {
+void
+Arguments::append(std::string const &key, ArgumentData const &value)
+{
   // perform overwrite for now
   _data_map[key] = value;
 }
 
-void Arguments::append_arg(std::string const &key, std::string const &value) {
+void
+Arguments::append_arg(std::string const &key, std::string const &value)
+{
   _data_map[key]._values.push_back(value);
 }
 
-void Arguments::set_env(std::string const &key, std::string const &value) {
+void
+Arguments::set_env(std::string const &key, std::string const &value)
+{
   // perform overwrite for now
   _data_map[key]._env_value = value;
 }
 
-void Arguments::show_all_configuration() const {
+void
+Arguments::show_all_configuration() const
+{
   for (auto const &it : _data_map) {
     std::cout << "name: " + it.first << std::endl;
     std::string msg;
@@ -571,7 +647,9 @@ void Arguments::show_all_configuration() const {
 }
 
 // invoke the function with the args
-void Arguments::invoke() {
+void
+Arguments::invoke()
+{
   if (_action) {
     // call the std::function
     _action();
@@ -580,22 +658,33 @@ void Arguments::invoke() {
   }
 }
 
-bool Arguments::has_action() const { return _action != nullptr; }
+bool
+Arguments::has_action() const
+{
+  return _action != nullptr;
+}
 
 //=========================== ArgumentData class
 //================================
 
-std::string const &ArgumentData::env() const noexcept { return _env_value; }
+std::string const &
+ArgumentData::env() const noexcept
+{
+  return _env_value;
+}
 
-std::string const &ArgumentData::at(unsigned index) const {
+std::string const &
+ArgumentData::at(unsigned index) const
+{
   if (index >= _values.size()) {
-    throw std::out_of_range("argument not fonud at index: " +
-                            std::to_string(index));
+    throw std::out_of_range("argument not fonud at index: " + std::to_string(index));
   }
   return _values.at(index);
 }
 
-std::string const &ArgumentData::value() const noexcept {
+std::string const &
+ArgumentData::value() const noexcept
+{
   if (_values.empty()) {
     // To prevent compiler warning
     static const std::string empty = "";
@@ -604,17 +693,27 @@ std::string const &ArgumentData::value() const noexcept {
   return _values.at(0);
 }
 
-size_t ArgumentData::size() const noexcept { return _values.size(); }
+size_t
+ArgumentData::size() const noexcept
+{
+  return _values.size();
+}
 
-bool ArgumentData::empty() const noexcept {
+bool
+ArgumentData::empty() const noexcept
+{
   return _values.empty() && _env_value.empty();
 }
 
-AP_StrVec::const_iterator ArgumentData::begin() const noexcept {
+AP_StrVec::const_iterator
+ArgumentData::begin() const noexcept
+{
   return _values.begin();
 }
 
-AP_StrVec::const_iterator ArgumentData::end() const noexcept {
+AP_StrVec::const_iterator
+ArgumentData::end() const noexcept
+{
   return _values.end();
 }
 

--- a/test/unit_tests/test_ProxyVerifier.cc
+++ b/test/unit_tests/test_ProxyVerifier.cc
@@ -12,7 +12,8 @@ const std::string key = "1";
 
 // Other parts of new code involve Info calls and reliance on these functions,
 // so instead are tested by the test cases in the json folder
-TEST_CASE("RuleChecks of non-duplicate fields", "[RuleCheck]") {
+TEST_CASE("RuleChecks of non-duplicate fields", "[RuleCheck]")
+{
   swoc::TextView test_name("testName");
   swoc::TextView expected_value("testValue");
   RuleCheck::options_init();
@@ -20,7 +21,8 @@ TEST_CASE("RuleChecks of non-duplicate fields", "[RuleCheck]") {
   swoc::TextView empty_name;
   swoc::TextView empty_value;
 
-  SECTION("presence checks") {
+  SECTION("presence checks")
+  {
     std::shared_ptr<RuleCheck> present_check =
         RuleCheck::make_rule_check(test_name, expected_value, "present");
     REQUIRE(present_check);
@@ -32,7 +34,8 @@ TEST_CASE("RuleChecks of non-duplicate fields", "[RuleCheck]") {
     CHECK(present_check->test(key, test_name, "some non-test value"));
   }
 
-  SECTION("absence checks") {
+  SECTION("absence checks")
+  {
     std::shared_ptr<RuleCheck> absent_check =
         RuleCheck::make_rule_check(test_name, expected_value, "absent");
     REQUIRE(absent_check);
@@ -43,7 +46,8 @@ TEST_CASE("RuleChecks of non-duplicate fields", "[RuleCheck]") {
     CHECK_FALSE(absent_check->test(key, test_name, expected_value));
   }
 
-  SECTION("equal checks") {
+  SECTION("equal checks")
+  {
     std::shared_ptr<RuleCheck> equal_check_not_blank =
         RuleCheck::make_rule_check(test_name, expected_value, "equal");
     REQUIRE(equal_check_not_blank);
@@ -54,7 +58,8 @@ TEST_CASE("RuleChecks of non-duplicate fields", "[RuleCheck]") {
     CHECK(equal_check_not_blank->test(key, test_name, expected_value));
   }
 
-  SECTION("equal checks with a blank value in the rule") {
+  SECTION("equal checks with a blank value in the rule")
+  {
     swoc::TextView non_empty_value = "some_value";
     std::shared_ptr<RuleCheck> equal_check_blank =
         RuleCheck::make_rule_check(test_name, "", "equal");
@@ -67,7 +72,8 @@ TEST_CASE("RuleChecks of non-duplicate fields", "[RuleCheck]") {
   }
 }
 
-TEST_CASE("RuleChecks of duplicate fields", "[RuleCheck]") {
+TEST_CASE("RuleChecks of duplicate fields", "[RuleCheck]")
+{
   swoc::TextView test_name("testName");
   std::list<swoc::TextView> expected_values_arg{
       "first_value",
@@ -83,9 +89,10 @@ TEST_CASE("RuleChecks of duplicate fields", "[RuleCheck]") {
 
   RuleCheck::options_init();
 
-  SECTION("presence checks") {
-    std::shared_ptr<RuleCheck> present_check = RuleCheck::make_rule_check(
-        test_name, std::move(expected_values_arg), "present");
+  SECTION("presence checks")
+  {
+    std::shared_ptr<RuleCheck> present_check =
+        RuleCheck::make_rule_check(test_name, std::move(expected_values_arg), "present");
     REQUIRE(present_check);
 
     CHECK_FALSE(present_check->test(key, empty_name, empty_values));
@@ -95,9 +102,10 @@ TEST_CASE("RuleChecks of duplicate fields", "[RuleCheck]") {
     CHECK(present_check->test(key, test_name, {"some", "non-test", "values"}));
   }
 
-  SECTION("absence checks") {
-    std::shared_ptr<RuleCheck> absent_check = RuleCheck::make_rule_check(
-        test_name, std::move(expected_values_arg), "absent");
+  SECTION("absence checks")
+  {
+    std::shared_ptr<RuleCheck> absent_check =
+        RuleCheck::make_rule_check(test_name, std::move(expected_values_arg), "absent");
     REQUIRE(absent_check);
 
     CHECK(absent_check->test(key, empty_name, empty_values));
@@ -106,10 +114,10 @@ TEST_CASE("RuleChecks of duplicate fields", "[RuleCheck]") {
     CHECK_FALSE(absent_check->test(key, test_name, expected_values));
   }
 
-  SECTION("equal checks") {
+  SECTION("equal checks")
+  {
     std::shared_ptr<RuleCheck> equal_check_not_blank =
-        RuleCheck::make_rule_check(test_name, std::move(expected_values_arg),
-                                   "equal");
+        RuleCheck::make_rule_check(test_name, std::move(expected_values_arg), "equal");
     REQUIRE(equal_check_not_blank);
 
     CHECK_FALSE(equal_check_not_blank->test(key, empty_name, empty_values));
@@ -128,13 +136,13 @@ TEST_CASE("RuleChecks of duplicate fields", "[RuleCheck]") {
         "second_value",
         "first_value",
     };
-    CHECK_FALSE(
-        equal_check_not_blank->test(key, test_name, re_arranged_values));
+    CHECK_FALSE(equal_check_not_blank->test(key, test_name, re_arranged_values));
   }
 
-  SECTION("equal checks with no values in the rule") {
-    std::shared_ptr<RuleCheck> equal_check_blank = RuleCheck::make_rule_check(
-        test_name, std::move(empty_values_arg), "equal");
+  SECTION("equal checks with no values in the rule")
+  {
+    std::shared_ptr<RuleCheck> equal_check_blank =
+        RuleCheck::make_rule_check(test_name, std::move(empty_values_arg), "equal");
     REQUIRE(equal_check_blank);
 
     swoc::TextView non_empty_values = {"some", "values"};
@@ -145,25 +153,28 @@ TEST_CASE("RuleChecks of duplicate fields", "[RuleCheck]") {
   }
 }
 
-TEST_CASE("Test path parsing", "[ParseUrl]") {
+TEST_CASE("Test path parsing", "[ParseUrl]")
+{
   HttpHeader header;
-  SECTION("Verify a simple path can be parsed") {
+  SECTION("Verify a simple path can be parsed")
+  {
     std::string url = "/a/path";
     header.parse_url(url);
     CHECK(header._scheme == "");
     CHECK(header._path == "/a/path");
     CHECK(header._authority == "");
   }
-  SECTION("Verify URL parsing") {
+  SECTION("Verify URL parsing")
+  {
     std::string url = "https://example-ab.candy.com/xy?zab=123456789:98765432";
     header.parse_url(url);
     CHECK(header._scheme == "https");
     CHECK(header._path == "/xy?zab=123456789:98765432");
     CHECK(header._authority == "example-ab.candy.com");
   }
-  SECTION("Verify URL parsing with a port") {
-    std::string url =
-        "http://example-ab.candy.com:8080/xy?zab=123456789:98765432";
+  SECTION("Verify URL parsing with a port")
+  {
+    std::string url = "http://example-ab.candy.com:8080/xy?zab=123456789:98765432";
     header.parse_url(url);
     CHECK(header._scheme == "http");
     CHECK(header._path == "/xy?zab=123456789:98765432");

--- a/test/unit_tests/test_chunk_parsing.cc
+++ b/test/unit_tests/test_chunk_parsing.cc
@@ -10,13 +10,13 @@
 
 using swoc::TextView;
 
-TEST_CASE("Check parsing of a chunked body", "[RuleCheck]") {
+TEST_CASE("Check parsing of a chunked body", "[RuleCheck]")
+{
   size_t num_body_bytes = 0;
   ChunkCodex codex;
   std::string accumulated_body;
   ChunkCodex::ChunkCallback cb{
-      [&num_body_bytes, &accumulated_body](TextView block, size_t offset,
-                                           size_t size) -> bool {
+      [&num_body_bytes, &accumulated_body](TextView block, size_t offset, size_t size) -> bool {
         num_body_bytes += block.size();
         accumulated_body += block;
         return true;

--- a/test/unit_tests/unit_test_main.cc
+++ b/test/unit_tests/unit_test_main.cc
@@ -8,7 +8,9 @@
 #define CATCH_CONFIG_RUNNER
 #include "catch.hpp"
 
-int main(int argc, char *argv[]) {
+int
+main(int argc, char *argv[])
+{
   int result = Catch::Session().run(argc, argv);
 
   return result;

--- a/tools/clang-format.sh
+++ b/tools/clang-format.sh
@@ -7,7 +7,7 @@
 #
 
 # Update the PKGDATE with the new version date when making a new clang-format binary package.
-PKGDATE="20180413"
+PKGDATE="20200514"
 
 function main() {
   set -e # exit on error
@@ -15,7 +15,7 @@ function main() {
 
   DIR=${1:-.}
   PACKAGE="clang-format-${PKGDATE}.tar.bz2"
-  VERSION="clang-format version 6.0.1 (http://llvm.org/git/clang.git d5f48a217f404c3462537527f4169bb45eed3904) (http://llvm.org/git/llvm.git aa0c91ae818e0b9e7981a42236dededc85997568)"
+  VERSION="clang-format version 10.0.0 (https://github.com/llvm/llvm-project.git d32170dbd5b0d54436537b6b75beaf44324e0c28)"
 
   URL=${URL:-https://ci.trafficserver.apache.org/bintray/${PACKAGE}}
 
@@ -50,7 +50,7 @@ function main() {
     ${CURL} -L --progress-bar -o ${ARCHIVE} ${URL}
     ${TAR} -x -C ${ROOT} -f ${ARCHIVE}
     cat > ${ROOT}/sha1 << EOF
-26aff1bc6dc315c695c62cadde38c934acd22d06  ${ARCHIVE}
+5eec43e5c7f3010d6e6f37639491cabe51de0ab2  ${ARCHIVE}
 EOF
     ${SHASUM} -c ${ROOT}/sha1
     chmod +x ${FORMAT}


### PR DESCRIPTION
Adding a clang-format file. Without this, running clang format doesn't do much.

### NOTE!!
This is built off of the commit from this PR: https://github.com/yahoo/proxy-verifier/pull/19

As such, only review the clang-format PR.

This is a non-functional change. Only the format is changing with this PR.





<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
