### PR TITLE
Pin pyopenssl; memove npn cryptography dependency.

### DIFF
--- a/test/autests/Pipfile
+++ b/test/autests/Pipfile
@@ -15,17 +15,14 @@ pyflakes = "*"
 
 [packages]
 autest = "==1.7.4"
-traffic-replay = "*" # this should install TRLib, MicroServer, MicroDNS, Traffic-Replay
 hyper = "*"
 dnslib = "*"
 # These are likely to be available via yum/dnf or apt-get
 requests = "*"
 gunicorn = "*"
 httpbin = "*"
-microserver = ">=1.0.4"
 jsonschema = "*"
-cryptography = "==2.8"
-pyopenssl = "*"
+pyOpenSSL = "==19.1.0"
 eventlet = "*"
 
 [requires]

--- a/test/autests/gold_tests/autest-site/proxy_http2.py
+++ b/test/autests/gold_tests/autest-site/proxy_http2.py
@@ -165,10 +165,6 @@ def alpn_callback(conn, protos):
     raise RuntimeError("No acceptable protocol offered!")
 
 
-def npn_advertise_cb(conn):
-    return [b'h2']
-
-
 def configure_http2_server(listen_port, server_port, https_pem):
     # Let's set up SSL. This is a lot of work in PyOpenSSL.
     options = (
@@ -185,7 +181,6 @@ def configure_http2_server(listen_port, server_port, https_pem):
     context.set_verify(SSL.VERIFY_NONE, lambda *args: True)
     context.use_privatekey_file(https_pem)
     context.use_certificate_file(https_pem)
-    context.set_npn_advertise_callback(npn_advertise_cb)
     context.set_alpn_select_callback(alpn_callback)
     context.set_cipher_list(
         "RSA+AESGCM"


### PR DESCRIPTION
The newest version of PyOpenssl breaks eventlet. I filed an opensource
bug with eventlet:
https://github.com/eventlet/eventlet/issues/671

Also, by simply removing the npn callback which we don't use anyway, we
no longer need to pin the cryptography version which is quite old at
this point.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
