### PR TITLE
Fixing a crash if ERR_reason_error_string returns a nullptr

### DIFF
--- a/local/src/core/ProxyVerifier.cc
+++ b/local/src/core/ProxyVerifier.cc
@@ -2702,7 +2702,10 @@ bwformat(BufferWriter &w, bwf::Spec const &spec, bwf::SSLError const &error)
     w.print(number_fmt, error._e);
   } else {
     w.write(short_name(error._e));
-    w.write(ERR_reason_error_string(error._e));
+    auto const &error_reason = ERR_reason_error_string(error._e);
+    if (error_reason != nullptr) {
+      w.write(ERR_reason_error_string(error._e));
+    }
     if (spec._type != 's' && spec._type != 'S') {
       w.write(' ');
       w.print(number_fmt, error._e);


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.


With enough TLS traffic, this would crash sometimes when a log message was attempted and ERR_reason_error_string was a nullptr.