### PR TITLE
Make "--thread-limt 1" serialize sessions.

### DIFF
--- a/local/src/core/ProxyVerifier.cc
+++ b/local/src/core/ProxyVerifier.cc
@@ -4215,7 +4215,7 @@ ThreadPool::get_worker()
   {
     std::unique_lock<std::mutex> lock(this->_threadPoolMutex);
     while (_threadPool.size() == 0) {
-      if (_allThreads.size() > max_threads) {
+      if (_allThreads.size() >= max_threads) {
         // Just sleep until a thread comes back
         _threadPoolCvar.wait(lock);
       } else { // Make a new thread


### PR DESCRIPTION
I noticed that I was still getting serialized sessions even when
"--thread-limit 1" was passed to the client. This was due to an
off-by-one bug in the ThreadPool::get_worker() logic.

---
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
