### PR TITLE
Removing the pyOpenSSL pin

### DIFF
--- a/test/autests/Pipfile
+++ b/test/autests/Pipfile
@@ -22,7 +22,7 @@ requests = "*"
 gunicorn = "*"
 httpbin = "*"
 jsonschema = "*"
-pyOpenSSL = "==19.1.0"
+pyOpenSSL = "*"
 eventlet = "*"
 
 [requires]


### PR DESCRIPTION
The eventlet issue requiring us to pin PyOpenSSL has been resolved:
https://github.com/eventlet/eventlet/issues/671

Therefore we can remove the PyOpenSSL pin.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
