### PR TITLE
Update server to be able to derive key from just client-request

### DIFF
--- a/local/include/core/ProxyVerifier.h
+++ b/local/include/core/ProxyVerifier.h
@@ -1095,6 +1095,9 @@ public:
 
   swoc::Errata serialize(swoc::BufferWriter &w) const;
 
+  static constexpr char const *const KEY_NOT_FOUND = "*N/A*";
+
+  /** Make the key for this transaction per the specified key format. */
   std::string make_key() const;
 
   /** Verify that the fields in 'this' correspond to the provided rules.

--- a/local/src/core/ProxyVerifier.cc
+++ b/local/src/core/ProxyVerifier.cc
@@ -4622,12 +4622,12 @@ HttpHeader::Binding::operator()(BufferWriter &w, const swoc::bwf::Spec &spec) co
         spot != _hdr._fields_rules->_fields.end()) {
       bwformat(w, spec, spot->second);
     } else {
-      bwformat(w, spec, "*N/A*");
+      bwformat(w, spec, KEY_NOT_FOUND);
     }
   } else if (0 == strcasecmp("url"_tv, name)) {
     bwformat(w, spec, _hdr._url);
   } else {
-    bwformat(w, spec, "*N/A*");
+    bwformat(w, spec, KEY_NOT_FOUND);
   }
   return w;
 }


### PR DESCRIPTION
Before this, the server had to get the key from a proxy-request node. If
an all:headers::fields::uid existed, it happened to get it from there,
but otherwise the server could not derive a key for a transaction
without a proxy-request. We don't want the user to be required to add
a proxy-request node, so this wasn't acceptable.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
