### PR TITLE
Fix a command line processing crash for non-existent cert.

### DIFF
--- a/local/src/client/verifier-client.cc
+++ b/local/src/client/verifier-client.cc
@@ -580,7 +580,7 @@ Engine::command_run()
   if (ca_certs_arg.size() >= 1) {
     errata.note(TLSSession::configure_ca_cert(ca_certs_arg[0]));
     if (!errata.is_ok()) {
-      errata.error(R"(Invalid ca-certs path "{}")", cert_arg[0]);
+      errata.error(R"(Invalid ca-certs path "{}")", ca_certs_arg[0]);
       process_exit_code = 1;
       return;
     }

--- a/local/src/server/verifier-server.cc
+++ b/local/src/server/verifier-server.cc
@@ -824,7 +824,7 @@ Engine::command_run()
         if (ca_certs_arg.size() >= 1) {
           errata.note(TLSSession::configure_ca_cert(ca_certs_arg[0]));
           if (!errata.is_ok()) {
-            errata.error(R"(Invalid ca-certs path "{}")", cert_arg[0]);
+            errata.error(R"(Invalid ca-certs path "{}")", ca_certs_arg[0]);
             process_exit_code = 1;
             return;
           }


### PR DESCRIPTION
Fix a crash that happened when:

1. User specified a non-existent file via --ca-certs.
2. Not specify a client or server cert.

Fixes #122 

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
