### PR TITLE
Add support for field/URL verification via a map

### DIFF
--- a/local/include/core/ProxyVerifier.h
+++ b/local/include/core/ProxyVerifier.h
@@ -79,9 +79,12 @@ static const std::string YAML_CONTENT_DATA_KEY{"data"};
 static const std::string YAML_CONTENT_ENCODING_KEY{"encoding"};
 static const std::string YAML_CONTENT_TRANSFER_KEY{"transfer"};
 
-static constexpr size_t YAML_RULE_NAME_KEY{0};
-static constexpr size_t YAML_RULE_DATA_KEY{1};
-static constexpr size_t YAML_RULE_TYPE_KEY{2};
+static constexpr size_t YAML_RULE_KEY_INDEX{0};
+static constexpr size_t YAML_RULE_VALUE_INDEX{1};
+static constexpr size_t YAML_RULE_TYPE_INDEX{2};
+
+static const std::string YAML_RULE_VALUE_MAP_KEY{"value"};
+static const std::string YAML_RULE_TYPE_MAP_KEY{"as"};
 
 static const std::string YAML_RULE_EQUALS{"equal"};
 static const std::string YAML_RULE_PRESENCE{"present"};

--- a/local/src/client/verifier-client.cc
+++ b/local/src/client/verifier-client.cc
@@ -58,7 +58,7 @@ std::list<std::shared_ptr<Ssn>> Session_List;
 
 std::deque<swoc::IPEndpoint> Target, Target_Https;
 
-/** Whether the replay-client behaves according to client-request or
+/** Whether the replay-client constructs traffic according to client-request or
  * proxy-request directives.
  *
  * This flag is toggled via the existence or non-existence of the --no-proxy

--- a/test/autests/gold_tests/arguments/format_argument/unique_by_host.yaml
+++ b/test/autests/gold_tests/arguments/format_argument/unique_by_host.yaml
@@ -32,7 +32,7 @@ sessions:
       headers:
         fields:
         - [ Host, host.one ]
-        - [ X-Request, first, equal ]
+        - [ X-Request, { value: first, as: equal } ]
     server-response:
       status: 200
       reason: OK
@@ -52,7 +52,7 @@ sessions:
         fields:
         - [ Content-Type, text/html ]
         - [ Content-Length, 0 ]
-        - [ X-Response, first, equal ]
+        - [ X-Response, { value: first, as: equal } ]
 
   - all:
       headers:
@@ -76,7 +76,7 @@ sessions:
       headers:
         fields:
         - [ Host, host.two ]
-        - [ X-Request, second, equal ]
+        - [ X-Request, { value: second, as: equal } ]
     server-response:
       status: 200
       reason: OK
@@ -96,7 +96,7 @@ sessions:
         fields:
         - [ Content-Type, text/html ]
         - [ Content-Length, 0 ]
-        - [ X-Response, two, equal ]
+        - [ X-Response, { value: two, as: equal } ]
 
   - all:
       headers:
@@ -120,7 +120,7 @@ sessions:
       headers:
         fields:
         - [ Host, host.three ]
-        - [ X-Request, third, equal ]
+        - [ X-Request, { value: third, as: equal } ]
     server-response:
       status: 200
       reason: OK
@@ -140,5 +140,4 @@ sessions:
         fields:
         - [ Content-Type, text/html ]
         - [ Content-Length, 0 ]
-        - [ X-Response, three, equal ]
-
+        - [ X-Response, { value: three, as: equal } ]

--- a/test/autests/gold_tests/arguments/keys_argument/five_transactions.yaml
+++ b/test/autests/gold_tests/arguments/keys_argument/five_transactions.yaml
@@ -2,8 +2,7 @@ meta:
   version: "1.0"
 
 sessions:
-- protocol: [ { name: tcp }, {name: ip, version: 4} ]
-  transactions:
+- transactions:
   - client-request:
       version: "1.1"
       scheme: "http"
@@ -13,26 +12,8 @@ sessions:
         fields:
         - [ Host, example.one ]
         - [ uuid, 1 ]
-    proxy-request:
-      version: "1.1"
-      scheme: "http"
-      method: "GET"
-      url: "http://example.one/path/1"
-      headers:
-        fields:
-        - [ Host, example.one ]
-        - [ uuid, 1 ]
+
     server-response:
-      status: 200
-      reason: OK
-      content:
-        size: 16
-      headers:
-        fields:
-        - [ Content-Type, text/html ]
-        - [ Content-Length, 16 ]
-        - [ uuid, 1 ]
-    proxy-response:
       status: 200
       reason: OK
       content:
@@ -52,26 +33,8 @@ sessions:
         fields:
         - [ Host, example.one ]
         - [ uuid, 2 ]
-    proxy-request:
-      version: "1.1"
-      scheme: "http"
-      method: "GET"
-      url: "http://example.one/path/2"
-      headers:
-        fields:
-        - [ Host, example.one ]
-        - [ uuid, 2 ]
+
     server-response:
-      status: 200
-      reason: OK
-      content:
-        size: 32
-      headers:
-        fields:
-        - [ Content-Type, text/html ]
-        - [ Content-Length, 32 ]
-        - [ uuid, 2 ]
-    proxy-response:
       status: 200
       reason: OK
       content:
@@ -91,26 +54,8 @@ sessions:
         fields:
         - [ Host, example.one ]
         - [ uuid, 3 ]
-    proxy-request:
-      version: "1.1"
-      scheme: "http"
-      method: "GET"
-      url: "http://example.one/path/3"
-      headers:
-        fields:
-        - [ Host, example.one ]
-        - [ uuid, 3 ]
+
     server-response:
-      status: 200
-      reason: OK
-      content:
-        size: 32
-      headers:
-        fields:
-        - [ Content-Type, text/html ]
-        - [ Content-Length, 32 ]
-        - [ uuid, 3 ]
-    proxy-response:
       status: 200
       reason: OK
       content:
@@ -130,26 +75,8 @@ sessions:
         fields:
         - [ Host, example.one ]
         - [ uuid, 4 ]
-    proxy-request:
-      version: "1.1"
-      scheme: "http"
-      method: "GET"
-      url: "http://example.one/path/4"
-      headers:
-        fields:
-        - [ Host, example.one ]
-        - [ uuid, 4 ]
+
     server-response:
-      status: 200
-      reason: OK
-      content:
-        size: 32
-      headers:
-        fields:
-        - [ Content-Type, text/html ]
-        - [ Content-Length, 32 ]
-        - [ uuid, 4 ]
-    proxy-response:
       status: 200
       reason: OK
       content:
@@ -169,26 +96,8 @@ sessions:
         fields:
         - [ Host, example.one ]
         - [ uuid, 5 ]
-    proxy-request:
-      version: "1.1"
-      scheme: "http"
-      method: "GET"
-      url: "http://example.one/path/5"
-      headers:
-        fields:
-        - [ Host, example.one ]
-        - [ uuid, 5 ]
+
     server-response:
-      status: 200
-      reason: OK
-      content:
-        size: 32
-      headers:
-        fields:
-        - [ Content-Type, text/html ]
-        - [ Content-Length, 32 ]
-        - [ uuid, 5 ]
-    proxy-response:
       status: 200
       reason: OK
       content:

--- a/test/autests/gold_tests/arguments/repeat_argument/replay_files/two_files/five_transactions.yaml
+++ b/test/autests/gold_tests/arguments/repeat_argument/replay_files/two_files/five_transactions.yaml
@@ -2,12 +2,12 @@ meta:
   version: "1.0"
 
 sessions:
-- protocol: [ { name: tcp }, {name: ip, version: 4} ]
-  transactions:
+- transactions:
   - all:
       headers:
         fields:
         - [ uuid, 1 ]
+
     client-request:
       version: "1.1"
       scheme: "http"
@@ -17,8 +17,6 @@ sessions:
         fields:
         - [ Host, example.one ]
 
-    proxy-request:
-
     server-response:
       status: 200
       reason: OK
@@ -29,12 +27,12 @@ sessions:
         - [ Content-Type, text/html ]
         - [ Content-Length, 16 ]
 
-    proxy-response:
 
   - all:
       headers:
         fields:
         - [ uuid, 2 ]
+
     client-request:
       version: "1.1"
       scheme: "http"
@@ -44,8 +42,6 @@ sessions:
         fields:
         - [ Host, example.one ]
 
-    proxy-request:
-
     server-response:
       status: 200
       reason: OK
@@ -56,12 +52,11 @@ sessions:
         - [ Content-Type, text/html ]
         - [ Content-Length, 16 ]
 
-    proxy-response:
-
   - all:
       headers:
         fields:
         - [ uuid, 3 ]
+
     client-request:
       version: "1.1"
       scheme: "http"
@@ -71,8 +66,6 @@ sessions:
         fields:
         - [ Host, example.one ]
 
-    proxy-request:
-
     server-response:
       status: 200
       reason: OK
@@ -83,12 +76,11 @@ sessions:
         - [ Content-Type, text/html ]
         - [ Content-Length, 16 ]
 
-    proxy-response:
-
   - all:
       headers:
         fields:
         - [ uuid, 4 ]
+
     client-request:
       version: "1.1"
       scheme: "http"
@@ -98,8 +90,6 @@ sessions:
         fields:
         - [ Host, example.one ]
 
-    proxy-request:
-
     server-response:
       status: 200
       reason: OK
@@ -110,14 +100,12 @@ sessions:
         - [ Content-Type, text/html ]
         - [ Content-Length, 16 ]
 
-    proxy-response:
-
-- protocol: [ { name: tcp }, {name: ip, version: 4} ]
-  transactions:
+- transactions:
   - all:
       headers:
         fields:
         - [ uuid, 5 ]
+
     client-request:
       version: "1.1"
       scheme: "http"
@@ -127,8 +115,6 @@ sessions:
         fields:
         - [ Host, example.one ]
 
-    proxy-request:
-
     server-response:
       status: 200
       reason: OK
@@ -138,6 +124,3 @@ sessions:
         fields:
         - [ Content-Type, text/html ]
         - [ Content-Length, 16 ]
-
-    proxy-response:
-

--- a/test/autests/gold_tests/arguments/repeat_argument/replay_files/two_files/three_transactions.yaml
+++ b/test/autests/gold_tests/arguments/repeat_argument/replay_files/two_files/three_transactions.yaml
@@ -2,8 +2,7 @@ meta:
   version: "1.0"
 
 sessions:
-- protocol: [ { name: tcp }, {name: ip, version: 4} ]
-  transactions:
+- transactions:
   - all:
       headers:
         fields:
@@ -17,8 +16,6 @@ sessions:
         fields:
         - [ Host, example.one ]
 
-    proxy-request:
-
     server-response:
       status: 200
       reason: OK
@@ -29,11 +26,8 @@ sessions:
         - [ Content-Type, text/html ]
         - [ Content-Length, 16 ]
 
-    proxy-response:
 
-
-- protocol: [ { name: tcp }, {name: ip, version: 4} ]
-  transactions:
+- transactions:
   - all:
       headers:
         fields:
@@ -47,8 +41,6 @@ sessions:
         fields:
         - [ Host, example.one ]
 
-    proxy-request:
-
     server-response:
       status: 200
       reason: OK
@@ -59,10 +51,7 @@ sessions:
         - [ Content-Type, text/html ]
         - [ Content-Length, 16 ]
 
-    proxy-response:
-
-- protocol: [ { name: tcp }, {name: ip, version: 4} ]
-  transactions:
+- transactions:
   - all:
       headers:
         fields:
@@ -76,8 +65,6 @@ sessions:
         fields:
         - [ Host, example.one ]
 
-    proxy-request:
-
     server-response:
       status: 200
       reason: OK
@@ -87,5 +74,3 @@ sessions:
         fields:
         - [ Content-Type, text/html ]
         - [ Content-Length, 16 ]
-
-    proxy-response:

--- a/test/autests/gold_tests/body/body.yaml
+++ b/test/autests/gold_tests/body/body.yaml
@@ -15,7 +15,6 @@ sessions:
 
     client-request:
       version: '1.1'
-      scheme: https
       method: POST
       url: https://example.data.com/a/path
       content:
@@ -30,7 +29,6 @@ sessions:
 
     proxy-request:
       version: '1.1'
-      scheme: ''
       method: POST
       url: "/a/path"
       content:
@@ -38,8 +36,8 @@ sessions:
         size: 48
       headers:
         fields:
-        - [ Transfer-Encoding, chunked, equal ]
-        - [ X-Request, "first_request", equal ]
+        - [ Transfer-Encoding, { value: chunked, as: equal } ]
+        - [ X-Request, { value: "first_request", as: equal } ]
 
     server-response:
       status: 200
@@ -66,10 +64,8 @@ sessions:
       headers:
         encoding: esc_json
         fields:
-        - [ Content-Type, multipart/form-data;snoopy=123456 ]
-        - [ Transfer-Encoding, chunked, equal ]
-        - [ Connection, keep-alive ]
-        - [ X-Response, "first_response", equal ]
+        - [ Transfer-Encoding, { value: chunked, as: equal } ]
+        - [ X-Response, { value: "first_response", as: equal } ]
 
   - all:
       headers:
@@ -78,7 +74,6 @@ sessions:
 
     client-request:
       version: '1.1'
-      scheme: https
       method: POST
       url: https://example.data.com/a/path
       content:
@@ -93,7 +88,6 @@ sessions:
 
     proxy-request:
       version: '1.1'
-      scheme: ''
       method: POST
       url: "/a/path"
       content:
@@ -101,7 +95,7 @@ sessions:
         size: 16
       headers:
         fields:
-        - [ X-Request, "second_request", equal ]
+        - [ X-Request, { value: "second_request", as: equal } ]
 
     server-response:
       status: 200
@@ -126,10 +120,7 @@ sessions:
       headers:
         encoding: esc_json
         fields:
-        - [ Content-Type, multipart/form-data;snoopy=123456 ]
-        - [ Transfer-Encoding, chunked ]
-        - [ Connection, keep-alive ]
-        - [ X-Response, "second_response", equal ]
+        - [ X-Response, { value: "second_response", as: equal } ]
 
   #
   # Verify we can handle a zero-length chunk.
@@ -141,7 +132,6 @@ sessions:
 
     client-request:
       version: '1.1'
-      scheme: https
       method: POST
       url: https://example.data.com/a/path
       content:
@@ -156,7 +146,6 @@ sessions:
 
     proxy-request:
       version: '1.1'
-      scheme: ''
       method: POST
       url: "/a/path"
       content:
@@ -164,8 +153,8 @@ sessions:
         size: 0
       headers:
         fields:
-        - [ X-Request, "second_request", equal ]
-        - [ Transfer-Encoding, chunked, equal ]
+        - [ X-Request, { value: "second_request", as: equal } ]
+        - [ Transfer-Encoding, { value: chunked, as: equal } ]
 
     server-response:
       status: 200
@@ -179,7 +168,7 @@ sessions:
         - [ Content-Type, multipart/form-data;snoopy=123456 ]
         - [ Connection, keep-alive ]
         - [ Transfer-Encoding, chunked ]
-        - [ X-Response, "second_response", equal ]
+        - [ X-Response, "second_response" ]
 
     proxy-response:
       status: 200
@@ -190,7 +179,5 @@ sessions:
       headers:
         encoding: esc_json
         fields:
-        - [ Content-Type, multipart/form-data;snoopy=123456 ]
-        - [ Transfer-Encoding, chunked, equal ]
-        - [ Connection, keep-alive ]
-        - [ X-Response, "second_response", equal ]
+        - [ Transfer-Encoding, { value: chunked, as: equal } ]
+        - [ X-Response, { value: "second_response", as: equal } ]

--- a/test/autests/gold_tests/doctest/sample_replay.yaml
+++ b/test/autests/gold_tests/doctest/sample_replay.yaml
@@ -33,11 +33,11 @@ sessions:
     #
     proxy-request:
       url:
-      - [ path, flower.jpeg, contains ]
+      - [ path, { value: flower.jpeg, as: contains } ]
 
       headers:
         fields:
-        - [ Content-Length, '399', present ]
+        - [ Content-Length, { value: '399', as: present } ]
 
     #
     # Direct the Proxy Verifier server to reply with a 200 OK response with a body
@@ -63,7 +63,7 @@ sessions:
       status: 200
       headers:
         fields:
-        - [ Transfer-Encoding, chunked, equal ]
+        - [ Transfer-Encoding, { value: chunked, as: equal } ]
 
 #
 # For the second session, we use a protocol node to configure HTTP/2 using an
@@ -104,15 +104,15 @@ sessions:
     #
     proxy-request:
       url:
-      - [ path, flower.jpeg, contains ]
+      - [ path, { value: flower.jpeg, as: contains } ]
 
       headers:
         fields:
         - [ :method, POST ]
         - [ :scheme, https ]
         - [ :authority, www.example.com ]
-        - [ :path, flower.jpeg, contains ]
-        - [ Content-Type, application/octet-stream, equal ]
+        - [ :path,        { value: flower.jpeg,              as: contains } ]
+        - [ Content-Type, { value: application/octet-stream, as: equal } ]
 
     #
     # Direct the Proxy Verifier server to reply with a 200 OK response with a body
@@ -133,4 +133,3 @@ sessions:
     #
     proxy-response:
       status: 200
-

--- a/test/autests/gold_tests/field_parsing/replay_files/duplicate_fields.yaml
+++ b/test/autests/gold_tests/field_parsing/replay_files/duplicate_fields.yaml
@@ -2,8 +2,7 @@ meta:
   version: "1.0"
 
 sessions:
-- protocol: [ { name: tcp }, {name: ip, version: 4} ]
-  transactions:
+- transactions:
   - client-request:
       version: "1.1"
       scheme: "http"
@@ -40,7 +39,7 @@ sessions:
         - [ x-test-response, first ]
         - [ x-test-response, second ]
         - [ x-test-response, third ]
-        - [ x-response-sequence, [ first, second, third ] ]
+        - [ x-response-sequence, { value: [ first, second, third ] } ]
         - [ uuid, 1 ]
     proxy-response:
       status: 200

--- a/test/autests/gold_tests/field_parsing/replay_files/empty_field.yaml
+++ b/test/autests/gold_tests/field_parsing/replay_files/empty_field.yaml
@@ -2,8 +2,7 @@ meta:
   version: "1.0"
 
 sessions:
-- protocol: [ { name: tcp }, {name: ip, version: 4} ]
-  transactions:
+- transactions:
   - client-request:
       version: "1.1"
       scheme: "http"

--- a/test/autests/gold_tests/field_parsing/replay_files/empty_proxy.yaml
+++ b/test/autests/gold_tests/field_parsing/replay_files/empty_proxy.yaml
@@ -2,8 +2,7 @@ meta:
   version: "1.0"
 
 sessions:
-- protocol: [ { name: tcp }, {name: ip, version: 4} ]
-  transactions:
+- transactions:
   - all: { headers: { fields: [[ uuid, 1 ]]}}
     client-request:
       version: "1.1"

--- a/test/autests/gold_tests/field_parsing/replay_files/transaction_fields.yaml
+++ b/test/autests/gold_tests/field_parsing/replay_files/transaction_fields.yaml
@@ -2,8 +2,7 @@ meta:
   version: "1.0"
 
 sessions:
-- protocol: [ { name: tcp }, {name: ip, version: 4} ]
-  transactions:
+- transactions:
   - all:
       headers:
         fields:

--- a/test/autests/gold_tests/field_parsing/replay_files/yaml_specified.yaml
+++ b/test/autests/gold_tests/field_parsing/replay_files/yaml_specified.yaml
@@ -44,8 +44,8 @@ sessions:
         fields:
         - [ Content-Type, text/html ]
         - [ Content-Length, 16 ]
-        - [ X-Test-Header, backAtYou, present ]
-        - [ X-Test-Different, something, absent ]
+        - [ X-Test-Header, { value: backAtYou, as: present } ]
+        - [ X-Test-Different, { value: something, as: absent } ]
         - [ uuid, 1 ]
 
   - client-request:
@@ -66,8 +66,8 @@ sessions:
       headers:
         fields:
         - [ Host, example.one ]
-        - [ X-Another-Header, "request", present ]
-        - [ X-Not-Present, "request2", present ]
+        - [ X-Another-Header, { value: "request", as: present } ]
+        - [ X-Not-Present, { value: "request2", as: present } ]
         - [ uuid, 2 ]
     server-response:
       status: 200
@@ -89,5 +89,5 @@ sessions:
         fields:
         - [ Content-Type, text/html ]
         - [ Content-Length, 32 ]
-        - [ X-Another-Response, "response", absent ]
+        - [ X-Another-Response, { value: "response", as: absent } ]
         - [ uuid, 2 ]

--- a/test/autests/gold_tests/field_verification/replay_files/cookie_equal.yaml
+++ b/test/autests/gold_tests/field_verification/replay_files/cookie_equal.yaml
@@ -2,8 +2,7 @@ meta:
   version: "1.0"
 
 sessions:
-- protocol: [ { name: tcp }, {name: ip, version: 4} ]
-  transactions:
+- transactions:
 
   - client-request:
       version: "1.1"
@@ -25,9 +24,9 @@ sessions:
       headers:
         fields:
         - [ Host, example.one ]
-        - [ X-Test-Request, rEQUESTdATA, equal ]
-        - [ X-Test-Present, "It's there", absent ]
-        - [ Cookie, "V1=d=AQABBOwAKl4CEHhhMYGPgqPDtrDE-lZJ1EEFEgEBAQFSK14zXgAAAAAA_SMAAAcIfkkiXn6kwz8&S=AQAAAvbDdNlyRU0neZmPg97sQC8; A3=d=AQABBOwAKl4CEHhhMYGPgqPDtrDE-lZJ1EEFEgEBAQFSK14zXgAAAAAA_SMAAAcIfkkiXn6kwz8&S=AQAAAvbDdNlyRU0neZmPg97sQC8; GUC=AQEBAQFeK1JeM0If1wSb; A1S=d=AQABBOwAKl4CEHhhMYGPgqPDtrDE-lZJ1EEFEgEBAQFSK14zXgAAAAAA_SMAAAcIfkkiXn6kwz8&S=AQAAAvbDdNlyRU0neZmPg97sQC8; uvts=24ce92ce-6bef-4940-5676-ccce503e26f6; APID=UP53275975-3e1e-11ea-b6a9-0e860b33a8b3; cmp=t=1579898053&j=0; apeaf=userintent%3D%257B%2522tooltipViews%2522%253A3%257D; APIDTS=1579898054; B=3vgt4fpf24ibu&b=3&s=o9", equal ]
+        - [ X-Test-Request, { value: rEQUESTdATA, as: equal } ]
+        - [ X-Test-Present, { value: "It's there", as: absent } ]
+        - [ Cookie, { value: "V1=d=AQABBOwAKl4CEHhhMYGPgqPDtrDE-lZJ1EEFEgEBAQFSK14zXgAAAAAA_SMAAAcIfkkiXn6kwz8&S=AQAAAvbDdNlyRU0neZmPg97sQC8; A3=d=AQABBOwAKl4CEHhhMYGPgqPDtrDE-lZJ1EEFEgEBAQFSK14zXgAAAAAA_SMAAAcIfkkiXn6kwz8&S=AQAAAvbDdNlyRU0neZmPg97sQC8; GUC=AQEBAQFeK1JeM0If1wSb; A1S=d=AQABBOwAKl4CEHhhMYGPgqPDtrDE-lZJ1EEFEgEBAQFSK14zXgAAAAAA_SMAAAcIfkkiXn6kwz8&S=AQAAAvbDdNlyRU0neZmPg97sQC8; uvts=24ce92ce-6bef-4940-5676-ccce503e26f6; APID=UP53275975-3e1e-11ea-b6a9-0e860b33a8b3; cmp=t=1579898053&j=0; apeaf=userintent%3D%257B%2522tooltipViews%2522%253A3%257D; APIDTS=1579898054; B=3vgt4fpf24ibu&b=3&s=o9", as: equal } ]
         - [ uuid, 5 ]
     server-response:
       status: 200
@@ -38,7 +37,7 @@ sessions:
         fields:
         - [ Content-Type, text/html ]
         - [ Content-Length, 16 ]
-        - [ Set-Cookie, ABCD, equal ]
+        - [ Set-Cookie, { value: ABCD, as: equal } ]
         - [ uuid, 5 ]
     proxy-response:
       status: 200
@@ -49,7 +48,7 @@ sessions:
         fields:
         - [ Content-Type, text/html ]
         - [ Content-Length, 16 ]
-        - [ Set-Cookie, ABCD, equal ]
-        - [ X-Not-A-Header, Whatever, absent ]
-        - [ X-Does-Not-Exist, NotHere, present ]
+        - [ Set-Cookie, { value: ABCD, as: equal } ]
+        - [ X-Not-A-Header, { value: Whatever, as: absent } ]
+        - [ X-Does-Not-Exist, { value: NotHere, as: present } ]
         - [ uuid, 5 ]

--- a/test/autests/gold_tests/field_verification/replay_files/duplicate_fields.yaml
+++ b/test/autests/gold_tests/field_verification/replay_files/duplicate_fields.yaml
@@ -29,9 +29,10 @@ sessions:
       headers:
         fields:
         - [ Host, example.one ]
-        - [ X-Test-Request, [ second_data, first_data ], equal ]
-        - [ X-Test-Present, [ alsohere ], absent ]
-        - [ X-Test-Equal, [ theSe, thE, values ], equal ]
+        - [ X-Test-Request, { value: [ second_data, first_data ], as: equal } ]
+        - [ X-Test-Present, { value: [ alsohere ], as: absent } ]
+        - [ X-Test-Equal, { value: [ theSe, thE, values ], as: equal } ]
+        # Verify we support the old sequence, as opposed to map, syntax.
         - [ X-Test-Another, [ who, cares ], present ]
     server-response:
       status: 200
@@ -52,6 +53,6 @@ sessions:
         fields:
         - [ Content-Type, text/html ]
         - [ Content-Length, 16 ]
-        - [ Set-Cookie, [ ABCD ], equal ]
-        - [ X-Not-A-Header, [ not, here ], absent ]
-        - [ X-Does-Not-Exist, [ also, not, here ], present ]
+        - [ Set-Cookie, { value: [ ABCD ], as: equal } ]
+        - [ X-Not-A-Header, { value: [ not, here ], as: absent } ]
+        - [ X-Does-Not-Exist, { value: [ also, not, here ], as: present } ]

--- a/test/autests/gold_tests/field_verification/replay_files/map_specification.yaml
+++ b/test/autests/gold_tests/field_verification/replay_files/map_specification.yaml
@@ -2,19 +2,22 @@ meta:
   version: "1.0"
 
 sessions:
-- transactions:
+- protocol: [ { name: tcp }, {name: ip, version: 4} ]
+  transactions:
 
-  - client-request:
+  - all: { headers: { fields: [ [ uuid, 13 ] ] } }
+
+    client-request:
       version: "1.1"
       scheme: "http"
       method: "GET"
-      url: "http://example.one/config/settings.yaml"
+      url: "/config/settings.yaml"
       headers:
         fields:
         - [ Host, example.one ]
         - [ X-Test-Request, RequestData ]
         - [ X-Test-Present, It's there ]
-        - [ uuid, 5 ]
+        - [ uuid, 13 ]
     proxy-request:
       version: "1.1"
       scheme: "http"
@@ -28,7 +31,10 @@ sessions:
         - [ Host, { value: two, as: contains } ]
         - [ X-Test-Request, { value: equest, as: prefix } ]
         - [ X-Test-Present, { value: er, as: suffix } ]
-        - [ uuid, 5 ]
+
+        # absent and present directives should not require a value.
+        - [ X-Test-Absent, { as: absent } ]
+        - [ X-Test-Present, { as: present } ]
     server-response:
       status: 200
       reason: OK
@@ -39,7 +45,6 @@ sessions:
         - [ Content-Type, text/html ]
         - [ Content-Length, 16 ]
         - [ Set-Cookie, ABCD ]
-        - [ uuid, 5 ]
     proxy-response:
       status: 200
       reason: OK
@@ -47,11 +52,10 @@ sessions:
         size: 16
       headers:
         fields:
-        - [ Content-Type, text/html ]
-        - [ Content-Length, 16 ]
+        # No directive, no verification.
+        - [ Content-Length, {value: who_cares_not_verified } ]
         - [ Content-Type, { value: html, as: contains } ]
         - [ Set-Cookie, { value: ABCDE, as: contains } ]
         - [ X-Not-A-Header, { value: Whatever, as: prefix } ]
         - [ X-Does-Not-Exist, { value: NotHere, as: contains } ]
-        - [ X-Does-Not-Exist, { value: NotHere, as: suffix } ]
-        - [ uuid, 5 ]
+        - [ X-Does-Not-Exist, {value: NotHere, as: suffix } ]

--- a/test/autests/gold_tests/field_verification/replay_files/substr_rules_duplicate.yaml
+++ b/test/autests/gold_tests/field_verification/replay_files/substr_rules_duplicate.yaml
@@ -2,8 +2,7 @@ meta:
   version: "1.0"
 
 sessions:
-- protocol: [ { name: tcp }, {name: ip, version: 4} ]
-  transactions:
+- transactions:
   - all:
       headers:
         fields:
@@ -27,12 +26,12 @@ sessions:
       headers:
         fields:
         - [ Host, example.one ]
-        - [ Pref-Cookie, [ AB, EF ], prefix ]
-        - [ Suff-Cookie, [ AB, EF ], suffix ]
-        - [ Set-Cookie, [ G, F ], contains ]
-        - [ Set-Cookie, [ AB, G ], suffix ]
-        - [ Set-Cookie, [ AB, E ], contains ]
-        - [ Set-Cookie, [ A, EFG ], prefix ]
+        - [ Pref-Cookie, { value: [ AB, EF ], as: prefix } ]
+        - [ Suff-Cookie, { value: [ AB, EF ], as: suffix } ]
+        - [ Set-Cookie, { value: [ G, F ], as: contains } ]
+        - [ Set-Cookie, { value: [ AB, G ], as: suffix } ]
+        - [ Set-Cookie, { value: [ AB, E ], as: contains } ]
+        - [ Set-Cookie, { value: [ A, EFG ], as: prefix } ]
     server-response:
       status: 200
       reason: OK
@@ -52,6 +51,6 @@ sessions:
         fields:
         - [ Content-Type, text/html ]
         - [ Content-Length, 16 ]
-        - [ Set-Cookie, [ AB ], contains ]
-        - [ Set-Cookie, [ BC, EF ], prefix ]
-        - [ Set-Cookie, [ ABCD, EFG ], suffix ]
+        - [ Set-Cookie, { value: [ AB ], as: contains } ]
+        - [ Set-Cookie, { value: [ BC, EF ], as: prefix } ]
+        - [ Set-Cookie, { value: [ ABCD, EFG ], as: suffix } ]

--- a/test/autests/gold_tests/field_verification/substr_rules.test.py
+++ b/test/autests/gold_tests/field_verification/substr_rules.test.py
@@ -113,3 +113,67 @@ client.Streams.stdout += Testers.ContainsExpression(
 
 client.ReturnCode = 1
 server.ReturnCode = 1
+
+#
+# Test 3: Verify field verification using the map specification syntax.
+#
+r = Test.AddTestRun("Verify field verification works with the map specification syntax")
+client = r.AddClientProcess("client3", "replay_files/map_specification.yaml", other_args="--verbose diag")
+server = r.AddServerProcess("server3", "replay_files/map_specification.yaml", other_args="--verbose diag")
+proxy = r.AddProxyProcess("proxy3", listen_port=client.Variables.http_port, server_port=server.Variables.http_port)
+
+server.Streams.stdout += Testers.ContainsExpression(
+        'Contains Success: Key: "13", Field Name: "host", Required Value: "le.on", Value: "example.one"',
+        'Validation should be happy that "le.on" is in "example.one".')
+
+server.Streams.stdout += Testers.ContainsExpression(
+        'Prefix Success: Key: "13", Field Name: "x-test-request", Required Value: "Req", Value: "RequestData"',
+        'Validation should be happy that "RequestData" began with "Req".')
+
+server.Streams.stdout += Testers.ContainsExpression(
+        'Suffix Success: Key: "13", Field Name: "x-test-present", Required Value: "there", Value: "It\'s there"',
+        'Validation should be happy that "It\'s there" ended with "there.')
+
+server.Streams.stdout += Testers.ContainsExpression(
+        'Contains Violation: Not Found. Key: "13", Field Name: "host", Required Value: "two", Actual Value: "example.one"',
+        'Validation should complain that "two" is not in "example.one".')
+
+server.Streams.stdout += Testers.ContainsExpression(
+        'Prefix Violation: Not Found. Key: "13", Field Name: "x-test-request", Required Value: "equest", Actual Value: "RequestData"',
+        'Validation should complain that "RequestData" did not begin with "equest".')
+
+server.Streams.stdout += Testers.ContainsExpression(
+        'Suffix Violation: Not Found. Key: "13", Field Name: "x-test-present", Required Value: "er", Actual Value: "It\'s there"',
+        'Validation should complain that "It\'s there" did not end with "er".')
+
+server.Streams.stdout += Testers.ContainsExpression(
+        'Absence Success: Key: "13", Field Name: "x-test-absent"',
+        'Validation should be happy that "X-Test-Absent" is not there.')
+
+server.Streams.stdout += Testers.ContainsExpression(
+        'Presence Success: Key: "13", Field Name: "x-test-present", Value: "It\'s there"',
+        'Validation should be happy that "X-Test-Present" is there.')
+
+client.Streams.stdout += Testers.ContainsExpression(
+        'Contains Success: Key: "13", Field Name: "content-type", Required Value: "html", Value: "text/html"',
+        'Validation should be happy that "html" is in "text/html".')
+
+client.Streams.stdout += Testers.ContainsExpression(
+        'Contains Violation: Not Found. Key: "13", Field Name: "set-cookie", Required Value: "ABCDE", Actual Value: "ABCD"',
+        'Validation should complain that "ABCDE" is not in "ABCD".')
+
+client.Streams.stdout += Testers.ContainsExpression(
+        'Prefix Violation: Absent. Key: "13", Field Name: "x-not-a-header", Required Value: "Whatever"',
+        'Validation should complain that "X-Not-A-Header" is missing.')
+
+client.Streams.stdout += Testers.ContainsExpression(
+        'Contains Violation: Absent. Key: "13", Field Name: "x-does-not-exist", Required Value: "NotHere"',
+        'Validation should complain that "X-Does-Not-Exist" is missing.')
+
+client.Streams.stdout += Testers.ContainsExpression(
+        'Suffix Violation: Absent. Key: "13", Field Name: "x-does-not-exist", Required Value: "NotHere"',
+        'Validation should complain that "X-Does-Not-Exist" is missing.')
+
+client.ReturnCode = 1
+server.ReturnCode = 1
+

--- a/test/autests/gold_tests/http/replay_files/single_transaction.yaml
+++ b/test/autests/gold_tests/http/replay_files/single_transaction.yaml
@@ -1,5 +1,7 @@
 meta:
   version: '1.0'
+
+# This file is taken largely from a sample Traffic Dump file.
 sessions:
 - connection-time: 1552705896896003926
   protocol: [ { name: tcp }, {name: ip, version: 4} ]

--- a/test/autests/gold_tests/http2/replay_files/http2_to_http1.yaml
+++ b/test/autests/gold_tests/http2/replay_files/http2_to_http1.yaml
@@ -10,9 +10,9 @@ sessions:
         - [ uuid, 1 ]
 
     client-request:
-      content:
-        encoding: plain
-        size: 0
+      method: GET
+      url: https://example.data.com/a/path
+      version: '1.1'
       headers:
         encoding: esc_json
         fields:
@@ -20,47 +20,17 @@ sessions:
         - [ Accept-Language, en-us ]
         - [ Accept-Encoding, gzip ]
         - [ Host, example.data.com ]
-      method: GET
-      scheme: https
-      url: https://example.data.com/a/path
-      version: '1.1'
+      content:
+        encoding: plain
+        size: 0
+
     proxy-request:
       # HTTP/1 on the server-side.
       protocol: [ {name: tls, version: 1.2, sni: test_sni}, { name: tcp }, {name: ip, version: 4} ]
-      content:
-        encoding: plain
-        size: 0
-      headers:
-        encoding: esc_json
-        fields:
-        - [ Accept, '*/*' ]
-        - [ Accept-Language, en-us ]
-        - [ Accept-Encoding, gzip ]
-        - [ Host, example.data.com ]
-      method: GET
-      scheme: ''
-      url: /a/path
-      version: '1.1'
-    proxy-response:
-      content:
-        encoding: plain
-        size: 16
-      headers:
-        encoding: esc_json
-        fields:
-        - [ Cache-Control, private ]
-        - [ Content-Encoding, gzip ]
-        - [ Content-Type, application/json;charset=utf-8 ]
-        - [ Content-Length, '16' ]
-        - [ Date, "Sat, 16 Mar 2019 01:13:21 GMT" ]
-        - [ Age, '0' ]
-        - [ Connection, keep-alive ]
-      reason: OK
-      status: 200
+
     server-response:
-      content:
-        encoding: plain
-        size: 16
+      status: 200
+      reason: OK
       headers:
         encoding: esc_json
         fields:
@@ -71,5 +41,6 @@ sessions:
         - [ Date, "Sat, 16 Mar 2019 01:13:21 GMT" ]
         - [ Age, '0' ]
         - [ Connection, keep-alive ]
-      reason: OK
-      status: 200
+      content:
+        encoding: plain
+        size: 16

--- a/test/autests/gold_tests/http2/replay_files/http2_to_http2.yaml
+++ b/test/autests/gold_tests/http2/replay_files/http2_to_http2.yaml
@@ -59,32 +59,29 @@ sessions:
 
       # URL verification is supported for HTTP/2, with the appropriate fields
       # from :scheme, :authority, and :path used.
-      - [ scheme, https, equal ]
-      - [ host, example.data.com, equal ]
-      - [ path, /a/path, equal ]
-      - [ authority, example.data.com, equal ]
-      - [ net-loc, example.data.com, equal ]
-      - [ query, q=3, present ]
-      - [ query, 3, contains ]
-      - [ fragment, F, absent ]
-      - [ host, example, present ]
-      - [ path, /, prefix ]
-      - [ port, 8, absent ]
+      - [ scheme, { value: https, as: equal } ]
+      - [ host, { value: example.data.com, as: equal } ]
+      - [ path, { value: /a/path, as: equal } ]
+      - [ authority, { value: example.data.com, as: equal } ]
+      - [ net-loc, { value: example.data.com, as: equal } ]
+      - [ query, { value: q=3, as: present } ]
+      - [ query, { value: 3, as: contains } ]
+      - [ fragment, { as: absent } ]
+      - [ host, { as: present } ]
+      - [ path, { value: /, as: prefix } ]
+      - [ port, { as: absent } ]
       headers:
         encoding: esc_json
         fields:
-        - [ :method, GET, equal ]
-        - [ :scheme, https, equal ]
-        - [ :authority, example.data.com, equal ]
-        - [ :path, '/a/path?q=3', equal ]
-        - [ Accept, '*/*' ]
-        - [ Accept-Language, en-us ]
-        - [ Accept-Encoding, gzip ]
+        - [ :method, { value: GET, as: equal } ]
+        - [ :scheme, { value: https, as: equal } ]
+        - [ :authority, { value: example.data.com, as: equal } ]
+        - [ :path, { value: '/a/path?q=3', as: equal } ]
         # Note that the Host field is still sent.
-        - [ Host, example.data.com, equal ]
-        - [ Content-Length, "0", equal ]
-        - [ x-test-duplicate-combined, [ first, second ], equal ]
-        - [ x-test-duplicate-separate, [ first, second ], equal ]
+        - [ Host, { value: example.data.com, as: equal } ]
+        - [ Content-Length, { value: "0", as: equal } ]
+        - [ x-test-duplicate-combined, { value: [ first, second ], as: equal } ]
+        - [ x-test-duplicate-separate, { value: [ first, second ], as: equal } ]
       content:
         encoding: plain
         size: 0
@@ -114,15 +111,11 @@ sessions:
       headers:
         encoding: esc_json
         fields:
-        - [ :status, 200, equal ]
+        - [ :status, { value: 200, as: equal } ]
         - [ Cache-Control, private ]
-        - [ Content-Encoding, gzip ]
-        - [ Content-Type, application/json;charset=utf-8 ]
-        - [ Content-Length, '16', equal ]
-        - [ Date, "Sat, 16 Mar 2019 01:13:21 GMT" ]
-        - [ Age, '0' ]
-        - [ x-test-duplicate-combined, [ one, two ], equal ]
-        - [ x-test-duplicate-separate, [ one, two ], equal ]
+        - [ Content-Length, { value: '16', as: equal } ]
+        - [ x-test-duplicate-combined, { value: [ one, two ], as: equal } ]
+        - [ x-test-duplicate-separate, { value: [ one, two ], as: equal } ]
 
   #
   # Do these without a content-length to make sure we handle that correctly.
@@ -292,25 +285,16 @@ sessions:
         size: 0
 
     proxy-request:
-      # HTTP/2 on the server-side.
-      protocol:
-      - name: http
-        version: 2
-      - name: tls
-        version: 1.2
-        sni: test_sni
-      - name: tcp
-      - name: ip
-        version: 4
+      # The session protocol node should be assumed on the server side.
 
       headers:
         encoding: esc_json
         fields:
-        - [ :method, GET, equal ]
-        - [ :scheme, https, equal ]
-        - [ :authority, example.data.com, equal ]
-        - [ :path, /b/path, equal ]
-        - [ X-Request-Header, test_request, equal ]
+        - [ :method, { value: GET, as: equal } ]
+        - [ :scheme, { value: https, as: equal } ]
+        - [ :authority, { value: example.data.com, as: equal } ]
+        - [ :path, { value: /b/path, as: equal } ]
+        - [ X-Request-Header, { value: test_request, as: equal } ]
       content:
         encoding: plain
         size: 0
@@ -330,9 +314,9 @@ sessions:
       headers:
         encoding: esc_json
         fields:
-        - [ :status, 200, equal ]
-        - [ X-Response-Header, response, equal ]
-        - [ Content-Length, 0, equal ]
+        - [ :status, { value: 200, as: equal } ]
+        - [ X-Response-Header, { value: response, as: equal } ]
+        - [ Content-Length, { value: 0, as: equal } ]
       content:
         encoding: plain
         size: 0

--- a/test/autests/gold_tests/http2/replay_files/http2_to_http2_verification_failures.yaml
+++ b/test/autests/gold_tests/http2/replay_files/http2_to_http2_verification_failures.yaml
@@ -25,19 +25,11 @@ sessions:
         size: 0
 
     proxy-request:
-      # HTTP/2 on the server-side.
-      protocol: [ {name: http, version: 2}, {name: tls, version: 1.2, sni: test_sni}, { name: tcp }, {name: ip, version: 4} ]
-
-      method: GET
-      scheme: ''
-      url: /a/path
-      version: '1.1'
       headers:
         encoding: esc_json
         fields:
-        - [ Host, example.data.com ]
-        - [ x-deleted-header, request, present ]
-        - [ x-added-header, 4, equal ]
+        - [ x-deleted-header, { as: present } ]
+        - [ x-added-header, { value: 4, as: equal } ]
       content:
         encoding: plain
         size: 0
@@ -56,12 +48,8 @@ sessions:
 
     proxy-response:
       status: 200
-      content:
-        encoding: plain
-        size: 16
       headers:
         encoding: esc_json
         fields:
-        - [ Content-Length, '16' ]
-        - [ x-deleted-header, doesnotmatter, present ]
-        - [ x-added-header, lmno, contains ]
+        - [ x-deleted-header, { as: present } ]
+        - [ x-added-header, { value: lmno, as: contains } ]

--- a/test/autests/gold_tests/http2/replay_files/set_alpn.yaml
+++ b/test/autests/gold_tests/http2/replay_files/set_alpn.yaml
@@ -51,15 +51,11 @@ sessions:
       - name: ip
         version: 4
 
-      method: GET
-      scheme: ''
-      url: /a/path
-      version: '2'
       headers:
         encoding: esc_json
         fields:
-        - [ Host, example.data.com, equal ]
-        - [ Content-Length, "0", equal ]
+        - [ Host, { value: example.data.com, as: equal } ]
+        - [ Content-Length, { value: "0", as: equal } ]
       content:
         encoding: plain
         size: 0
@@ -76,13 +72,10 @@ sessions:
 
     proxy-response:
       status: 200
-      content:
-        encoding: plain
-        size: 16
       headers:
         encoding: esc_json
         fields:
-        - [ X-Response-Header, response, equal ]
+        - [ X-Response-Header, { value: response, as: equal } ]
 
   #
   # Remove h2 from the server's ALPN protocol list.
@@ -133,15 +126,11 @@ sessions:
       - name: ip
         version: 4
 
-      method: GET
-      scheme: ''
-      url: /b/path
-      version: '2'
       headers:
         encoding: esc_json
         fields:
-        - [ Host, example.data.com, equal ]
-        - [ Content-Length, "0", equal ]
+        - [ Host, { value: example.data.com, as: equal } ]
+        - [ Content-Length, { value: "0", as: equal } ]
       content:
         encoding: plain
         size: 0
@@ -158,10 +147,7 @@ sessions:
 
     proxy-response:
       status: 200
-      content:
-        encoding: plain
-        size: 16
       headers:
         encoding: esc_json
         fields:
-        - [ X-Response-Header, response2, equal ]
+          - [ X-Response-Header, { value: response2, as: equal } ]

--- a/test/autests/gold_tests/https/replay_files/mtls.yaml
+++ b/test/autests/gold_tests/https/replay_files/mtls.yaml
@@ -13,15 +13,10 @@ sessions:
       headers:
         fields:
         - [ Host, example.one ]
+
     proxy-request:
       protocol: [ {name: tls, version: 1.2, sni: bob, proxy-provided-certificate: true}, { name: tcp }, {name: ip, version: 4} ]
-      version: "1.1"
-      scheme: "https"
-      method: "GET"
-      url: "https://example.one/config/settings.yaml"
-      headers:
-        fields:
-        - [ Host, example.one ]
+
     server-response:
       status: 200
       reason: OK
@@ -31,13 +26,6 @@ sessions:
         fields:
         - [ Content-Type, text/html ]
         - [ Content-Length, 16 ]
+
     proxy-response:
       status: 200
-      reason: OK
-      content:
-        size: 16
-      headers:
-        fields:
-        - [ Content-Type, text/html ]
-        - [ Content-Length, 16 ]
-

--- a/test/autests/gold_tests/ipv6/gold/single_transaction_client.gold
+++ b/test/autests/gold_tests/ipv6/gold/single_transaction_client.gold
@@ -1,5 +1,6 @@
 ``
 ``Sent the following HTTP/1 GET request:
+- "content-length": "0"
 - "host": "example.one"
 - "x-test-request": "request"
 - "uuid": "1"

--- a/test/autests/gold_tests/ipv6/gold/single_transaction_server.gold
+++ b/test/autests/gold_tests/ipv6/gold/single_transaction_server.gold
@@ -10,6 +10,7 @@
 
 ``Request with key 1 passed validation.
 ``Received an HTTP/1 request with key 1:
+- "content-length": "0"
 - "host": "example.one"
 - "x-test-request": "request"
 - "uuid": "1"

--- a/test/autests/gold_tests/ipv6/ipv6.test.py
+++ b/test/autests/gold_tests/ipv6/ipv6.test.py
@@ -22,6 +22,9 @@ client = r.AddClientProcess("client1", "replay_files/single_transaction.yaml",
                             use_ipv6=True, http_ports=[server.Variables.http_port],
                             other_args="--no-proxy --verbose diag")
 
+# Note that this test involves no proxy and, instead, the client talks directly
+# to the server.
+
 client.Streams.stdout = "gold/single_transaction_client.gold"
 server.Streams.stdout = "gold/single_transaction_server.gold"
 

--- a/test/autests/gold_tests/ipv6/replay_files/single_transaction.yaml
+++ b/test/autests/gold_tests/ipv6/replay_files/single_transaction.yaml
@@ -2,7 +2,7 @@ meta:
   version: "1.0"
 
 sessions:
-- protocol: [ { name: tcp }, {name: ip, version: 4} ]
+- protocol: [ { name: tcp }, {name: ip, version: 6} ]
   transactions:
   - client-request:
       version: "1.1"
@@ -13,7 +13,9 @@ sessions:
         fields:
         - [ Host, example.one ]
         - [ X-Test-Request, request ]
+        - [ Content-Length, 0 ]
         - [ uuid, 1 ]
+
     proxy-request:
       version: "1.1"
       scheme: "http"
@@ -21,9 +23,11 @@ sessions:
       url: "http://example.one/config/settings.yaml"
       headers:
         fields:
-        - [ Host, example.one ]
-        - [ X-Test-Request, request ]
+        - [ Content-Length, 0 ]
+        - [ Host, { value: example.one, as: equal } ]
+        - [ X-Test-Request, { value: request, as: equal } ]
         - [ uuid, 1 ]
+
     server-response:
       status: 200
       reason: OK
@@ -35,6 +39,7 @@ sessions:
         - [ Content-Length, 16 ]
         - [ X-Test-Response, response ]
         - [ uuid, 1 ]
+
     proxy-response:
       status: 200
       reason: OK
@@ -42,7 +47,4 @@ sessions:
         size: 16
       headers:
         fields:
-        - [ Content-Type, text/html ]
-        - [ Content-Length, 16 ]
-        - [ X-Test-Response, response ]
-        - [ uuid, 1 ]
+        - [ X-Test-Response, { value: response, as: equal } ]

--- a/test/autests/gold_tests/url_verification/url_verification.yaml
+++ b/test/autests/gold_tests/url_verification/url_verification.yaml
@@ -7,7 +7,6 @@ sessions:
 
   - client-request:
       version: "1.1"
-      scheme: "http"
       method: "GET"
       url: "http://example.one:8080/config/settings.yaml?q=3"
       headers:
@@ -18,27 +17,23 @@ sessions:
         - [ X-Proxy-Directive, "SetURL=%<http://example.one:8080/config/settings.yaml?q=3%>" ]
     proxy-request:
       version: "1.1"
-      scheme: "http"
       method: "GET"
       url:
-      - [ host, example.one, equal ]
-      - [ path, config/settings.yaml, equal ]
-      - [ scheme, http, equal ]
-      - [ authority, example.one:8080, equal ]
-      - [ net-loc, example.one:8080, equal ]
-      - [ port, 8, contains ]
-      - [ query, q=3, present ]
-      - [ fragment, F, absent ]
-      - [ host, example.one, present ]
-      - [ path, yaml, contains ]
-      - [ scheme, p, suffix ]
-      - [ port, 8, prefix ]
-      - [ authority, 8080, equal ]
-      - [ fragment, F, equal ]
-      headers:
-        fields:
-        - [ Host, example.one ]
-        - [ uuid, 5 ]
+      - [ host, { value: example.one, as: equal } ]
+      - [ path, { value: config/settings.yaml, as: equal } ]
+      - [ scheme, { value: http, as: equal } ]
+      - [ authority, { value: example.one:8080, as: equal } ]
+      - [ net-loc, { value: example.one:8080, as: equal } ]
+      - [ port, { value: 8, as: contains } ]
+      - [ query, { value: q=3, as: present } ]
+      - [ fragment, { value: F, as: absent } ]
+      - [ host, { value: example.one, as: present } ]
+      - [ path, { value: yaml, as: contains } ]
+      - [ scheme, { value: p, as: suffix } ]
+      - [ port, { value: 8, as: prefix } ]
+      - [ authority, { value: 8080, as: equal } ]
+      - [ fragment, { value: F, as: equal } ]
+
     server-response:
       status: 200
       reason: OK
@@ -48,7 +43,7 @@ sessions:
         fields:
         - [ Content-Type, text/html ]
         - [ Content-Length, 16 ]
-        - [ Set-Cookie, ABCD, equal ]
+        - [ Set-Cookie, ABCD ]
         - [ uuid, 5 ]
     proxy-response:
       status: 200
@@ -57,6 +52,4 @@ sessions:
         size: 16
       headers:
         fields:
-        - [ Content-Type, text/html ]
-        - [ Content-Length, 16 ]
-        - [ Set-Cookie, ABCD, equal ]
+        - [ Set-Cookie, { value: ABCD, as: equal } ]


### PR DESCRIPTION
For example:

    url:
    - [ host, { value: example.one, as: equal } ]
    - [ path, { value: config/settings.yaml, as: equal } ]

Fixes #82 

### Confirmation Message
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
