### PR TITLE
Refactor: create YamlParser and Localizer classes.

### DIFF
--- a/local/include/core/Localizer.h
+++ b/local/include/core/Localizer.h
@@ -1,0 +1,65 @@
+/** @file
+ * Declaration of Localizer, the string localization class.
+ *
+ * Copyright 2021, Verizon Media
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "case_insensitive_utils.h"
+
+#include <unordered_set>
+
+#include "swoc/MemArena.h"
+#include "swoc/TextView.h"
+#include "swoc/bwf_base.h"
+
+/** A class to handle localizing memory for strings.
+ *
+ * During the YAML processing stage, transactions are deserialized with their
+ * strings referenced as TextViews. Common strings, such as common field names,
+ * are referenced as such to save space so their memory does not exist in
+ * duplicate across all transactions. The storage of this space in a single
+ * location is called, in this context, localizing it. This class's functions
+ * encapsulate this logic.
+ */
+class Localizer
+{
+public:
+  /** Indicate that no more localization should be performed.
+   *
+   * All localization should be completed during the YAML parsing stage. If
+   * localization happens elsewhere, then there is a logic flaw. This sets
+   * state saying that localization is completed such that if localization is
+   * requested elsewhere, assertions will be triggered.
+   */
+  static void freeze_localization();
+
+  static swoc::TextView localize(char const *text);
+  static swoc::TextView localize_lower(char const *text);
+
+  static swoc::TextView localize(swoc::TextView text);
+  static swoc::TextView localize_lower(swoc::TextView text);
+
+  /// Encoding for input text.
+  enum class Encoding {
+    TEXT, ///< Plain text, no encoding.
+    URI   //< URI encoded.
+  };
+
+  static swoc::TextView localize(swoc::TextView text, Encoding enc);
+
+private:
+  /** A convenience boolean for the corresponding parameter to localize_helper.
+   */
+  static constexpr bool SHOULD_LOWER = true;
+
+  static swoc::TextView localize_helper(swoc::TextView text, bool should_lower);
+
+private:
+  using NameSet = std::unordered_set<swoc::TextView, Hash, Hash>;
+  static NameSet _names;
+  static swoc::MemArena _arena;
+  static bool _frozen;
+};

--- a/local/include/core/YamlParser.h
+++ b/local/include/core/YamlParser.h
@@ -1,0 +1,321 @@
+/** @file
+ * Declaration of YamlParser, the YAML file parsing class.
+ *
+ * Copyright 2021, Verizon Media
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <string>
+#include <unordered_set>
+
+#include "yaml-cpp/yaml.h"
+
+#include "swoc/BufferWriter.h"
+#include "swoc/Errata.h"
+#include "swoc/MemArena.h"
+#include "swoc/TextView.h"
+#include "swoc/bwf_base.h"
+#include "swoc/swoc_file.h"
+
+class HttpFields;
+class HttpHeader;
+
+// Definitions of keys in the CONFIG files.
+// These need to be @c std::string or the node look up will construct a @c
+// std::string.
+static const std::string YAML_META_KEY{"meta"};
+static const std::string YAML_GLOBALS_KEY{"global-field-rules"};
+static const std::string YAML_SSN_KEY{"sessions"};
+static const std::string YAML_TIME_START_KEY{"connection-time"};
+static const std::string YAML_SSN_PROTOCOL_KEY{"protocol"};
+static const std::string YAML_SSN_PROTOCOL_NAME{"name"};
+static const std::string YAML_SSN_PROTOCOL_VERSION{"version"};
+static const std::string YAML_SSN_PROTOCOL_TLS_NAME{"tls"};
+static const std::string YAML_SSN_PROTOCOL_HTTP_NAME{"http"};
+static const std::string YAML_SSN_TLS_SNI_KEY{"sni"};
+static const std::string YAML_SSN_TLS_ALPN_PROTOCOLS_KEY{"alpn-protocols"};
+static const std::string YAML_SSN_TLS_VERIFY_MODE_KEY{"verify-mode"};
+static const std::string YAML_SSN_TLS_REQUEST_CERTIFICATE_KEY{"request-certificate"};
+static const std::string YAML_SSN_TLS_PROXY_PROVIDED_CERTIFICATE_KEY{"proxy-provided-certificate"};
+static const std::string YAML_TXN_KEY{"transactions"};
+static const std::string YAML_CLIENT_REQ_KEY{"client-request"};
+static const std::string YAML_PROXY_REQ_KEY{"proxy-request"};
+static const std::string YAML_SERVER_RSP_KEY{"server-response"};
+static const std::string YAML_PROXY_RSP_KEY{"proxy-response"};
+static const std::string YAML_ALL_MESSAGES_KEY{"all"};
+static const std::string YAML_HDR_KEY{"headers"};
+static const std::string YAML_FIELDS_KEY{"fields"};
+static const std::string YAML_HTTP_VERSION_KEY{"version"};
+static const std::string YAML_HTTP_STATUS_KEY{"status"};
+static const std::string YAML_HTTP_REASON_KEY{"reason"};
+static const std::string YAML_HTTP_METHOD_KEY{"method"};
+static const std::string YAML_HTTP_SCHEME_KEY{"scheme"};
+static const std::string YAML_HTTP2_KEY{"http2"};
+static const std::string YAML_HTTP2_PSEUDO_METHOD_KEY{":method"};
+static const std::string YAML_HTTP2_PSEUDO_SCHEME_KEY{":scheme"};
+static const std::string YAML_HTTP2_PSEUDO_AUTHORITY_KEY{":authority"};
+static const std::string YAML_HTTP2_PSEUDO_PATH_KEY{":path"};
+static const std::string YAML_HTTP2_PSEUDO_STATUS_KEY{":status"};
+static const std::string YAML_HTTP_STREAM_ID_KEY{"stream-id"};
+static const std::string YAML_HTTP_URL_KEY{"url"};
+static const std::string YAML_CONTENT_KEY{"content"};
+static const std::string YAML_CONTENT_SIZE_KEY{"size"};
+static const std::string YAML_CONTENT_DATA_KEY{"data"};
+static const std::string YAML_CONTENT_ENCODING_KEY{"encoding"};
+static const std::string YAML_CONTENT_TRANSFER_KEY{"transfer"};
+
+static constexpr size_t YAML_RULE_KEY_INDEX{0};
+static constexpr size_t YAML_RULE_VALUE_INDEX{1};
+static constexpr size_t YAML_RULE_TYPE_INDEX{2};
+
+static const std::string YAML_RULE_VALUE_MAP_KEY{"value"};
+static const std::string YAML_RULE_TYPE_MAP_KEY{"as"};
+
+static constexpr swoc::TextView FIELD_HOST{"host"};
+
+static constexpr bool ASSUME_EQUALITY_RULE = true;
+
+// YAML support utilities.
+namespace swoc
+{
+inline BufferWriter &
+bwformat(BufferWriter &w, bwf::Spec const & /* spec */, YAML::Mark const &mark)
+{
+  return w.print("line {}", mark.line);
+}
+} // namespace swoc
+
+struct VerificationConfig
+{
+  std::shared_ptr<HttpFields> txn_rules;
+};
+
+/** Protocol class for loading a replay file.
+ * The client and server are expected subclass this an provide an
+ * implementation.
+ */
+class ReplayFileHandler
+{
+public:
+  ReplayFileHandler() = default;
+  virtual ~ReplayFileHandler() = default;
+
+  /** The rules associated with YAML_GLOBALS_KEY. */
+  VerificationConfig global_config;
+
+  virtual swoc::Errata
+  file_open(swoc::file::path const &path)
+  {
+    _path = path.string();
+    return {};
+  }
+  virtual swoc::Errata
+  file_close()
+  {
+    return {};
+  }
+  virtual swoc::Errata
+  ssn_open(YAML::Node const & /* node */)
+  {
+    return {};
+  }
+  virtual swoc::Errata
+  ssn_close()
+  {
+    return {};
+  }
+
+  /** Open the transaction node.
+   *
+   * @param node Transaction node.
+   * @return Errors, if any.
+   *
+   * This is required to do any base validation of the transaction such as
+   * verifying required keys.
+   */
+  virtual swoc::Errata
+  txn_open(YAML::Node const & /* node */)
+  {
+    return {};
+  }
+
+  virtual swoc::Errata
+  txn_close()
+  {
+    return {};
+  }
+  virtual swoc::Errata
+  client_request(YAML::Node const & /* node */)
+  {
+    return {};
+  }
+  virtual swoc::Errata
+  proxy_request(YAML::Node const & /* node */)
+  {
+    return {};
+  }
+  virtual swoc::Errata
+  server_response(YAML::Node const & /* node */)
+  {
+    return {};
+  }
+  virtual swoc::Errata
+  proxy_response(YAML::Node const & /* node */)
+  {
+    return {};
+  }
+  virtual swoc::Errata
+  apply_to_all_messages(HttpFields const & /* all_headers */)
+  {
+    return {};
+  }
+
+protected:
+  /** Parse the "protocol" node for the requested protocol.
+   *
+   * Keep in mind that the "protocol" node is the protocol stack containing a
+   * set of protocol descriptions, such as "tcp", "tls", etc.
+   *
+   * @param[in] protocol_node The "protocol" node from which to search for a
+   * specified protocol node.
+   *
+   * @para[in] protocol_name The key for the protocol node to return.
+   *
+   * @return The protocol node or a node whose type is "YAML::NodeType::Undefined"
+   * if the node did not exist in the protocol map.
+   */
+  static swoc::Rv<YAML::Node const> parse_for_protocol_node(
+      YAML::Node const &protocol_node,
+      std::string_view protocol_name);
+
+  /** Parse a "tls" node for an "sni" key and return the value.
+   *
+   * @param[in] tls_node The tls node from which to parse the SNI.
+   *
+   * @return The SNI from the "tls" node or empty string if it doesn't exist.
+   */
+  static swoc::Rv<std::string> parse_sni(YAML::Node const &tls_node);
+
+  /** Parse a "tls" node for the given verify-mode node value.
+   *
+   * @param[in] tls_node The tls node from which to parse the verify-mode.
+   *
+   * @return The value of verify-mode, or -1 if it doesn't exist.
+   */
+  static swoc::Rv<int> parse_verify_mode(YAML::Node const &tls_node);
+
+  static swoc::Rv<std::string> parse_alpn_protocols_node(YAML::Node const &tls_node);
+
+protected:
+  /** The replay file associated with this handler.
+   */
+  swoc::file::path _path;
+};
+
+/** The class responsible for parsing YAML message nodes. */
+class YamlParser
+{
+public:
+  /** Parse the YAML file executing callbacks into a handler.
+   *
+   * @param[in] path The path to the YAML file to parse.
+   *
+   * @param[in] handler Conceptually, this contains the set of callbacks to
+   *   dispatch into as the YAML file is parsed.
+   *
+   * @return Any errata from parsing the file.
+   */
+  static swoc::Errata load_replay_file(swoc::file::path const &path, ReplayFileHandler &handler);
+
+  using loader_t = std::function<swoc::Errata(swoc::file::path const &)>;
+
+  /** Parse the specified YAML file(s).
+   *
+   * @param[in] path The path to the file or directory containing YAML
+   *   files to parse. Note this may actually be a path to a single file.
+   *
+   * @param[in] loader The function to use for each file in path.
+   *
+   * @param[in] n_threads The number of threads to use to parse the files in
+   *   path.
+   *
+   * @return Any errata from parsing the file.
+   */
+  static swoc::Errata load_replay_files(
+      swoc::file::path const &path,
+      loader_t loader,
+      int n_threads = 10);
+
+  /** Populate an HTTP message from a YAML node.
+   *
+   * @param[in] node The YAML node from which to parse HTTP message information.
+   * @param[out] message The HTTP message to populate from node.
+   *
+   * @return Any errata from parsing the node.
+   */
+  static swoc::Errata populate_http_message(YAML::Node const &node, HttpHeader &message);
+
+  /** Populate a HTTP fields from a YAML node.
+   *
+   * @param[in] node The YAML node from which to parse HTTP field information.
+   * @param[out] fields The HTTP fields to populate from node.
+   *
+   * @return Any errata from parsing the node.
+   */
+  static swoc::Errata parse_global_rules(YAML::Node const &node, HttpFields &fields);
+
+private:
+  /** Indicate that parsing has started.
+   */
+  static swoc::Errata parsing_is_started();
+
+  /** Indicate that parsing is completed.
+   *
+   * This is helpful for indicating the end of the parsing phase. Functionally
+   * this means that string localization should be completed at this point.
+   */
+  static swoc::Errata parsing_is_done();
+
+  /** Process HTTP/2 pseudo headers from the message node.
+   *
+   * @param[in] node The YAML node from which to parse HTTP pseudo headers.
+   * @param[out] message The object to populate with pseudo headers.
+   *
+   * @return Any errata from parsing the node.
+   */
+  static swoc::Errata process_pseudo_headers(YAML::Node const &node, HttpHeader &message);
+
+  /** Process fields and verification rules from the fields node.
+   *
+   * @param[in] node The YAML node containing fields.
+   * @param[out] fields The object to populate with fields and rules.
+   *
+   * @return Any errata from parsing the node.
+   */
+  static swoc::Errata parse_fields_and_rules(
+      YAML::Node const &fields_rules,
+      HttpFields &fields,
+      bool assume_equality_rule);
+
+  /** Process URL information from the node
+   *
+   * @param[in] node The YAML node URL information.
+   * @param[out] fields The object to populate with URL data from node.
+   *
+   * @return Any errata from parsing the node.
+   */
+  static swoc::Errata parse_url_rules(
+      YAML::Node const &url_rules,
+      HttpFields &fields,
+      bool assume_equality_rule);
+
+private:
+  using ClockType = std::chrono::system_clock;
+  using TimePoint = std::chrono::time_point<ClockType, std::chrono::nanoseconds>;
+  static TimePoint _parsing_start_time;
+};

--- a/local/include/core/case_insensitive_utils.h
+++ b/local/include/core/case_insensitive_utils.h
@@ -1,0 +1,38 @@
+/** @file
+ * Data structures to support case-insensitive containers.
+ *
+ * Copyright 2021, Verizon Media
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <strings.h>
+
+#include "swoc/ext/HashFNV.h"
+#include "swoc/TextView.h"
+
+/** Case-insensitive hashing function. */
+struct Hash
+{
+  swoc::Hash64FNV1a::value_type
+  operator()(swoc::TextView view) const
+  {
+    return swoc::Hash64FNV1a{}.hash_immediate(swoc::transform_view_of(&tolower, view));
+  }
+  bool
+  operator()(swoc::TextView const &lhs, swoc::TextView const &rhs) const
+  {
+    return 0 == strcasecmp(lhs, rhs);
+  }
+};
+
+/** Case-insensitive comparison function. */
+struct CaseInsensitiveCompare
+{
+  bool
+  operator()(swoc::TextView const &lhs, swoc::TextView const &rhs) const
+  {
+    return strcasecmp(lhs, rhs) < 0;
+  }
+};

--- a/local/src/core/Localizer.cc
+++ b/local/src/core/Localizer.cc
@@ -1,0 +1,105 @@
+/** @file
+ * Definition of Localizer.
+ *
+ * Copyright 2021, Verizon Media
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "core/Localizer.h"
+
+#include <cassert>
+#include <dirent.h>
+#include <thread>
+#include <vector>
+
+#include "swoc/bwf_ex.h"
+#include "swoc/bwf_ip.h"
+#include "swoc/bwf_std.h"
+#include "swoc/bwf_std.h"
+
+using swoc::TextView;
+using namespace swoc::literals;
+using namespace std::literals;
+
+Localizer::NameSet Localizer::_names;
+swoc::MemArena Localizer::_arena{8000};
+bool Localizer::_frozen = false;
+
+swoc::TextView
+Localizer::localize_helper(TextView text, bool should_lower)
+{
+  assert(!_frozen);
+  auto span{_arena.alloc(text.size()).rebind<char>()};
+  if (should_lower) {
+    std::transform(text.begin(), text.end(), span.begin(), &tolower);
+  } else {
+    std::copy(text.begin(), text.end(), span.begin());
+  }
+  TextView local{span.data(), text.size()};
+  if (should_lower) {
+    _names.insert(local);
+  }
+  return local;
+}
+
+void
+Localizer::freeze_localization()
+{
+  _frozen = true;
+}
+
+swoc::TextView
+Localizer::localize(char const *text)
+{
+  return localize_helper(TextView{text, strlen(text) + 1}, !SHOULD_LOWER);
+}
+
+swoc::TextView
+Localizer::localize_lower(char const *text)
+{
+  return localize_lower(TextView{text, strlen(text) + 1});
+}
+
+swoc::TextView
+Localizer::localize(TextView text)
+{
+  return localize_helper(text, !SHOULD_LOWER);
+}
+
+swoc::TextView
+Localizer::localize_lower(TextView text)
+{
+  // _names.find() does a case insensitive lookup, so cache lookup via
+  // _names only should be used for case-insensitive localization. It's
+  // value applies to well-known, common strings such as HTTP headers.
+  auto spot = _names.find(text);
+  if (spot != _names.end()) {
+    return *spot;
+  }
+  return localize_helper(text, SHOULD_LOWER);
+}
+
+swoc::TextView
+Localizer::localize(TextView text, Encoding enc)
+{
+  assert(!_frozen);
+  if (Encoding::URI == enc) {
+    auto span{_arena.require(text.size()).remnant().rebind<char>()};
+    auto spot = text.begin(), limit = text.end();
+    char *dst = span.begin();
+    while (spot < limit) {
+      if (*spot == '%' &&
+          (spot + 1 < limit && isxdigit(spot[1]) && (spot + 2 < limit && isxdigit(spot[2]))))
+      {
+        *dst++ = swoc::svto_radix<16>(TextView{spot + 1, spot + 3});
+        spot += 3;
+      } else {
+        *dst++ = *spot++;
+      }
+    }
+    TextView text{span.data(), dst};
+    _arena.alloc(text.size());
+    return text;
+  }
+  return localize(text);
+}

--- a/local/src/core/YamlParser.cc
+++ b/local/src/core/YamlParser.cc
@@ -1,0 +1,944 @@
+/** @file
+ * Definition of YamlParser.
+ *
+ * Copyright 2021, Verizon Media
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "core/YamlParser.h"
+#include "core/ProxyVerifier.h"
+
+#include "core/Localizer.h"
+#include "core/yaml_util.h"
+
+#include <cassert>
+#include <dirent.h>
+#include <thread>
+#include <vector>
+
+#include "swoc/bwf_ex.h"
+#include "swoc/bwf_ip.h"
+#include "swoc/bwf_std.h"
+#include "swoc/bwf_std.h"
+
+using swoc::Errata;
+using swoc::TextView;
+using namespace swoc::literals;
+using namespace std::literals;
+
+using std::chrono::duration_cast;
+using std::chrono::milliseconds;
+using std::chrono::nanoseconds;
+using std::chrono::seconds;
+using ClockType = std::chrono::system_clock;
+using TimePoint = std::chrono::time_point<ClockType, nanoseconds>;
+
+TimePoint YamlParser::_parsing_start_time{};
+
+Errata
+YamlParser::populate_http_message(YAML::Node const &node, HttpHeader &message)
+{
+  Errata errata;
+
+  if (node[YAML_HTTP_VERSION_KEY]) {
+    message._http_version = Localizer::localize_lower(node[YAML_HTTP_VERSION_KEY].Scalar());
+  } else {
+    message._http_version = "1.1";
+  }
+  if (node[YAML_HTTP2_KEY]) {
+    auto http2_node{node[YAML_HTTP2_KEY]};
+    if (http2_node.IsMap()) {
+      if (http2_node[YAML_HTTP_STREAM_ID_KEY]) {
+        auto http_stream_id_node{http2_node[YAML_HTTP_STREAM_ID_KEY]};
+        if (http_stream_id_node.IsScalar()) {
+          TextView text{http_stream_id_node.Scalar()};
+          TextView parsed;
+          auto n = swoc::svtou(text, &parsed);
+          if (parsed.size() == text.size() && 0 < n) {
+            message._stream_id = n;
+          } else {
+            errata.error(
+                R"("{}" value "{}" at {} must be a positive integer.)",
+                YAML_HTTP_STREAM_ID_KEY,
+                text,
+                http_stream_id_node.Mark());
+          }
+        } else {
+          errata.error(
+              R"("{}" at {} must be a positive integer.)",
+              YAML_HTTP_STREAM_ID_KEY,
+              http_stream_id_node.Mark());
+        }
+      }
+    } else {
+      errata.error(
+          R"("{}" value at {} must be a map of HTTP/2 values.)",
+          YAML_HTTP2_KEY,
+          http2_node.Mark());
+    }
+  }
+
+  if (node[YAML_HTTP_STATUS_KEY]) {
+    message._is_response = true;
+    auto status_node{node[YAML_HTTP_STATUS_KEY]};
+    if (status_node.IsScalar()) {
+      TextView text{status_node.Scalar()};
+      TextView parsed;
+      auto n = swoc::svtou(text, &parsed);
+      if (parsed.size() == text.size() && 0 < n && n <= 599) {
+        message._status = n;
+        message._status_string = std::to_string(message._status);
+      } else {
+        errata.error(
+            R"("{}" value "{}" at {} must be an integer in the range [1..599].)",
+            YAML_HTTP_STATUS_KEY,
+            text,
+            status_node.Mark());
+      }
+    } else {
+      errata.error(
+          R"("{}" value at {} must be an integer in the range [1..599].)",
+          YAML_HTTP_STATUS_KEY,
+          status_node.Mark());
+    }
+  }
+
+  if (node[YAML_HTTP_REASON_KEY]) {
+    auto reason_node{node[YAML_HTTP_REASON_KEY]};
+    if (reason_node.IsScalar()) {
+      message._reason = Localizer::localize(reason_node.Scalar());
+    } else {
+      errata.error(
+          R"("{}" value at {} must be a string.)",
+          YAML_HTTP_REASON_KEY,
+          reason_node.Mark());
+    }
+  }
+
+  if (node[YAML_HTTP_METHOD_KEY]) {
+    auto method_node{node[YAML_HTTP_METHOD_KEY]};
+    if (method_node.IsScalar()) {
+      message._method = Localizer::localize(method_node.Scalar());
+      message._is_request = true;
+    } else {
+      errata.error(
+          R"("{}" value at {} must be a string.)",
+          YAML_HTTP_REASON_KEY,
+          method_node.Mark());
+    }
+  }
+
+  if (node[YAML_HTTP_URL_KEY]) {
+    auto url_node{node[YAML_HTTP_URL_KEY]};
+    if (url_node.IsScalar()) {
+      message._url = Localizer::localize(url_node.Scalar());
+      message.parse_url(message._url);
+    } else if (url_node.IsSequence()) {
+      errata.note(parse_url_rules(url_node, *message._fields_rules, message._verify_strictly));
+    } else {
+      errata.error(
+          R"("{}" value at {} must be a string or sequence.)",
+          YAML_HTTP_URL_KEY,
+          url_node.Mark());
+    }
+  }
+
+  if (node[YAML_HTTP_SCHEME_KEY]) {
+    auto scheme_node{node[YAML_HTTP_SCHEME_KEY]};
+    if (scheme_node.IsScalar()) {
+      message._scheme = Localizer::localize(scheme_node.Scalar());
+    } else {
+      errata.error(
+          R"("{}" value at {} must be a string.)",
+          YAML_HTTP_SCHEME_KEY,
+          scheme_node.Mark());
+    }
+  }
+
+  if (node[YAML_HDR_KEY]) {
+    auto hdr_node{node[YAML_HDR_KEY]};
+    if (hdr_node[YAML_FIELDS_KEY]) {
+      auto field_list_node{hdr_node[YAML_FIELDS_KEY]};
+      Errata result =
+          parse_fields_and_rules(field_list_node, *message._fields_rules, message._verify_strictly);
+      if (result.is_ok()) {
+        errata.note(message.update_content_length(message._method));
+        errata.note(message.update_transfer_encoding());
+      } else {
+        errata.error("Failed to parse response at {}", node.Mark());
+        errata.note(std::move(result));
+      }
+    }
+  }
+
+  errata.note(process_pseudo_headers(node, message));
+
+  if (!message._method.empty() && message._authority.empty()) {
+    // The URL didn't have the authority. Get it from the Host header if it
+    // exists.
+    auto const it = message._fields_rules->_fields.find(FIELD_HOST);
+    if (it != message._fields_rules->_fields.end()) {
+      message._authority = it->second;
+    }
+  }
+
+  // Do this after parsing fields so it can override transfer encoding.
+  if (auto content_node{node[YAML_CONTENT_KEY]}; content_node) {
+    if (content_node.IsMap()) {
+      if (auto xf_node{content_node[YAML_CONTENT_TRANSFER_KEY]}; xf_node) {
+        TextView xf{xf_node.Scalar()};
+        if (0 == strcasecmp("chunked"_tv, xf)) {
+          message._chunked_p = true;
+        } else if (0 == strcasecmp("plain"_tv, xf)) {
+          message._chunked_p = false;
+        } else {
+          errata.error(
+              R"(Invalid value "{}" for "{}" key at {} in "{}" node at {})",
+              xf,
+              YAML_CONTENT_TRANSFER_KEY,
+              xf_node.Mark(),
+              YAML_CONTENT_KEY,
+              content_node.Mark());
+        }
+      }
+      if (auto data_node{content_node[YAML_CONTENT_DATA_KEY]}; data_node) {
+        Localizer::Encoding enc{Localizer::Encoding::TEXT};
+        if (auto enc_node{content_node[YAML_CONTENT_ENCODING_KEY]}; enc_node) {
+          TextView text{enc_node.Scalar()};
+          if (0 == strcasecmp("uri"_tv, text)) {
+            enc = Localizer::Encoding::URI;
+          } else if (0 == strcasecmp("plain"_tv, text)) {
+            enc = Localizer::Encoding::TEXT;
+          } else {
+            errata.error(R"(Unknown encoding "{}" at {}.)", text, enc_node.Mark());
+          }
+        }
+        TextView content{Localizer::localize(data_node.Scalar(), enc)};
+        message._content_data = content.data();
+        const size_t content_size = content.size();
+        message._recorded_content_size = content_size;
+        if (message._content_length_p) {
+          if (message._content_size != content_size) {
+            errata.diag(
+                R"(Conflicting sizes for "Content-Length", sending header value {} instead of data value {}.)",
+                message._content_size,
+                content_size);
+          }
+        }
+      } else if (auto size_node{content_node[YAML_CONTENT_SIZE_KEY]}; size_node) {
+        const size_t content_size = swoc::svtou(size_node.Scalar());
+        message._recorded_content_size = content_size;
+        // Cross check against previously read content-length header, if any.
+        if (message._content_length_p) {
+          if (message._content_size != content_size) {
+            errata.diag(
+                R"(Conflicting sizes for "Content-Length", sending header value {} instead of rule value {}.)",
+                message._content_size,
+                content_size);
+          }
+        } else if (message._chunked_p) {
+          message._content_size = content_size;
+        } else if (message._is_http2) {
+          // HTTP/2 transactions may, and likely won't, have a Content-Length
+          // header field. And chunked encoding is not allowed in HTTP/2.
+          message._content_size = content_size;
+        }
+      } else {
+        errata.error(
+            R"("{}" node at {} does not have a "{}" or "{}" key as required.)",
+            YAML_CONTENT_KEY,
+            node.Mark(),
+            YAML_CONTENT_SIZE_KEY,
+            YAML_CONTENT_DATA_KEY);
+      }
+    } else {
+      errata.error(R"("{}" node at {} is not a map.)", YAML_CONTENT_KEY, content_node.Mark());
+    }
+  }
+
+  // After everything has been read, there should be enough information now to
+  // derive a key.
+  message.derive_key();
+
+  return errata;
+}
+
+Errata
+YamlParser::parse_global_rules(YAML::Node const &node, HttpFields &fields)
+{
+  Errata errata;
+
+  if (auto rules_node{node[YAML_FIELDS_KEY]}; rules_node) {
+    if (rules_node.IsSequence()) {
+      if (rules_node.size() > 0) {
+        auto result{parse_fields_and_rules(rules_node, fields, !ASSUME_EQUALITY_RULE)};
+        if (!result.is_ok()) {
+          errata.error("Failed to parse fields and rules at {}", node.Mark());
+          errata.note(std::move(result));
+        }
+      } else {
+        errata.info(R"(Fields and rules node at {} is an empty list.)", rules_node.Mark());
+      }
+    } else {
+      errata.info(R"(Fields and rules node at {} is not a sequence.)", rules_node.Mark());
+    }
+  } else {
+    errata.info(R"(Node at {} is missing a fields node.)", node.Mark());
+  }
+  return errata;
+}
+
+Errata
+YamlParser::parse_url_rules(
+    YAML::Node const &url_rules_node,
+    HttpFields &fields,
+    bool assume_equality_rule)
+{
+  Errata errata;
+
+  for (auto const &node : url_rules_node) {
+    if (!node.IsSequence()) {
+      errata.error("URL rule at {} is not a sequence as required.", node.Mark());
+      continue;
+    }
+    const auto node_size = node.size();
+    if (node_size != 2 && node_size != 3) {
+      errata.error(
+          "URL rule node at {} is not a sequence of length 2 "
+          "or 3 as required.",
+          node.Mark());
+      continue;
+    }
+
+    TextView part_name{Localizer::localize_lower(node[YAML_RULE_KEY_INDEX].Scalar())};
+    UrlPart part_id = HttpHeader::parse_url_part(part_name);
+    if (part_id == UrlPart::Error) {
+      errata.error("URL rule node at {} has an invalid URL part.", node.Mark());
+      continue;
+    }
+    const YAML::Node ValueNode{node[YAML_RULE_VALUE_INDEX]};
+    if (ValueNode.IsScalar()) {
+      // There's only a single value associated with this URL part.
+      TextView value{Localizer::localize(node[YAML_RULE_VALUE_INDEX].Scalar())};
+      if (node_size == 2 && assume_equality_rule) {
+        fields._url_rules[static_cast<size_t>(part_id)].push_back(
+            RuleCheck::make_equality(part_id, value));
+      } else if (node_size == 3) {
+        // Contains a verification rule.
+        TextView rule_type{node[YAML_RULE_TYPE_INDEX].Scalar()};
+        std::shared_ptr<RuleCheck> tester = RuleCheck::make_rule_check(part_id, value, rule_type);
+        if (!tester) {
+          errata.error(
+              "URL rule node at {} does not have a valid directive ({})",
+              node.Mark(),
+              rule_type);
+          continue;
+        } else {
+          fields._url_rules[static_cast<size_t>(part_id)].push_back(tester);
+        }
+      }
+      // No error reported if incorrect length
+    } else if (ValueNode.IsMap()) {
+      // Verification is specified as a map, such as:
+      // - [ path, { value: config/settings.yaml, as: equal } ]
+      TextView value;
+      if (auto const url_value_node{ValueNode[YAML_RULE_VALUE_MAP_KEY]}; url_value_node) {
+        value = Localizer::localize(url_value_node.Scalar());
+      }
+      if (!ValueNode[YAML_RULE_TYPE_MAP_KEY]) {
+        // No verification directive was specified.
+        if (assume_equality_rule) {
+          fields._url_rules[static_cast<size_t>(part_id)].push_back(
+              RuleCheck::make_equality(part_id, value));
+        }
+        continue;
+      }
+      TextView rule_type{ValueNode[YAML_RULE_TYPE_MAP_KEY].Scalar()};
+      std::shared_ptr<RuleCheck> tester = RuleCheck::make_rule_check(part_id, value, rule_type);
+      if (!tester) {
+        errata.error(
+            "URL rule node at {} does not have a valid directive ({})",
+            node.Mark(),
+            rule_type);
+        continue;
+      } else {
+        fields._url_rules[static_cast<size_t>(part_id)].push_back(tester);
+      }
+    } else if (ValueNode.IsSequence()) {
+      errata.error("URL rule node at {} has multiple values, which is not allowed.", node.Mark());
+      continue;
+    }
+  }
+  return errata;
+}
+
+Errata
+YamlParser::parse_fields_and_rules(
+    YAML::Node const &fields_rules_node,
+    HttpFields &fields,
+    bool assume_equality_rule)
+{
+  Errata errata;
+
+  for (auto const &node : fields_rules_node) {
+    if (!node.IsSequence()) {
+      errata.error("Field or rule at {} is not a sequence as required.", node.Mark());
+      continue;
+    }
+    auto const node_size = node.size();
+    if (node_size != 2 && node_size != 3) {
+      errata.error(
+          "Field or rule node at {} is not a sequence of length 2 "
+          "or 3 as required.",
+          node.Mark());
+      continue;
+    }
+
+    TextView name{Localizer::localize_lower(node[YAML_RULE_KEY_INDEX].Scalar())};
+    const YAML::Node ValueNode{node[YAML_RULE_VALUE_INDEX]};
+    if (ValueNode.IsScalar()) {
+      // There's only a single value associated with this field name.
+      TextView value{Localizer::localize(node[YAML_RULE_VALUE_INDEX].Scalar())};
+      fields.add_field(name, value);
+      if (node_size == 2 && assume_equality_rule) {
+        fields._rules.emplace(name, RuleCheck::make_equality(name, value));
+      } else if (node_size == 3) {
+        // Contains a verification rule.
+        // -[ Host, example.com, equal ]
+        TextView rule_type{node[YAML_RULE_TYPE_INDEX].Scalar()};
+        std::shared_ptr<RuleCheck> tester = RuleCheck::make_rule_check(name, value, rule_type);
+        if (!tester) {
+          errata.error(
+              "Field rule at {} does not have a valid directive ({})",
+              node.Mark(),
+              rule_type);
+          continue;
+        } else {
+          fields._rules.emplace(name, tester);
+        }
+      }
+    } else if (ValueNode.IsSequence()) {
+      // There's a list of values associated with this field. This
+      // indicates duplicate fields for the same field name.
+      std::vector<TextView> values;
+      values.reserve(ValueNode.size());
+      for (auto const &value : ValueNode) {
+        TextView localized_value{Localizer::localize(value.Scalar())};
+        values.emplace_back(localized_value);
+        fields.add_field(name, localized_value);
+      }
+      if (node_size == 2 && assume_equality_rule) {
+        fields._rules.emplace(name, RuleCheck::make_equality(name, std::move(values)));
+      } else if (node_size == 3) {
+        // Contains a verification rule.
+        // -[ set-cookie, [ first-cookie, second-cookie ], present ]
+        TextView rule_type{node[YAML_RULE_TYPE_INDEX].Scalar()};
+        std::shared_ptr<RuleCheck> tester =
+            RuleCheck::make_rule_check(name, std::move(values), rule_type);
+        if (!tester) {
+          errata.error(
+              "Field rule at {} does not have a valid directive ({})",
+              node.Mark(),
+              rule_type);
+          continue;
+        } else {
+          fields._rules.emplace(name, tester);
+        }
+      }
+    } else if (ValueNode.IsMap()) {
+      // Verification is specified as a map, such as:
+      // -[ Host, { value: example.com, as: equal } ]
+      TextView value;
+      if (auto const field_value_node{ValueNode[YAML_RULE_VALUE_MAP_KEY]}; field_value_node) {
+        if (field_value_node.IsScalar()) {
+          value = Localizer::localize(field_value_node.Scalar());
+          fields.add_field(name, value);
+        } else if (field_value_node.IsSequence()) {
+          // Verification is for duplicate fields:
+          // -[ set-cookie, { value: [ cookiea, cookieb], as: equal } ]
+          std::vector<TextView> values;
+          values.reserve(ValueNode.size());
+          for (auto const &value : field_value_node) {
+            TextView localized_value{Localizer::localize(value.Scalar())};
+            values.emplace_back(localized_value);
+            fields.add_field(name, localized_value);
+          }
+          if (auto const rule_type_node{ValueNode[YAML_RULE_TYPE_MAP_KEY]}; rule_type_node) {
+            TextView rule_type{rule_type_node.Scalar()};
+            std::shared_ptr<RuleCheck> tester =
+                RuleCheck::make_rule_check(name, std::move(values), rule_type);
+            if (!tester) {
+              errata.error(
+                  "Field rule at {} does not have a valid directive ({})",
+                  node.Mark(),
+                  rule_type);
+              continue;
+            } else {
+              fields._rules.emplace(name, tester);
+            }
+          } else {
+            // No verification directive was specified.
+            if (assume_equality_rule) {
+              fields._rules.emplace(name, RuleCheck::make_equality(name, std::move(values)));
+            }
+          }
+          continue;
+        }
+      }
+      if (auto const rule_type_node{ValueNode[YAML_RULE_TYPE_MAP_KEY]}; rule_type_node) {
+        TextView rule_type{rule_type_node.Scalar()};
+        std::shared_ptr<RuleCheck> tester = RuleCheck::make_rule_check(name, value, rule_type);
+        if (!tester) {
+          errata.error(
+              "Field rule at {} does not have a valid directive ({})",
+              node.Mark(),
+              rule_type);
+          continue;
+        } else {
+          fields._rules.emplace(name, tester);
+        }
+      } else {
+        // No verification directive was specified.
+        if (assume_equality_rule) {
+          fields._rules.emplace(name, RuleCheck::make_equality(name, value));
+        }
+        continue;
+      }
+    }
+  }
+  return errata;
+}
+
+Errata
+YamlParser::parsing_is_started()
+{
+  _parsing_start_time = ClockType::now();
+  return {};
+}
+
+Errata
+YamlParser::parsing_is_done()
+{
+  // Localization should only be done during the YAML parsing stages. Any
+  // localization done after this point (such as during the parsing of bytes
+  // off the wire) would be a logic error.
+  Localizer::freeze_localization();
+
+  Errata errata;
+  auto parsing_duration = ClockType::now() - _parsing_start_time;
+  if (parsing_duration > 10s) {
+    errata.info("Replay file parsing took: {} seconds.",
+        duration_cast<seconds>(parsing_duration).count());
+  } else {
+    errata.info("Replay file parsing took: {} milliseconds.",
+        duration_cast<milliseconds>(parsing_duration).count());
+  }
+  return errata;
+}
+
+Errata
+YamlParser::process_pseudo_headers(YAML::Node const &node, HttpHeader &message)
+{
+  Errata errata;
+  auto number_of_pseudo_headers = 0;
+  auto pseudo_it = message._fields_rules->_fields.find(YAML_HTTP2_PSEUDO_METHOD_KEY);
+  if (pseudo_it != message._fields_rules->_fields.end()) {
+    if (!message._method.empty()) {
+      errata.error(
+          "The {} node is not compatible with the {} pseudo header: {}",
+          YAML_HTTP_METHOD_KEY,
+          YAML_HTTP2_PSEUDO_METHOD_KEY,
+          node.Mark());
+    }
+    message._method = pseudo_it->second;
+    ++number_of_pseudo_headers;
+    message._is_request = true;
+  }
+  pseudo_it = message._fields_rules->_fields.find(YAML_HTTP2_PSEUDO_SCHEME_KEY);
+  if (pseudo_it != message._fields_rules->_fields.end()) {
+    if (!message._scheme.empty()) {
+      errata.error(
+          "The {} node is not compatible with the {} pseudo header: {}",
+          YAML_HTTP_SCHEME_KEY,
+          YAML_HTTP2_PSEUDO_SCHEME_KEY,
+          node.Mark());
+    }
+    message._scheme = pseudo_it->second;
+    ++number_of_pseudo_headers;
+    message._is_request = true;
+  }
+  pseudo_it = message._fields_rules->_fields.find(YAML_HTTP2_PSEUDO_AUTHORITY_KEY);
+  if (pseudo_it != message._fields_rules->_fields.end()) {
+    auto const host_it = message._fields_rules->_fields.find(FIELD_HOST);
+    if (host_it != message._fields_rules->_fields.end()) {
+      // We intentionally allow this, even though contrary to spec, to allow the use
+      // of Proxy Verifier to test proxy's handling of this.
+      errata.info(
+          "Contrary to spec, a transaction is specified with both {} and {} header fields: {}",
+          YAML_HTTP2_PSEUDO_AUTHORITY_KEY,
+          FIELD_HOST,
+          node.Mark());
+    } else if (!message._authority.empty()) {
+      errata.error(
+          "The {} node is not compatible with the {} pseudo header: {}",
+          YAML_HTTP_URL_KEY,
+          YAML_HTTP2_PSEUDO_AUTHORITY_KEY,
+          node.Mark());
+    }
+    message._authority = pseudo_it->second;
+    ++number_of_pseudo_headers;
+    message._is_request = true;
+  }
+  pseudo_it = message._fields_rules->_fields.find(YAML_HTTP2_PSEUDO_PATH_KEY);
+  if (pseudo_it != message._fields_rules->_fields.end()) {
+    if (!message._path.empty()) {
+      errata.error(
+          "The {} node is not compatible with the {} pseudo header: {}",
+          YAML_HTTP_URL_KEY,
+          YAML_HTTP2_PSEUDO_PATH_KEY,
+          node.Mark());
+    }
+    message._path = pseudo_it->second;
+    ++number_of_pseudo_headers;
+    message._is_request = true;
+  }
+  pseudo_it = message._fields_rules->_fields.find(YAML_HTTP2_PSEUDO_STATUS_KEY);
+  if (pseudo_it != message._fields_rules->_fields.end()) {
+    if (message._status != 0) {
+      errata.error(
+          "The {} node is not compatible with the {} pseudo header: {}",
+          YAML_HTTP_STATUS_KEY,
+          YAML_HTTP2_PSEUDO_STATUS_KEY,
+          node.Mark());
+    }
+    auto const &status_field_value = pseudo_it->second;
+    TextView parsed;
+    auto n = swoc::svtou(status_field_value, &parsed);
+    if (parsed.size() == status_field_value.size() && 0 < n && n <= 599) {
+      message._status = n;
+      message._status_string = std::to_string(message._status);
+    } else {
+      errata.error(
+          R"("{}" pseudo header value "{}" at {} must be an integer in the range [1..599].)",
+          YAML_HTTP2_PSEUDO_STATUS_KEY,
+          status_field_value,
+          node.Mark());
+    }
+    ++number_of_pseudo_headers;
+    message._is_response = true;
+  }
+  if (number_of_pseudo_headers > 0) {
+    // Do some sanity checking on the user's pseudo headers, if provided.
+    if (message._is_response && number_of_pseudo_headers != 1) {
+      errata.error("Found a mixture of request and response pseudo header fields: {}", node.Mark());
+    }
+    if (message._is_request && number_of_pseudo_headers != 4) {
+      errata.error(
+          "Did not find all four required pseudo header fields "
+          "(:method, :scheme, :authority, :path): {}",
+          node.Mark());
+    }
+    // Pseudo header fields currently implies HTTP/2.
+    message._http_version = "2";
+    message._contains_pseudo_headers_in_fields_array = true;
+  }
+  return errata;
+}
+
+swoc::Rv<YAML::Node const>
+ReplayFileHandler::parse_for_protocol_node(
+    YAML::Node const &protocol_node,
+    std::string_view protocol_name)
+{
+  swoc::Rv<YAML::Node const> desired_node = YAML::Node{YAML::NodeType::Undefined};
+  if (!protocol_node.IsSequence()) {
+    desired_node.error("Protocol node at {} is not a sequence as required.", protocol_node.Mark());
+    return desired_node;
+  }
+  if (protocol_node.size() == 0) {
+    desired_node.error("Protocol node at {} is an empty sequence.", protocol_node.Mark());
+    return desired_node;
+  }
+  for (auto const &protocol_element : protocol_node) {
+    if (!protocol_element.IsMap()) {
+      desired_node.error("Protocol element at {} is not a map.", protocol_element.Mark());
+      return desired_node;
+    }
+    if (protocol_element[YAML_SSN_PROTOCOL_NAME].Scalar() != protocol_name) {
+      continue;
+    }
+    return swoc::Rv<YAML::Node const>{protocol_element};
+  }
+  return desired_node;
+}
+
+swoc::Rv<std::string>
+ReplayFileHandler::parse_sni(YAML::Node const &tls_node)
+{
+  swoc::Rv<std::string> sni;
+  if (auto sni_node{tls_node[YAML_SSN_TLS_SNI_KEY]}; sni_node) {
+    if (sni_node.IsScalar()) {
+      sni.result() = sni_node.Scalar();
+    } else {
+      sni.error(
+          R"(Session has a value for key "{}" that is not a scalar as required.)",
+          YAML_SSN_TLS_SNI_KEY);
+    }
+  }
+  return sni;
+}
+
+swoc::Rv<int>
+ReplayFileHandler::parse_verify_mode(YAML::Node const &tls_node)
+{
+  swoc::Rv<int> verify_mode{-1};
+  if (auto tls_verify_mode{tls_node[YAML_SSN_TLS_VERIFY_MODE_KEY]}; tls_verify_mode) {
+    if (tls_verify_mode.IsScalar()) {
+      verify_mode = std::stoi(tls_verify_mode.Scalar());
+    } else {
+      verify_mode.error(
+          R"(Session has a value for key "{}" that is not a scalar as required.)",
+          YAML_SSN_TLS_SNI_KEY);
+    }
+  }
+  return verify_mode;
+}
+
+swoc::Rv<std::string>
+ReplayFileHandler::parse_alpn_protocols_node(YAML::Node const &tls_node)
+{
+  swoc::Rv<std::string> alpn_protocol_string;
+  if (auto alpn_protocols_node{tls_node[YAML_SSN_TLS_ALPN_PROTOCOLS_KEY]}; alpn_protocols_node) {
+    if (!alpn_protocols_node.IsSequence()) {
+      alpn_protocol_string.error(
+          R"(Session has a value for key "{}" that is not a sequence as required.)",
+          YAML_SSN_TLS_ALPN_PROTOCOLS_KEY);
+      return alpn_protocol_string;
+    }
+    for (auto const &protocol : alpn_protocols_node) {
+      std::string_view protocol_view{protocol.Scalar()};
+      alpn_protocol_string.result().append(1, (char)protocol_view.size());
+      alpn_protocol_string.result().append(protocol_view);
+    }
+  }
+  return alpn_protocol_string;
+}
+
+/** RAII for managing the handler's file. */
+struct HandlerOpener
+{
+public:
+  Errata errata;
+
+public:
+  HandlerOpener(ReplayFileHandler &handler, swoc::file::path const &path) : _handler(handler)
+  {
+    errata.note(_handler.file_open(path));
+  }
+  ~HandlerOpener()
+  {
+    errata.note(_handler.file_close());
+  }
+
+private:
+  ReplayFileHandler &_handler;
+};
+
+Errata
+YamlParser::load_replay_file(swoc::file::path const &path, ReplayFileHandler &handler)
+{
+  HandlerOpener opener(handler, path);
+  auto errata = opener.errata;
+  if (!errata.is_ok()) {
+    return errata;
+  }
+  std::error_code ec;
+  std::string content{swoc::file::load(path, ec)};
+  if (ec.value()) {
+    errata.error(R"(Error loading "{}": {})", path, ec);
+    return errata;
+  }
+  YAML::Node root;
+  auto global_fields_rules = std::make_shared<HttpFields>();
+  try {
+    root = YAML::Load(content);
+    yaml_merge(root);
+  } catch (std::exception const &ex) {
+    errata.error(R"(Exception: {} in "{}".)", ex.what(), path);
+  }
+  if (!errata.is_ok()) {
+    return errata;
+  }
+  if (root[YAML_META_KEY]) {
+    auto meta_node{root[YAML_META_KEY]};
+    if (meta_node[YAML_GLOBALS_KEY]) {
+      auto globals_node{meta_node[YAML_GLOBALS_KEY]};
+      // Path not passed to later calls than Load_Replay_File.
+      errata.note(YamlParser::parse_global_rules(globals_node, *global_fields_rules));
+    }
+  } else {
+    errata.info(R"(No meta node ("{}") at "{}":{}.)", YAML_META_KEY, path, root.Mark().line);
+  }
+  handler.global_config = VerificationConfig{global_fields_rules};
+  if (!root[YAML_SSN_KEY]) {
+    errata.error(R"(No sessions list ("{}") at "{}":{}.)", YAML_META_KEY, path, root.Mark().line);
+    return errata;
+  }
+  auto ssn_list_node{root[YAML_SSN_KEY]};
+  if (!ssn_list_node.IsSequence()) {
+    errata.error(
+        R"("{}" value at "{}":{} is not a sequence.)",
+        YAML_SSN_KEY,
+        path,
+        ssn_list_node.Mark());
+    return errata;
+  }
+  if (ssn_list_node.size() == 0) {
+    errata.diag(R"(Session list at "{}":{} is an empty list.)", path, ssn_list_node.Mark().line);
+    return errata;
+  }
+  for (auto const &ssn_node : ssn_list_node) {
+    // HeaderRules ssn_rules = global_rules;
+    auto session_errata{handler.ssn_open(ssn_node)};
+    if (!session_errata.is_ok()) {
+      errata.note(std::move(session_errata));
+      errata.error(R"(Failure opening session at "{}":{}.)", path, ssn_node.Mark().line);
+      continue;
+    }
+    if (!ssn_node[YAML_TXN_KEY]) {
+      errata.error(
+          R"(Session at "{}":{} has no "{}" key.)",
+          path,
+          ssn_node.Mark().line,
+          YAML_TXN_KEY);
+      continue;
+    }
+    auto txn_list_node{ssn_node[YAML_TXN_KEY]};
+    if (!txn_list_node.IsSequence()) {
+      session_errata.error(
+          R"(Transaction list at {} in session at {} in "{}" is not a list.)",
+          txn_list_node.Mark(),
+          ssn_node.Mark(),
+          path);
+    }
+    if (txn_list_node.size() == 0) {
+      session_errata.info(
+          R"(Transaction list at {} in session at {} in "{}" is an empty list.)",
+          txn_list_node.Mark(),
+          ssn_node.Mark(),
+          path);
+    }
+    for (auto const &txn_node : txn_list_node) {
+      // HeaderRules txn_rules = ssn_rules;
+      auto txn_errata = handler.txn_open(txn_node);
+      if (!txn_errata.is_ok()) {
+        session_errata.error(R"(Could not open transaction at {} in "{}".)", txn_node.Mark(), path);
+      }
+      HttpFields all_fields;
+      if (auto all_node{txn_node[YAML_ALL_MESSAGES_KEY]}; all_node) {
+        if (auto headers_node{all_node[YAML_HDR_KEY]}; headers_node) {
+          txn_errata.note(YamlParser::parse_global_rules(headers_node, all_fields));
+        }
+      }
+      if (auto creq_node{txn_node[YAML_CLIENT_REQ_KEY]}; creq_node) {
+        txn_errata.note(handler.client_request(creq_node));
+      }
+      if (auto preq_node{txn_node[YAML_PROXY_REQ_KEY]}; preq_node) { // global_rules appears to be
+                                                                     // being copied
+        txn_errata.note(handler.proxy_request(preq_node));
+      }
+      if (auto ursp_node{txn_node[YAML_SERVER_RSP_KEY]}; ursp_node) {
+        txn_errata.note(handler.server_response(ursp_node));
+      }
+      if (auto prsp_node{txn_node[YAML_PROXY_RSP_KEY]}; prsp_node) {
+        txn_errata.note(handler.proxy_response(prsp_node));
+      }
+      if (!all_fields._fields.empty()) {
+        txn_errata.note(handler.apply_to_all_messages(all_fields));
+      }
+      txn_errata.note(handler.txn_close());
+      if (!txn_errata.is_ok()) {
+        txn_errata.error(R"(Failure with transaction at {} in "{}".)", txn_node.Mark(), path);
+      }
+      session_errata.note(std::move(txn_errata));
+    }
+    session_errata.note(handler.ssn_close());
+    errata.note(std::move(session_errata));
+  }
+  return errata;
+}
+
+Errata
+YamlParser::load_replay_files(
+    swoc::file::path const &path,
+    loader_t loader,
+    int n_threads)
+{
+  Errata errata;
+  errata.note(parsing_is_started());
+  std::mutex local_mutex;
+  std::error_code ec;
+
+  dirent **elements = nullptr;
+
+  auto stat{swoc::file::status(path, ec)};
+  if (ec) {
+    errata.error(R"(Invalid test directory "{}": [{}])", path, ec);
+    errata.note(parsing_is_done());
+    return errata;
+  } else if (swoc::file::is_regular_file(stat)) {
+    errata.note(loader(path));
+    errata.note(parsing_is_done());
+    return errata;
+  } else if (!swoc::file::is_dir(stat)) {
+    errata.error(R"("{}" is not a file or a directory.)", path);
+    errata.note(parsing_is_done());
+    return errata;
+  }
+
+  if (0 == chdir(path.c_str())) {
+    int n_sessions = scandir(
+        ".",
+        &elements,
+        [](dirent const *entry) -> int {
+          auto extension = swoc::TextView{entry->d_name, strlen(entry->d_name)}.suffix_at('.');
+          return 0 == strcasecmp(extension, "json") || 0 == strcasecmp(extension, "yaml");
+        },
+        &alphasort);
+    if (n_sessions > 0) {
+      std::atomic<int> idx{0};
+      swoc::MemSpan<dirent *> entries{elements, static_cast<size_t>(n_sessions)};
+
+      // Lambda suitable to spawn in a thread to load files.
+      auto load_wrapper = [&]() -> void {
+        size_t k = 0;
+        while ((k = idx++) < entries.count()) {
+          auto result = loader(swoc::file::path{entries[k]->d_name});
+          std::lock_guard<std::mutex> lock(local_mutex);
+          errata.note(result);
+        }
+      };
+
+      errata.info("Loading {} replay files.", n_sessions);
+      std::vector<std::thread> threads;
+      threads.reserve(n_threads);
+      for (int tidx = 0; tidx < n_threads; ++tidx) {
+        threads.emplace_back(load_wrapper);
+      }
+      for (std::thread &thread : threads) {
+        thread.join();
+      }
+      for (int i = 0; i < n_sessions; i++) {
+        free(elements[i]);
+      }
+      free(elements);
+
+    } else {
+      errata.error(R"(No replay files found in "{}".)", path);
+    }
+  } else {
+    errata.error(R"(Failed to access directory "{}": {}.)", path, swoc::bwf::Errno{});
+  }
+  errata.note(parsing_is_done());
+  return errata;
+}

--- a/local/src/core/core.part
+++ b/local/src/core/core.part
@@ -21,5 +21,5 @@ env.SdkInclude(
 )
 
 env.SdkLib(
-    env.StaticLibrary("verifier-core",["ArgParser.cc", "ProxyVerifier.cc"])
+    env.StaticLibrary("verifier-core",["ArgParser.cc", "Localizer.cc", "YamlParser.cc", "ProxyVerifier.cc"])
 )


### PR DESCRIPTION
This separates YAML parsin and Localizer into YamlParser and Localizer,
each compiled into their own objects. This also adds YAML parsing timing
information.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
