### PR TITLE
Fix cryptography autest pipenv package for macos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1021,6 +1021,28 @@ quick description of the various command-line options. See the [AuTest
 Documentation](https://autestsuite.bitbucket.io) for further details about the
 framework.
 
+**A note for macOS**: The Python virtual environment for these gold tests
+requires the [cryptograpy](https://github.com/pyca/cryptography) package as a
+dependency of the [pyOpenSSL](https://www.pyopenssl.org/en/stable/) package.
+Pipenv will install this automatically, but the installation of the
+`cryptography` package will require compiling certain c files against OpenSSL.
+macOS has its own SSL libraries which brew's version of OpenSSL does not
+replace, for understandable reasons. The building of `cryptography` will
+fail against the system's SSL libraries. To point the build to brew's OpenSSL
+libraries, the `autest.sh` script exports the following variables before
+running `pipenv install`:
+
+```
+export LDFLAGS="-L/usr/local/opt/openssl/lib"
+export CPPFLAGS="-I/usr/local/opt/openssl/include"
+export PKG_CONFIG_PATH="/usr/local/opt/openssl/lib/pkgconfig"
+```
+
+Thus if you stick with using the `autest.sh` script you do not need to worry
+about this. But if you install pipenv by hand rather than through the
+`autest.sh` script on macOS, then keep this in mind and export those variables
+before running `pipenv install`.
+
 ## Usage
 
 This section describes how to run the Proxy Verifier client and server at

--- a/test/autests/test-env-check.sh
+++ b/test/autests/test-env-check.sh
@@ -37,6 +37,28 @@ if [ $? -eq 0 ]; then
     pipenv --venv &> /dev/null
     if [ $? -ne 0 ]; then
         echo "Installing a new virtual environment via pipenv"
+
+        os_name=$(uname)
+        if [ "${os_name}" == "Darwin" ]
+        then
+          # MacOS has its own SSL version. The PyOpenSSL Python package
+          # installed via the following pipenv command will build the
+          # crytpography package which will require the brew-installed openssl
+          # version. We set the following variables to point the cryptography
+          # build to the brew openssl.
+          brew_openssl_lib="/usr/local/opt/openssl/lib"
+          if [ ! -d "${brew_openssl_lib}" ]
+          then
+            echo "WARNING:"
+            echo "Could not find ${brew_openssl_lib}. Have you run \"brew install openssl\"?"
+            echo "If the cryptography package fails to install, the lack of brew's openssl may be why."
+          else
+            export LDFLAGS="-L/usr/local/opt/openssl/lib"
+            export CPPFLAGS="-I/usr/local/opt/openssl/include"
+            export PKG_CONFIG_PATH="/usr/local/opt/openssl/lib/pkgconfig"
+          fi
+        fi
+
         pipenv install
     else
         echo "Using the pre-existing virtual environment."


### PR DESCRIPTION
The latest brew upgrade resulted in the Python cryptography package
required for the AuTests to fail compilation. This detects if the user's
environment is macOS and sets the appropriate environment variables to
point installation to brew's openssl rather than the system SSL to
address this.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
