### PR TITLE
Make the response's key set in (hopefully) all instances.

### DIFF
--- a/local/src/client/verifier-client.cc
+++ b/local/src/client/verifier-client.cc
@@ -326,15 +326,18 @@ ClientReplayFileHandler::server_response(YAML::Node const &node)
 swoc::Errata
 ClientReplayFileHandler::apply_to_all_messages(HttpFields const &all_headers)
 {
-  _txn._req._fields_rules->merge(all_headers);
-  _txn._rsp._fields_rules->merge(all_headers);
+  _txn._req.merge(all_headers);
+  _txn._rsp.merge(all_headers);
   return {};
 }
 
 swoc::Errata
 ClientReplayFileHandler::txn_close()
 {
-  const auto &key{_txn._req.make_key()};
+  const auto &key{_txn._req.get_key()};
+  // The user need not specify the key in the server-response node. For logging
+  // purposes, make sure _txn._rsp is aware of the key.
+  _txn._rsp.set_key(key);
   if (Keys_Whitelist.empty() || Keys_Whitelist.count(key) > 0) {
     _ssn->_transactions.emplace_back(std::move(_txn));
   }


### PR DESCRIPTION
The transaction key is only required in the client-request, but logging
would sometimes show "*N/A*" if the server-response didn't have it. This
addresses that. I no longer see any "*N/A*" in any of the tests.

Fixes #86 

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
