### PR TITLE
HTTP/2 stream handling fixes.

### DIFF
--- a/test/autests/gold_tests/http2/gold/http2_to_http2_proxy.gold
+++ b/test/autests/gold_tests/http2/gold/http2_to_http2_proxy.gold
@@ -44,6 +44,9 @@ x-request-header: request
 uuid: 2
 X-Added-Header: 1
 
+==== REQUEST BODY ====
+b'0000000 00'
+
 ==== RESPONSE ====
 500 
 
@@ -55,7 +58,7 @@ uuid: 2
 x-added-header: 1
 
 ==== RESPONSE BODY ====
-b''
+b'0000000 0000001 0000002 0000003 '
 
 ==== REQUEST HEADERS ====
 :method: GET

--- a/test/autests/gold_tests/http2/gold/http2_to_http2_server.gold
+++ b/test/autests/gold_tests/http2/gold/http2_to_http2_server.gold
@@ -41,6 +41,7 @@
 - "uuid": "2"
 - "x-added-header": "1"
 
+``Drained HTTP/2 body for transaction with key: 2, stream id: 3 of 10 bytes with content: 0000000 00
 ``Equals Success: Key: "2", Field Name: ":authority", Value: "example.data.com"
 ``Equals Success: Key: "2", Field Name: ":method", Value: "POST"
 ``Equals Success: Key: "2", Field Name: ":scheme", Value: "https"


### PR DESCRIPTION
This address some issues shinrich found in prod testing. The biggest
changes are:

1. HTTP/2 now correctly sends body data if there is no Content-Length
header.

2. The mechanism by which HTTP/2 streams are handled is chanced such
that entire streams are handled at once rather than trying to separate
the read of headers vs body. The latter doesn't work if you get headers
for stream id 1, headers for stream id 3, then body for stream id 1, for
instance.

3. This also fixes poll_for_headers for HTTP/2 so that if requests are
read on a previous call, this will not block indefinitely.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
