### PR TITLE
Verify YAML node existence before querying data on it.

### DIFF
--- a/local/src/client/verifier-client.cc
+++ b/local/src/client/verifier-client.cc
@@ -260,8 +260,9 @@ ClientReplayFileHandler::ssn_open(YAML::Node const &node)
       errata.note(std::move(http_node.errata()));
       return errata;
     }
-    if (http_node.result().IsDefined() &&
-        http_node.result()[YAML_SSN_PROTOCOL_VERSION].Scalar() == "2") {
+    if (http_node.result().IsDefined() && http_node.result()[YAML_SSN_PROTOCOL_VERSION] &&
+        http_node.result()[YAML_SSN_PROTOCOL_VERSION].Scalar() == "2")
+    {
       _ssn->is_h2 = true;
     }
   }

--- a/local/src/core/YamlParser.cc
+++ b/local/src/core/YamlParser.cc
@@ -699,6 +699,13 @@ ReplayFileHandler::parse_for_protocol_node(
       desired_node.error("Protocol element at {} is not a map.", protocol_element.Mark());
       return desired_node;
     }
+    if (!protocol_element[YAML_SSN_PROTOCOL_NAME]) {
+      desired_node.error(
+          R"(Protocol element at {} does not have a "{}" element.)",
+          protocol_element.Mark(),
+          YAML_SSN_PROTOCOL_NAME);
+      return desired_node;
+    }
     if (protocol_element[YAML_SSN_PROTOCOL_NAME].Scalar() != protocol_name) {
       continue;
     }

--- a/local/src/server/verifier-server.cc
+++ b/local/src/server/verifier-server.cc
@@ -419,8 +419,9 @@ ServerReplayFileHandler::handle_protocol_node(YAML::Node const &proxy_request_no
     errata.note(std::move(http_node.errata()));
     return errata;
   }
-  if (http_node.result().IsDefined() &&
-      http_node.result()[YAML_SSN_PROTOCOL_VERSION].Scalar() == "2") {
+  if (http_node.result().IsDefined() && http_node.result()[YAML_SSN_PROTOCOL_VERSION] &&
+      http_node.result()[YAML_SSN_PROTOCOL_VERSION].Scalar() == "2")
+  {
     _txn._req._is_http2 = true;
     _txn._rsp._is_http2 = true;
   }


### PR DESCRIPTION
This avoids aborts from yaml-cpp code in certain circumstances by
testing that a node exists before retrieving data from it.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
