### PR TITLE
Fixing memory leak of TLSSession::server_context 

### DIFF
--- a/local/include/core/ProxyVerifier.h
+++ b/local/include/core/ProxyVerifier.h
@@ -1635,7 +1635,7 @@ public:
 
   // static members
   static swoc::Errata init();
-  static swoc::Errata init(SSL_CTX *&server_context, SSL_CTX *&client_context);
+  static void terminate();
 
   /** Register the TLS handshake verification mode of the server per the SNI.
    *
@@ -1721,6 +1721,10 @@ public:
   static swoc::file::path ca_certificate_dir;
 
 protected:
+  static swoc::Errata client_init(SSL_CTX *&client_context);
+  static swoc::Errata server_init(SSL_CTX *&server_context);
+  static void terminate(SSL_CTX *&context);
+
   /** A helper file to configure a host certificate.
    *
    * @param[in] cert_path The path to a directory with private and public key
@@ -1860,8 +1864,8 @@ public:
 
   swoc::Errata accept() override;
   swoc::Errata connect() override;
-  static swoc::Errata init(SSL_CTX *&server_context, SSL_CTX *&client_context);
   static swoc::Errata init(int *process_exit_code);
+  static void terminate();
   swoc::Errata client_session_init();
   swoc::Errata server_session_init();
   swoc::Errata send_connection_settings();
@@ -1904,6 +1908,11 @@ public:
 public:
   /// A mapping from stream_id to H2StreamState.
   std::unordered_map<int32_t, std::shared_ptr<H2StreamState>> _stream_map;
+
+protected:
+  static swoc::Errata client_init(SSL_CTX *&client_context);
+  static swoc::Errata server_init(SSL_CTX *&server_context);
+  static void terminate(SSL_CTX *&client_context);
 
 private:
   /** Populate an nghttp2 vector from the information in an HttpHeader instance.

--- a/local/src/client/verifier-client.cc
+++ b/local/src/client/verifier-client.cc
@@ -718,6 +718,9 @@ Engine::command_run()
       n_txn / static_cast<double>(n_ssn),
       replay_duration.count(),
       n_txn / static_cast<double>(replay_duration.count()));
+
+  TLSSession::terminate();
+  H2Session::terminate();
 };
 
 int

--- a/local/src/server/verifier-server.cc
+++ b/local/src/server/verifier-server.cc
@@ -829,7 +829,8 @@ Engine::command_run()
           }
         }
         if (errata.is_ok()) {
-          errata = H2Session::init(&process_exit_code);
+          errata.note(TLSSession::init());
+          errata.note(H2Session::init(&process_exit_code));
         }
       } else {
         errata.error(
@@ -839,13 +840,13 @@ Engine::command_run()
       }
     }
 
-    errata = Load_Replay_Directory(
+    errata.note(Load_Replay_Directory(
         swoc::file::path{args[0]},
         [](swoc::file::path const &file) -> swoc::Errata {
           ServerReplayFileHandler handler;
           return Load_Replay_File(file, handler);
         },
-        10);
+        10));
 
     if (!errata.is_ok()) {
       process_exit_code = 1;
@@ -900,6 +901,8 @@ Engine::command_run()
   Accept_Threads.clear();
   Server_Thread_Pool.join_threads();
 
+  TLSSession::terminate();
+  H2Session::terminate();
   exit(Engine::process_exit_code);
 }
 


### PR DESCRIPTION
Fixing a memory leak found with ASan. The call to H2Session::init called
TLSSession::init with server_context after TLSSession::init already
called it for the same server_context. (Both TLSSession and H2Session
share the same server_context because they need not be different between
the two.) This caused server_context to be initialized twice with
SSL_CTX_new, with the first one being immediately overwritten by the
second, thus causing the first to be leaked.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
