### PR TITLE
AuTest: pin the cryptography version to keep npn support

### DIFF
--- a/test/autests/Pipfile
+++ b/test/autests/Pipfile
@@ -24,6 +24,7 @@ gunicorn = "*"
 httpbin = "*"
 microserver = ">=1.0.4"
 jsonschema = "*"
+cryptography = "==2.8"
 pyopenssl = "*"
 eventlet = "*"
 

--- a/test/autests/gold_tests/http2/gold/single_transaction_client.gold_macos
+++ b/test/autests/gold_tests/http2/gold/single_transaction_client.gold_macos
@@ -1,0 +1,12 @@
+``
+``:status: 200
+``age: 0
+``date: Sat, 16 Mar 2019 01:13:21 GMT
+``content-type: application/json;charset=utf-8
+``content-encoding: gzip
+``cache-control: private
+``content-length: 16
+``
+``Starting session "single_transaction.json":5 protocol=h2.
+``1 transactions in 1 sessions ``
+``

--- a/test/autests/gold_tests/http2/gold/single_transaction_proxy.gold_macos
+++ b/test/autests/gold_tests/http2/gold/single_transaction_proxy.gold_macos
@@ -1,0 +1,30 @@
+``
+==== REQUEST HEADERS ====
+
+:method: GET
+:scheme: https
+:path: /a/path
+:authority: example.data.com
+accept-encoding: gzip
+accept-language: en-us
+host: example.com
+uuid: cb9b4e94-5d42-43d4-8545-320033298ba2-211674043
+accept: */*
+==== REQUEST BODY ====
+b''
+
+200 OK
+
+==== RESPONSE HEADERS ====
+age: 0
+date: Sat, 16 Mar 2019 01:13:21 GMT
+content-type: application/json;charset=utf-8
+content-encoding: gzip
+cache-control: private
+content-length: 16
+
+
+
+==== RESPONSE BODY ====
+b'0000000 0000001 '
+``

--- a/test/autests/gold_tests/http2/gold/single_transaction_server.gold_macos
+++ b/test/autests/gold_tests/http2/gold/single_transaction_server.gold_macos
@@ -1,0 +1,13 @@
+``
+``Ready with 1 transactions.
+``Loading 1 replay files.
+``
+``Responding to request /a/path with status 200.
+``Headers:
+- "Content-Length": "0"
+- "accept-language": "en-us"
+- "host": "example.com"
+- "uuid": "cb9b4e94-5d42-43d4-8545-320033298ba2-211674043"
+- "accept": "*/*"
+- "accept-encoding": "gzip"
+``

--- a/test/autests/gold_tests/http2/http2.test.py
+++ b/test/autests/gold_tests/http2/http2.test.py
@@ -7,20 +7,6 @@ Verify basic HTTP/2 functionality.
 # SPDX-License-Identifier: Apache-2.0
 #
 
-# The Python OpenSSL library used by the test proxy on the Mac fails with a
-# not-implemented error:
-# Traceback (most recent call last):
-#   File "/tmp/sbpv/http2/proxy1/test_proxy.py", line 60, in <module>
-#     sys.exit(main())
-#   File "/tmp/sbpv/http2/proxy1/test_proxy.py", line 46, in main
-#     proxy_http2.configure_http2_server(args.listen_port, args.server_port, args.https_pem)
-#   File "/Users/bneradt/project_not_synced/src/proxy-verifier/test/autests/gold_tests/autest-site/proxy_http2.py", line 188, in configure_http2_server
-#     context.set_npn_advertise_callback(npn_advertise_cb)
-#   File "/Users/bneradt/.local/share/virtualenvs/autests-Wg7FsRw_/lib/python3.8/site-packages/OpenSSL/SSL.py", line 666, in explode
-#     raise NotImplementedError(error)
-# NotImplementedError: NPN not available
-Test.SkipUnless(Condition.IsPlatform("linux"))
-
 Test.Summary = '''
 Verify basic HTTP/2 functionality.
 '''

--- a/test/autests/gold_tests/https/gold/single_transaction_client.gold_macos
+++ b/test/autests/gold_tests/https/gold/single_transaction_client.gold_macos
@@ -1,0 +1,14 @@
+``
+``Status: "200"
+``Headers:
+- "date": "Sat, 16 Mar 2019 01:33:27 GMT"
+- "content-type": "multipart/form-data;snoopy=123456"
+- "uuid": "cb9b4e94-5d42-43d4-8545-320033298ba2-214279439"
+- "age": "1"
+- "content-length": "12"
+
+``
+``Connecting via TLS.
+``Starting session "single_http_transaction.yaml":5 protocol=https.
+``1 transactions in 1 sessions ``
+``

--- a/test/autests/gold_tests/https/gold/single_transaction_proxy.gold_macos
+++ b/test/autests/gold_tests/https/gold/single_transaction_proxy.gold_macos
@@ -1,0 +1,19 @@
+``
+Client SNI: test_sni
+``
+POST https://example.data.com/a/path HTTP/1.1
+uuid: cb9b4e94-5d42-43d4-8545-320033298ba2-214279439
+``
+content-length: 10
+``
+==== REQUEST BODY ====
+b'0000000 00'
+
+HTTP/1.1 200 OK
+uuid: cb9b4e94-5d42-43d4-8545-320033298ba2-214279439
+age: 1
+content-length: 12
+``
+==== RESPONSE BODY ====
+b'0000000 0000'
+``

--- a/test/autests/gold_tests/https/gold/single_transaction_server.gold_macos
+++ b/test/autests/gold_tests/https/gold/single_transaction_server.gold_macos
@@ -1,0 +1,16 @@
+``
+``Listening at 127.0.0.1:4444
+``Listening at 127.0.0.1:8080
+``Ready with 1 transactions.
+``Loading 1 replay files.
+``
+``Responding to request /a/path with status 200.
+``Headers:
+- "content-type": "application/json; charset=utf-8"
+- "accept-encoding": "gzip"
+- "uuid": "cb9b4e94-5d42-43d4-8545-320033298ba2-214279439"
+- "content-length": "10"
+- "host": "example.com"
+``
+``Handling request with url: /a/path
+``

--- a/test/autests/gold_tests/https/https.test.py
+++ b/test/autests/gold_tests/https/https.test.py
@@ -7,21 +7,6 @@ Verify basic HTTPS functionality.
 # SPDX-License-Identifier: Apache-2.0
 #
 
-
-# The Python OpenSSL library used by the test proxy on the Mac fails with a
-# not-implemented error:
-# Traceback (most recent call last):
-#   File "/tmp/sbpv/http2/proxy1/test_proxy.py", line 60, in <module>
-#     sys.exit(main())
-#   File "/tmp/sbpv/http2/proxy1/test_proxy.py", line 46, in main
-#     proxy_http2.configure_http2_server(args.listen_port, args.server_port, args.https_pem)
-#   File "/Users/bneradt/project_not_synced/src/proxy-verifier/test/autests/gold_tests/autest-site/proxy_http2.py", line 188, in configure_http2_server
-#     context.set_npn_advertise_callback(npn_advertise_cb)
-#   File "/Users/bneradt/.local/share/virtualenvs/autests-Wg7FsRw_/lib/python3.8/site-packages/OpenSSL/SSL.py", line 666, in explode
-#     raise NotImplementedError(error)
-# NotImplementedError: NPN not available
-Test.SkipUnless(Condition.IsPlatform("linux"))
-
 Test.Summary = '''
 Verify basic HTTPS functionality.
 '''
@@ -31,14 +16,19 @@ client = r.AddClientProcess("client1", "replay_files/single_transaction", https_
 server = r.AddServerProcess("server1", "replay_files/single_transaction", https_ports=[4444], other_args="--verbose diag")
 proxy = r.AddProxyProcess("proxy1", listen_port=4443, server_port=4444, use_ssl=True)
 
-proxy.Streams.stdout = "gold/single_transaction_proxy.gold"
+if Condition.IsPlatform("darwin"):
+    proxy.Streams.stdout = "gold/single_transaction_proxy.gold_macos"
+    client.Streams.stdout = "gold/single_transaction_client.gold_macos"
+    server.Streams.stdout = "gold/single_transaction_server.gold_macos"
+else:
+    proxy.Streams.stdout = "gold/single_transaction_proxy.gold"
+    client.Streams.stdout = "gold/single_transaction_client.gold"
+    server.Streams.stdout = "gold/single_transaction_server.gold"
 
-client.Streams.stdout = "gold/single_transaction_client.gold"
 client.Streams.stdout += Testers.ExcludesExpression(
         "Violation:",
         "There should be no verification errors because there are none added.")
 
-server.Streams.stdout = "gold/single_transaction_server.gold"
 server.Streams.stdout += Testers.ExcludesExpression(
         "Violation:",
         "There should be no verification errors because there are none added.")

--- a/test/autests/test-env-check.sh
+++ b/test/autests/test-env-check.sh
@@ -15,7 +15,7 @@ _END_
 if [ $? = 1 ]
 then
     echo "Python 3.5 or newer is not installed/enabled."
-    return
+    exit 1
 else
     echo "Python 3.5 or newer detected!"
 fi
@@ -27,16 +27,20 @@ then
     echo "python3-dev/devel detected!"
 else
     echo "python3-dev/devel is not installed. "
-    return
+    exit 1
 fi
 
 # check for pipenv
 pipenv --version &> /dev/null
-if [ $? = 0 ]
-then
+if [ $? -eq 0 ]; then
     echo "pipenv detected!"
-    pipenv install
-    # pipenv shell
+    pipenv --venv &> /dev/null
+    if [ $? -ne 0 ]; then
+        echo "Installing a new virtual environment via pipenv"
+        pipenv install
+    else
+        echo "Using the pre-existing virtual environment."
+    fi
 else
     echo "pipenv is not installed/enabled. "
 fi


### PR DESCRIPTION
The http2 test depends upon NPN support. This pins the cryptography
version to keep NPN support.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
