### PR TITLE
Fix handling of zero-length chunked bodies.

### DIFF
--- a/local/src/core/ProxyVerifier.cc
+++ b/local/src/core/ProxyVerifier.cc
@@ -578,9 +578,10 @@ Session::write_body(HttpHeader const &hdr)
 
   /* Observe that by this point, hdr._content_size will have been adjusted to 0
    * for HEAD requests via update_content_length. */
-  if (hdr._content_size > 0 && ((hdr._status == 0 /* this is a request */) ||
-                                (hdr._status && !HttpHeader::STATUS_NO_CONTENT[hdr._status])))
-  {
+  auto const message_type_permits_body =
+      (hdr._status == 0 || (hdr._status && !HttpHeader::STATUS_NO_CONTENT[hdr._status]));
+  // Note that zero-length chunked bodies must send a zero-length encoded chunk.
+  if (message_type_permits_body && (hdr._content_size > 0 || hdr._chunked_p)) {
     TextView content;
     if (hdr._content_data) {
       content = TextView{hdr._content_data, hdr._content_size};

--- a/test/autests/gold_tests/autest-site/proxy_http1.py
+++ b/test/autests/gold_tests/autest-site/proxy_http1.py
@@ -104,7 +104,7 @@ class ProxyRequestHandler(BaseHTTPRequestHandler):
         setattr(req, 'headers', self.filter_headers(req.headers))
 
         replay_server = "127.0.0.1:{}".format(self.server_port)
-        print("Connecting to: {}".format(replay_server))
+        print("Connecting to: {} with scheme {}".format(replay_server, scheme))
 
         try:
             origin = (scheme, replay_server)
@@ -243,6 +243,8 @@ class ProxyRequestHandler(BaseHTTPRequestHandler):
 
     @staticmethod
     def chunkify_body(res_body):
+        if len(res_body) == 0:
+            return b'0\r\n\r\n'
         header = '{:x}\r\n'.format(len(res_body)).encode()
         trailer = b'\r\n0\r\n\r\n'
         return header + res_body + trailer

--- a/test/autests/gold_tests/body/body.yaml
+++ b/test/autests/gold_tests/body/body.yaml
@@ -2,6 +2,9 @@
 meta:
   version: '1.0'
 
+#
+# Verify correct handling of chunked and content-length bodies.
+#
 sessions:
 - protocol: [ {name: http, version: 1.1}, {name: tls, version: 1.2, sni: test_sni}, { name: tcp }, {name: ip, version: 4} ]
   transactions:
@@ -35,7 +38,7 @@ sessions:
         size: 48
       headers:
         fields:
-        - [ Transfer-Encoding, chunked ]
+        - [ Transfer-Encoding, chunked, equal ]
         - [ X-Request, "first_request", equal ]
 
     server-response:
@@ -64,7 +67,7 @@ sessions:
         encoding: esc_json
         fields:
         - [ Content-Type, multipart/form-data;snoopy=123456 ]
-        - [ Transfer-Encoding, chunked ]
+        - [ Transfer-Encoding, chunked, equal ]
         - [ Connection, keep-alive ]
         - [ X-Response, "first_response", equal ]
 
@@ -125,5 +128,69 @@ sessions:
         fields:
         - [ Content-Type, multipart/form-data;snoopy=123456 ]
         - [ Transfer-Encoding, chunked ]
+        - [ Connection, keep-alive ]
+        - [ X-Response, "second_response", equal ]
+
+  #
+  # Verify we can handle a zero-length chunk.
+  #
+  - all:
+      headers:
+        fields:
+        - [ uuid, 3 ]
+
+    client-request:
+      version: '1.1'
+      scheme: https
+      method: POST
+      url: https://example.data.com/a/path
+      content:
+        encoding: plain
+        size: 0
+      headers:
+        encoding: esc_json
+        fields:
+        - [ Content-Type, application/json; charset=utf-8 ]
+        - [ Transfer-Encoding, chunked ]
+        - [ X-Request, "second_request" ]
+
+    proxy-request:
+      version: '1.1'
+      scheme: ''
+      method: POST
+      url: "/a/path"
+      content:
+        encoding: plain
+        size: 0
+      headers:
+        fields:
+        - [ X-Request, "second_request", equal ]
+        - [ Transfer-Encoding, chunked, equal ]
+
+    server-response:
+      status: 200
+      reason: OK
+      content:
+        encoding: plain
+        size: 0
+      headers:
+        encoding: esc_json
+        fields:
+        - [ Content-Type, multipart/form-data;snoopy=123456 ]
+        - [ Connection, keep-alive ]
+        - [ Transfer-Encoding, chunked ]
+        - [ X-Response, "second_response", equal ]
+
+    proxy-response:
+      status: 200
+      reason: OK
+      content:
+        encoding: plain
+        size: 0
+      headers:
+        encoding: esc_json
+        fields:
+        - [ Content-Type, multipart/form-data;snoopy=123456 ]
+        - [ Transfer-Encoding, chunked, equal ]
         - [ Connection, keep-alive ]
         - [ X-Response, "second_response", equal ]

--- a/test/autests/gold_tests/field_parsing/gold/transaction_fields_proxy.gold
+++ b/test/autests/gold_tests/field_parsing/gold/transaction_fields_proxy.gold
@@ -16,7 +16,7 @@ content-type: text/html
 ==== RESPONSE BODY ====
 b'0000000 0000001 '
 
-Connecting to: 127.0.0.1:8083
+Connecting to:``
 GET http://example.one/path/2 HTTP/1.1
 uuid: 2
 host: example.one

--- a/test/autests/gold_tests/field_parsing/gold/transaction_fields_proxy.gold_macos
+++ b/test/autests/gold_tests/field_parsing/gold/transaction_fields_proxy.gold_macos
@@ -16,7 +16,7 @@ uuid: 1
 ==== RESPONSE BODY ====
 b'0000000 0000001 '
 
-Connecting to: 127.0.0.1:8083
+Connecting to:``
 GET http://example.one/path/2 HTTP/1.1
 uuid: 2
 host: example.one

--- a/test/autests/gold_tests/field_parsing/gold/yaml_specified_proxy.gold
+++ b/test/autests/gold_tests/field_parsing/gold/yaml_specified_proxy.gold
@@ -18,7 +18,7 @@ content-type: text/html
 ==== RESPONSE BODY ====
 b'0000000 0000001 '
 
-Connecting to: 127.0.0.1:8083
+Connecting to:``
 GET http://example.one/config/settings.yaml HTTP/1.1
 x-another-header: request
 uuid: 2

--- a/test/autests/gold_tests/field_parsing/gold/yaml_specified_proxy.gold_macos
+++ b/test/autests/gold_tests/field_parsing/gold/yaml_specified_proxy.gold_macos
@@ -18,7 +18,7 @@ uuid: 1
 ==== RESPONSE BODY ====
 b'0000000 0000001 '
 
-Connecting to: 127.0.0.1:8083
+Connecting to:``
 GET http://example.one/config/settings.yaml HTTP/1.1
 host: example.one
 uuid: 2


### PR DESCRIPTION
We didn't send a zero-length chunked body for empty content chunked
encoded messages. This fixes that.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
