### PR TITLE
Adding --enable-asan option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ gh-md-toc README.md
 Then copy and paste the output here.
 -->
 
-
 Table of Contents
 =================
 
@@ -30,6 +29,7 @@ Table of Contents
       * [Install](#install)
          * [Prerequisites](#prerequisites)
          * [Building](#building)
+            * [ASan Instrumentation](#asan-instrumentation)
          * [Running the Tests](#running-the-tests)
             * [Unit Tests](#unit-tests)
             * [Gold Tests](#gold-tests)
@@ -937,6 +937,28 @@ the root of the repository. Note:
    directs it to do a non-debug build for the various components with
    optimization enabled (e.g., with `-O2` for g++ builds). This is critical if
    replaying high volumes of traffic.
+
+#### ASan Instrumentation
+
+The local Sconstruct file is configured to take an optional `--enable-asan`
+parameter. If this is passed to the scons build line then the Proxy Verifier
+objects and binaries will be compiled and linked with the flags that instrument
+them for [AddressSanatizer](https://clang.llvm.org/docs/AddressSanitizer.html).
+This assumes that the system has the AddressSanatizer library installed on the
+system. Thus the above invocation would look like the following to compile it
+with AddressSanitizer instrumentation:
+
+```
+pipenv install
+pipenv shell
+scons \
+    -j8 \
+    --with-ssl=/path/to/openssl \
+    --with-nghttp2=/path/to/nghttp2 \
+    --cfg=release \
+    --enable-asan \
+    proxy-verifier
+```
 
 ### Running the Tests
 

--- a/Sconstruct
+++ b/Sconstruct
@@ -24,6 +24,12 @@ AddOption("--with-nghttp2",
           help='Optional path to custom build of nghttp2'
          )
 
+
+AddOption('--enable-asan',
+          dest='enable_asan',
+          action='store_true',
+          help='Configure compiling and linking for ASan.')
+
 path_ssl = GetOption("with_ssl")
 Part("#lib/openssl.part", CUSTOM_PATH=path_ssl)
 path_nghttp2 = GetOption("with_nghttp2")

--- a/local/src/client/verifier-client.part
+++ b/local/src/client/verifier-client.part
@@ -9,10 +9,19 @@ env.DependsOn([
     Component("proxy-verifier.core"),
 ])
 
-env.AppendUnique(
-    CCFLAGS=['-std=c++17', '-g', '-Wall', '-Wextra', '-Werror'],
-    LIBS=['pthread'],
-)
+cflags = ['-std=c++17', '-g', '-Wall', '-Wextra', '-Werror']
+if env.GetOption('enable_asan'):
+    cflags += ['-fsanitize=address', '-fno-omit-frame-pointer']
+    env.AppendUnique(
+        CCFLAGS=cflags,
+        LIBS=['pthread'],
+        LINKFLAGS=['-fsanitize=address', '-static-libasan'],
+    )
+else:
+    env.AppendUnique(
+        CCFLAGS=cflags,
+        LIBS=['pthread'],
+    )
 
 env.InstallBin(
     env.SetRPath(  # allow fancy patchelf runpath setting it defined

--- a/local/src/core/core.part
+++ b/local/src/core/core.part
@@ -8,9 +8,13 @@ env.DependsOn([
     Component("yaml-cpp"),
 ])
 
+cflags = ['-std=c++17', '-g', '-Wall', '-Wextra', '-Werror']
+if env.GetOption('enable_asan'):
+    cflags += ['-fsanitize=address', '-fno-omit-frame-pointer']
+
 env.AppendUnique(
     CPPPATH=["${CHECK_OUT_DIR}/local/include"],
-    CCFLAGS=['-std=c++17', '-g', '-Wall', '-Wextra', '-Werror'],
+    CCFLAGS=cflags,
     LIBS=['pthread'],
 )
 

--- a/local/src/server/verifier-server.part
+++ b/local/src/server/verifier-server.part
@@ -8,10 +8,19 @@ env.DependsOn([
     Component("proxy-verifier.core"),
 ])
 
-env.AppendUnique(
-    CCFLAGS=['-std=c++17', '-g', '-Wall', '-Wextra', '-Werror'],
-    LIBS=['pthread'],
-)
+cflags = ['-std=c++17', '-g', '-Wall', '-Wextra', '-Werror']
+if env.GetOption('enable_asan'):
+    cflags += ['-fsanitize=address', '-fno-omit-frame-pointer']
+    env.AppendUnique(
+        CCFLAGS=cflags,
+        LIBS=['pthread'],
+        LINKFLAGS=['-fsanitize=address', '-static-libasan'],
+    )
+else:
+    env.AppendUnique(
+        CCFLAGS=cflags,
+        LIBS=['pthread'],
+    )
 
 env.InstallBin(
     env.SetRPath(  # allow fancy patchelf runpath setting it defined


### PR DESCRIPTION
Adding a scons --enable-asan option to build compile and link the
executables for ASan.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
