### PR TITLE
Deal with the case when multiple H2 requests some in at once

### DIFF
--- a/local/src/core/ProxyVerifier.cc
+++ b/local/src/core/ProxyVerifier.cc
@@ -1212,7 +1212,7 @@ H2Session::read_and_parse_request(swoc::FixedBufferWriter &buffer)
   }
   auto stream_map_iter = _stream_map.find(stream_id);
   if (stream_map_iter == _stream_map.end()) {
-    zret.error("Requested request headers, but none are available.");
+    zret.error("Requested request headers, but none are available. stream id: {}", stream_id);
     return zret;
   }
   auto &stream_state = stream_map_iter->second;
@@ -2373,7 +2373,7 @@ on_data_chunk_recv_cb(
     void *user_data)
 {
   swoc::Errata errata;
-  errata.diag("on_data_chunk_recv_cb {} bytes", len);
+  errata.diag("on_data_chunk_recv_cb {} bytes, stream id: {}", len, stream_id);
   auto *session_data = reinterpret_cast<H2Session *>(user_data);
   auto iter = session_data->_stream_map.find(stream_id);
   if (iter == session_data->_stream_map.end()) {

--- a/local/src/server/verifier-server.cc
+++ b/local/src/server/verifier-server.cc
@@ -492,7 +492,8 @@ TF_Serve_Connection(std::thread *t)
       thread_errata.note(poll_errata);
       if (poll_return == 0) {
         // Poll timed out. Loop back around.
-        continue;
+        continue; 
+        // Continue to see if anything got added to the ready queue
       } else if (!poll_errata.is_ok()) {
         thread_errata.error("Poll failed: {}", swoc::bwf::Errno{});
         break;


### PR DESCRIPTION
Without this change, rapid requests could all get processed at once, but only one request is processed per poll event, so the later requests would be stuck forever.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
