### PR TITLE
Support contains, prefix, and suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ Each header field specification can verify one of the following:
 
 1. The absence of a field with the specified name.
 1. The presence of a field with the specified name.
-1. Both the presence of a field with the specified name and value (matched cases sensitively).
+1. Both the presence of a field with the specified name and value (matched case sensitively).
+1. The presence of a field with the specified name with a value containing the specified value (matched case sensitively).
+1. The presence of a field with the specified name with a value prefixed with the specified value (matched case sensitively).
+1. The presence of a field with the specified name with a value suffixed with the specified value (matched case sensitively).
 
 Thus the following JSON field specification requests no field verification:
 
@@ -32,10 +35,34 @@ The following specifies that the HTTP field `X-Forwarded-For` _with any value_ s
   - [ X-Forwarded-For, 10.10.10.2, absent ]
 ```
 
+The following specifies that the HTTP field `X-Forwarded-For` _with any value_ should  have been sent by the proxy:
+
+```YAML
+  - [ X-Forwarded-For, 10.10.10.2, present ]
+```
+
 The following specifies that `X-Forwarded-For` should have been received from the proxy with the exact value "10.10.10.2":
 
 ```YAML
   - [ X-Forwarded-For, 10.10.10.2, equal ]
+```
+
+The following specifies that `X-Forwarded-For` should have been received from the proxy containing the value "10" at any position in the actual value:
+
+```YAML
+  - [ X-Forwarded-For, 10, contains ]
+```
+
+The following specifies that `X-Forwarded-For` should have been received from the proxy with an actual value prefixed with "1":
+
+```YAML
+  - [ X-Forwarded-For, 1, prefix ]
+```
+
+The following specifies that `X-Forwarded-For` should have been received from the proxy with an actual value suffixed with "2":
+
+```YAML
+  - [ X-Forwarded-For, 2, suffix ]
 ```
 
 ## Install

--- a/test/autests/gold_tests/field_verification/http_replay_files/substr_rules/substr_rules.yaml
+++ b/test/autests/gold_tests/field_verification/http_replay_files/substr_rules/substr_rules.yaml
@@ -1,0 +1,58 @@
+meta:
+  version: "1.0"
+
+sessions:
+- protocol: [ { name: tcp }, {name: ip, version: 4} ]
+  transactions:
+
+  - client-request:
+      version: "1.1"
+      scheme: "http"
+      method: "GET"
+      url: "http://example.one/config/settings.yaml"
+      headers:
+        fields:
+        - [ Host, example.one ]
+        - [ X-Test-Request, RequestData ]
+        - [ X-Test-Present, It's there ]
+        - [ uuid, 5 ]
+    proxy-request:
+      version: "1.1"
+      scheme: "http"
+      method: "GET"
+      url: "http://example.one/config/settings.yaml"
+      headers:
+        fields:
+        - [ Host, le.on, contains ]
+        - [ X-Test-Request, Req, prefix ]
+        - [ X-Test-Present, there, suffix ]
+        - [ Host, two, contains ]
+        - [ X-Test-Request, equest, prefix ]
+        - [ X-Test-Present, er, suffix ]
+        - [ uuid, 5 ]
+    server-response:
+      status: 200
+      reason: OK
+      content:
+        size: 16
+      headers:
+        fields:
+        - [ Content-Type, text/html ]
+        - [ Content-Length, 16 ]
+        - [ Set-Cookie, ABCD ]
+        - [ uuid, 5 ]
+    proxy-response:
+      status: 200
+      reason: OK
+      content:
+        size: 16
+      headers:
+        fields:
+        - [ Content-Type, text/html ]
+        - [ Content-Length, 16 ]
+        - [ Content-Type, html, contains ]
+        - [ Set-Cookie, ABCDE, contains ]
+        - [ X-Not-A-Header, Whatever, prefix ]
+        - [ X-Does-Not-Exist, NotHere, contains ]
+        - [ X-Does-Not-Exist, NotHere, suffix ]
+        - [ uuid, 5 ]

--- a/test/autests/gold_tests/field_verification/http_replay_files/substr_rules_duplicate/substr_rules_duplicate.yaml
+++ b/test/autests/gold_tests/field_verification/http_replay_files/substr_rules_duplicate/substr_rules_duplicate.yaml
@@ -1,0 +1,57 @@
+meta:
+  version: "1.0"
+
+sessions:
+- protocol: [ { name: tcp }, {name: ip, version: 4} ]
+  transactions:
+  - all:
+      headers:
+        fields:
+        - [ uuid, 1 ]
+
+    client-request:
+      version: "1.1"
+      scheme: "http"
+      method: "GET"
+      url: "http://example.one/config/settings.yaml"
+      headers:
+        fields:
+        - [ Host, example.one ]
+        - [ Set-Cookie, [ ABCD, EFG ] ]
+        - [ Pref-Cookie, [ ABCD ] ]
+    proxy-request:
+      version: "1.1"
+      scheme: "http"
+      method: "GET"
+      url: "http://example.one/config/settings.yaml"
+      headers:
+        fields:
+        - [ Host, example.one ]
+        - [ Pref-Cookie, [ AB, EF ], prefix ]
+        - [ Suff-Cookie, [ AB, EF ], suffix ]
+        - [ Set-Cookie, [ G, F ], contains ]
+        - [ Set-Cookie, [ AB, G ], suffix ]
+        - [ Set-Cookie, [ AB, E ], contains ]
+        - [ Set-Cookie, [ A, EFG ], prefix ]
+    server-response:
+      status: 200
+      reason: OK
+      content:
+        size: 16
+      headers:
+        fields:
+        - [ Content-Type, text/html ]
+        - [ Content-Length, 16 ]
+        - [ Set-Cookie, [ ABCD, EFG ] ]
+    proxy-response:
+      status: 200
+      reason: OK
+      content:
+        size: 16
+      headers:
+        fields:
+        - [ Content-Type, text/html ]
+        - [ Content-Length, 16 ]
+        - [ Set-Cookie, [ AB ], contains ]
+        - [ Set-Cookie, [ BC, EF ], prefix ]
+        - [ Set-Cookie, [ ABCD, EFG ], suffix ]

--- a/test/autests/gold_tests/field_verification/substr_rules.test.py
+++ b/test/autests/gold_tests/field_verification/substr_rules.test.py
@@ -1,0 +1,115 @@
+'''
+Verify correct field verification behavior for contains, prefix, and suffix.
+'''
+# @file
+#
+# Copyright 2020, Verizon Media
+# SPDX-License-Identifier: Apache-2.0
+#
+
+
+Test.Summary = '''
+Verify correct field verification behavior for contains, prefix, and suffix.
+'''
+
+#
+# Test 1: Verify field verification in a YAML replay file.
+#
+r = Test.AddTestRun("Verify field verification works for a simple HTTP transaction")
+client = r.AddClientProcess("client1", "http_replay_files/substr_rules", http_ports=[8080], other_args="--verbose diag")
+server = r.AddServerProcess("server1", "http_replay_files/substr_rules", http_ports=[8081], other_args="--verbose diag")
+proxy = r.AddProxyProcess("proxy1", listen_port=8080, server_port=8081)
+
+server.Streams.stdout += Testers.ContainsExpression(
+        'Contains Success: Key: "5", Name: "host", Required Value: "le.on", Value: "example.one"',
+        'Validation should be happy that "le.on" is in "example.one".')
+
+server.Streams.stdout += Testers.ContainsExpression(
+        'Prefix Success: Key: "5", Name: "x-test-request", Required Prefix: "Req", Value: "RequestData"',
+        'Validation should be happy that "RequestData" began with "Req".')
+
+server.Streams.stdout += Testers.ContainsExpression(
+        'Suffix Success: Key: "5", Name: "x-test-present", Required Suffix: "there", Value: "It\'s there"',
+        'Validation should be happy that "It\'s there" ended with "there.')
+
+server.Streams.stdout += Testers.ContainsExpression(
+        'Contains Violation: Not Contained. Key: "5", Name: "host", Required Value: "two", Actual Value: "example.one"',
+        'Validation should complain that "two" is not in "example.one".')
+
+server.Streams.stdout += Testers.ContainsExpression(
+        'Prefix Violation: Not Found. Key: "5", Name: "x-test-request", Required Prefix: "equest", Actual Value: "RequestData"',
+        'Validation should complain that "RequestData" did not begin with "equest".')
+
+server.Streams.stdout += Testers.ContainsExpression(
+        'Suffix Violation: Not Found. Key: "5", Name: "x-test-present", Required Suffix: "er", Actual Value: "It\'s there"',
+        'Validation should complain that "It\'s there" did not end with "er".')
+
+client.Streams.stdout += Testers.ContainsExpression(
+        'Contains Success: Key: "5", Name: "content-type", Required Value: "html", Value: "text/html"',
+        'Validation should be happy that "html" is in "text/html".')
+
+client.Streams.stdout += Testers.ContainsExpression(
+        'Contains Violation: Not Contained. Key: "5", Name: "set-cookie", Required Value: "ABCDE", Actual Value: "ABCD"',
+        'Validation should complain that "ABCDE" is not in "ABCD".')
+
+client.Streams.stdout += Testers.ContainsExpression(
+        'Prefix Violation: Absent. Key: "5", Name: "x-not-a-header", Required Prefix: "Whatever"',
+        'Validation should complain that "X-Not-A-Header" is missing.')
+
+client.Streams.stdout += Testers.ContainsExpression(
+        'Contains Violation: Absent. Key: "5", Name: "x-does-not-exist", Required Value: "NotHere"',
+        'Validation should complain that "X-Does-Not-Exist" is missing.')
+
+client.Streams.stdout += Testers.ContainsExpression(
+        'Suffix Violation: Absent. Key: "5", Name: "x-does-not-exist", Required Suffix: "NotHere"',
+        'Validation should complain that "X-Does-Not-Exist" is missing.')
+
+client.ReturnCode = 1
+server.ReturnCode = 1
+
+#
+# Test 2: Verify duplicate field verification in a YAML replay file.
+#
+r = Test.AddTestRun("Verify field verification works for HTTP transaction with duplicate fields")
+client = r.AddClientProcess("client2", "http_replay_files/substr_rules_duplicate", http_ports=[8080], other_args="--verbose diag")
+server = r.AddServerProcess("server2", "http_replay_files/substr_rules_duplicate", http_ports=[8081], other_args="--verbose diag")
+proxy = r.AddProxyProcess("proxy2", listen_port=8080, server_port=8081)
+
+client.Streams.stdout += Testers.ContainsExpression(
+        'Contains Violation: Absent/Mismatched. Key: "1", Name: "set-cookie", Required Values: "AB", Received Values: "ABCD" "EFG"',
+        'Validation should be complain that "Set-Cookie" had too many values.')
+
+server.Streams.stdout += Testers.ContainsExpression(
+        'Prefix Violation: Absent/Mismatched. Key: "1", Name: "pref-cookie", Required Prefixes: "AB" "EF", Received Values: "ABCD"',
+        'Validation should be complain that "Set-Cookie" had too few values.')
+
+server.Streams.stdout += Testers.ContainsExpression(
+        'Suffix Violation: Absent/Mismatched. Key: "1", Name: "suff-cookie", Required Suffixes: "AB" "EF", Received Values:',
+        'Validation should complain that "Set-Cookie" had no values.')
+
+server.Streams.stdout += Testers.ContainsExpression(
+        'Contains Violation: Not Contained. Key: "1", Name: "set-cookie", Required Values: "G" "F", Received Values: "ABCD" "EFG"',
+        'Validation should be complain that "Set-Cookie" had uncontained values.')
+
+client.Streams.stdout += Testers.ContainsExpression(
+        'Prefix Violation: Not Found. Key: "1", Name: "set-cookie", Required Prefixes: "BC" "EF", Received Values: "ABCD" "EFG"',
+        'Validation should be complain that "Set-Cookie" did not match all prefixes.')
+
+server.Streams.stdout += Testers.ContainsExpression(
+        'Suffix Violation: Not Found. Key: "1", Name: "set-cookie", Required Suffixes: "AB" "G", Received Values: "ABCD" "EFG"',
+        'Validation should complain that "Set-Cookie" did not match all suffixes.')
+
+server.Streams.stdout += Testers.ContainsExpression(
+        'Contains Success: Key: "1", Name: "set-cookie", Required Values: "AB" "E", Received Values: "ABCD" "EFG"',
+        'Validation should be happy that "Set-Cookie" matched all values.')
+
+server.Streams.stdout += Testers.ContainsExpression(
+        'Prefix Success: Key: "1", Name: "set-cookie", Required Prefixes: "A" "EFG", Received Values: "ABCD" "EFG"',
+        'Validation should be happy that "Set-Cookie" matched all prefixes.')
+
+client.Streams.stdout += Testers.ContainsExpression(
+        'Suffix Success: Key: "1", Name: "set-cookie", Required Suffixes: "ABCD" "EFG", Received Values: "ABCD" "EFG"',
+        'Validation should be happy that "Set-Cookie" matched all suffixes.')
+
+client.ReturnCode = 1
+server.ReturnCode = 1

--- a/test/unit_tests/test_ProxyVerifier.cc
+++ b/test/unit_tests/test_ProxyVerifier.cc
@@ -70,6 +70,53 @@ TEST_CASE("RuleChecks of non-duplicate fields", "[RuleCheck]")
     CHECK(equal_check_blank->test(key, test_name, empty_value));
     CHECK_FALSE(equal_check_blank->test(key, test_name, non_empty_value));
   }
+
+  SECTION("contains checks")
+  {
+    swoc::TextView contained_value("Val");
+    std::shared_ptr<RuleCheck> contains_check =
+        RuleCheck::make_rule_check(test_name, contained_value, "contains");
+    REQUIRE(contains_check);
+
+    CHECK_FALSE(contains_check->test(key, empty_name, empty_value));
+    CHECK_FALSE(contains_check->test(key, empty_name, expected_value));
+    CHECK_FALSE(contains_check->test(key, empty_name, contained_value));
+    CHECK_FALSE(contains_check->test(key, test_name, empty_value));
+    CHECK(contains_check->test(key, test_name, expected_value));
+    CHECK(contains_check->test(key, test_name, contained_value));
+  }
+
+  SECTION("prefix checks")
+  {
+    swoc::TextView prefix_value("test");
+    std::shared_ptr<RuleCheck> prefix_check =
+        RuleCheck::make_rule_check(test_name, prefix_value, "prefix");
+    REQUIRE(prefix_check);
+
+    CHECK_FALSE(prefix_check->test(key, empty_name, empty_value));
+    CHECK_FALSE(prefix_check->test(key, empty_name, expected_value));
+    CHECK_FALSE(prefix_check->test(key, empty_name, prefix_value));
+    CHECK_FALSE(prefix_check->test(key, test_name, empty_value));
+    CHECK(prefix_check->test(key, test_name, expected_value));
+    CHECK(prefix_check->test(key, test_name, prefix_value));
+  }
+
+  SECTION("suffix checks")
+  {
+    swoc::TextView suffix_value("alue");
+    std::shared_ptr<RuleCheck> suffix_check =
+        RuleCheck::make_rule_check(test_name, suffix_value, "suffix");
+    REQUIRE(suffix_check);
+
+    CHECK_FALSE(suffix_check->test(key, empty_name, empty_value));
+    CHECK_FALSE(suffix_check->test(key, empty_name, expected_value));
+    CHECK_FALSE(suffix_check->test(key, empty_name, suffix_value));
+    CHECK_FALSE(suffix_check->test(key, test_name, empty_value));
+    CHECK(suffix_check->test(key, test_name, expected_value));
+    CHECK(suffix_check->test(key, test_name, suffix_value));
+  }
+
+  // contains/prefix/suffix rule with blank value would be absurd, so skipped
 }
 
 TEST_CASE("RuleChecks of duplicate fields", "[RuleCheck]")


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Supports new rules for field verification. contains allows searching for substrings in any position of a field value, prefix at the beginning of a field value, and suffix at the end of a field value. For example:

```
- [ "Host", "stage.video.ex:", prefix ]
- [ "Path", ".jpg", suffix ]
- [ "Via", "traffic server", contains ]
```
