### PR TITLE
Fail parsing if transactions without keys are found.

### DIFF
--- a/local/src/server/verifier-server.cc
+++ b/local/src/server/verifier-server.cc
@@ -220,8 +220,8 @@ private:
   swoc::Errata handle_tls_node_directives(YAML::Node const &tls_node, std::string_view sni);
 
 private:
-  YAML::Node const *_ssn_node;
-  YAML::Node const *_txn_node;
+  YAML::Node const *_ssn_node = nullptr;
+  YAML::Node const *_txn_node = nullptr;
   /** The key for this transaction.
    *
    * This can be derived in a variety of ways:
@@ -439,7 +439,8 @@ ServerReplayFileHandler::txn_close()
   swoc::Errata errata;
   if (_key.empty()) {
     errata.error(
-        R"(Could not find a key for transaction at "{}":{}.)",
+        R"(Could not find a key of format "{}" for transaction at "{}":{}.)",
+        HttpHeader::_key_format,
         _path,
         _txn_node->Mark().line);
   } else {
@@ -453,7 +454,7 @@ ServerReplayFileHandler::txn_close()
   }
   this->reset();
   LoadMutex.unlock();
-  return {};
+  return errata;
 }
 
 void

--- a/test/autests/gold_tests/arguments/format_argument/format_argument.test.py
+++ b/test/autests/gold_tests/arguments/format_argument/format_argument.test.py
@@ -127,3 +127,33 @@ server.Streams.stdout += Testers.ContainsExpression(
 server.Streams.stdout += Testers.ContainsExpression(
         'Key: "host.one//same/path"',
         "The key should be parsed from the host/url, not the uuid.")
+
+#
+# Test 4: Verify that the client detects when a key is not present in a
+# transaction.
+#
+r = Test.AddTestRun('Verify that the client detects a non-existent key')
+client = r.AddClientProcess("client4", "no_uuid.yaml",
+                            other_args="--verbose diag")
+
+# The client will give a non-zero return code because it found a transaction
+# without a key.
+client.ReturnCode = 1
+client.Streams.stdout += Testers.ContainsExpression(
+        'Could not find a key of format "{field.uuid}" for transaction',
+        "There should be a parsing warning that a key was not found for a transaction.")
+
+#
+# Test 5: Verify that the server detects when a key is not present in a
+# transaction.
+#
+r = Test.AddTestRun('Verify that the server detects a non-existent key')
+server = r.AddDefaultServerProcess("server5", "no_uuid.yaml",
+                                   other_args="--verbose diag")
+
+# The server will give a non-zero return code because it found a transaction
+# without a key.
+server.ReturnCode = 1
+server.Streams.stdout += Testers.ContainsExpression(
+        'Could not find a key of format "{field.uuid}" for transaction',
+        "There should be a parsing warning that a key was not found for a transaction.")

--- a/test/autests/gold_tests/arguments/format_argument/no_uuid.yaml
+++ b/test/autests/gold_tests/arguments/format_argument/no_uuid.yaml
@@ -1,0 +1,23 @@
+meta:
+  version: "1.0"
+
+sessions:
+- transactions:
+  - client-request:
+      version: "1.1"
+      method: "GET"
+      url: "/v1/video/search/channel/delain"
+      headers:
+        fields:
+        # Intentionally exclude a uuid field value, the default key.
+        - [ Host, base.ex ]
+
+    server-response:
+      status: 200
+      reason: OK
+      content:
+        size: 96
+      headers:
+        fields:
+        - [ Content-Type, html/plaintext ]
+        - [ Content-Length, 96 ]

--- a/test/autests/gold_tests/autest-site/server.test.ext
+++ b/test/autests/gold_tests/autest-site/server.test.ext
@@ -161,6 +161,17 @@ def MakeServerProcess(test, name, replay_dir, find_ports=True, use_ipv6=False,
     return server
 
 
+def AddDefaultServerProcess(run, name, replay_dir, find_ports=True, use_ipv6=False,
+                            http_ports=None, https_ports=None,
+                            ssl_cert='', ca_certs='', other_args=''):
+
+    server = run.Processes.Default
+    _configure_server(run, server, name, replay_dir, find_ports, use_ipv6,
+                      http_ports, https_ports, ssl_cert,
+                      ca_certs, other_args)
+    return server
+
+
 def AddServerProcess(run, name, replay_dir, find_ports=True, use_ipv6=False,
                      http_ports=None, https_ports=None,
                      ssl_cert='', ca_certs='', other_args=''):
@@ -189,4 +200,5 @@ def AddServerProcess(run, name, replay_dir, find_ports=True, use_ipv6=False,
 
 ##########################################################################
 ExtendTest(MakeServerProcess, name="MakeServerProcess")
+ExtendTestRun(AddDefaultServerProcess, name="AddDefaultServerProcess")
 ExtendTestRun(AddServerProcess, name="AddServerProcess")


### PR DESCRIPTION
This would have saved @SolidWallOfCode some hassle if Proxy Verifier more explicitly failed parsing when transactions without keys are found.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
