### PR TITLE
Fix path/query parsing bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,11 +67,12 @@ The following specifies that `X-Forwarded-For` should have been received from th
 
 ## URL Verification
 
-Similarly to Field Verification, a mechanism exists to verify the parts of URLs being received from the proxy by the server. The parts follow the URI specification, with scheme, host, port, authority (also known as net-loc, the combination of host and port), path, query, and fragment supported. In each of these cases, supporting characters like slashes, colons, question marks, and number signs are removed, with the exception of a URL with no scheme or authority, where a leading slash to start the path, if present, is maintained.
+Similarly to Field Verification, a mechanism exists to verify the parts of URLs being received from the proxy by the server. These rules can be given as an alternative to a scalar URL for the "url" field in the proxy request. The parts follow the URI specification, with scheme, host, port, authority (also known as net-loc, the combination of host and port), path, query, and fragment supported. In each of these cases, supporting characters like slashes, colons, question marks, and number signs are removed, with the exception of a URL with no scheme or authority, where a leading slash to start the path, if present, is maintained.
 
  The following specifies the verification of the URL `http://example.one:8080/path?query=q#Frag`. All rules specified in Field Verification are still supported:
 
 ```YAML
+  url:
   - [ scheme, http, equal ]
   - [ host, example.one, equal ]
   - [ port, 8080, equal ]
@@ -89,6 +90,7 @@ Alternatively, authority, with an alias of net-loc, could be used. It is the com
 Verification of the path `/path/x/y?query=q#Frag` could be specified like this:
 
 ```YAML
+  url:
   - [ authority, foo, absent ]
   - [ path, /path/x/y, equal ]
   - [ query, query=q, equal ]

--- a/local/src/core/ProxyVerifier.cc
+++ b/local/src/core/ProxyVerifier.cc
@@ -2859,6 +2859,7 @@ HttpHeader::parse_url(TextView url)
     uri_authority = this->localize(url.substr(host_start, port_end - host_start));
   } else {
     path_start = 0; // assume no scheme or authority
+    port_end = 0;
   }
   std::size_t query_start = url.find("?", port_end);
   std::size_t fragment_start = url.find("#", port_end);

--- a/test/unit_tests/test_ProxyVerifier.cc
+++ b/test/unit_tests/test_ProxyVerifier.cc
@@ -205,10 +205,26 @@ TEST_CASE("Test path parsing", "[ParseUrl]")
   HttpHeader header;
   SECTION("Verify a simple path can be parsed")
   {
-    std::string url = "/a/path";
+    std::string url = "a/path";
     header.parse_url(url);
     CHECK(header._scheme == "");
-    CHECK(header._path == "/a/path");
+    CHECK(header._path == "a/path");
+    CHECK(header._authority == "");
+
+    CHECK(header.uri_scheme == "");
+    CHECK(header.uri_host == "");
+    CHECK(header.uri_port == "");
+    CHECK(header.uri_authority == "");
+    CHECK(header.uri_path == "a/path");
+    CHECK(header.uri_query == "");
+    CHECK(header.uri_fragment == "");
+  }
+  SECTION("Verify a less simple path can be parsed")
+  {
+    std::string url = "/a/path?q=q#F";
+    header.parse_url(url);
+    CHECK(header._scheme == "");
+    CHECK(header._path == "/a/path?q=q#F");
     CHECK(header._authority == "");
 
     CHECK(header.uri_scheme == "");
@@ -216,8 +232,8 @@ TEST_CASE("Test path parsing", "[ParseUrl]")
     CHECK(header.uri_port == "");
     CHECK(header.uri_authority == "");
     CHECK(header.uri_path == "/a/path");
-    CHECK(header.uri_query == "");
-    CHECK(header.uri_fragment == "");
+    CHECK(header.uri_query == "q=q");
+    CHECK(header.uri_fragment == "F");
   }
   SECTION("Verify URL parsing")
   {


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Fixes a bug with URL parsing when a scheme is missing (marker was not reset to 0 if missing)