### PR TITLE
Adding server-side delay specification.

### DIFF
--- a/local/include/core/YamlParser.h
+++ b/local/include/core/YamlParser.h
@@ -106,6 +106,16 @@ bwformat(BufferWriter &w, bwf::Spec const & /* spec */, YAML::Mark const &mark)
  */
 swoc::Rv<std::chrono::microseconds> interpret_delay_string(swoc::TextView delay);
 
+/** Parse the node for YAML_TIME_DELAY_KEY and return the delay value it
+ * specifies.
+ *
+ * @param[in] node The parent node containing a YAML_TIME_START_KEY value.
+ *
+ * @return The specified delay, parsed and converted (if need be) to
+ * microseconds.
+ */
+swoc::Rv<std::chrono::microseconds> get_delay_time(YAML::Node const &node);
+
 struct VerificationConfig
 {
   std::shared_ptr<HttpFields> txn_rules;

--- a/local/src/client/verifier-client.cc
+++ b/local/src/client/verifier-client.cc
@@ -132,23 +132,6 @@ get_start_time(YAML::Node const &node)
   return zret;
 }
 
-swoc::Rv<microseconds>
-get_delay_time(YAML::Node const &node)
-{
-  swoc::Rv<microseconds> zret;
-  if (node[YAML_TIME_DELAY_KEY]) {
-    auto delay_node{node[YAML_TIME_DELAY_KEY]};
-    if (delay_node.IsScalar()) {
-      auto &&[delay, delay_errata] = interpret_delay_string(delay_node.Scalar());
-      zret.note(std::move(delay_errata));
-      zret = delay;
-    } else {
-      zret.error(R"("{}" key that is not a scalar.)", YAML_TIME_DELAY_KEY);
-    }
-  }
-  return zret;
-}
-
 class ClientReplayFileHandler : public ReplayFileHandler
 {
 public:
@@ -356,7 +339,7 @@ ClientReplayFileHandler::client_request(YAML::Node const &node)
       if (!delay_errata.is_ok()) {
         errata.note(std::move(delay_errata));
         errata.error(
-            R"(Session at "{}":{} has a bad "{}" key value.)",
+            R"(client-request node at "{}":{} has a bad "{}" key value.)",
             _path,
             _ssn->_line_no,
             YAML_TIME_DELAY_KEY);
@@ -384,7 +367,7 @@ ClientReplayFileHandler::proxy_request(YAML::Node const &node)
       if (!delay_errata.is_ok()) {
         errata.note(std::move(delay_errata));
         errata.error(
-            R"(Session at "{}":{} has a bad "{}" key value.)",
+            R"(proxy-request node at "{}":{} has a bad "{}" key value.)",
             _path,
             _ssn->_line_no,
             YAML_TIME_DELAY_KEY);

--- a/local/src/core/YamlParser.cc
+++ b/local/src/core/YamlParser.cc
@@ -67,6 +67,23 @@ interpret_delay_string(TextView src)
           .error(R"(Unrecognized unit, "{}", for delay specification: "{}")", delay_suffix, src)};
 }
 
+swoc::Rv<microseconds>
+get_delay_time(YAML::Node const &node)
+{
+  swoc::Rv<microseconds> zret;
+  if (node[YAML_TIME_DELAY_KEY]) {
+    auto delay_node{node[YAML_TIME_DELAY_KEY]};
+    if (delay_node.IsScalar()) {
+      auto &&[delay, delay_errata] = interpret_delay_string(delay_node.Scalar());
+      zret.note(std::move(delay_errata));
+      zret = delay;
+    } else {
+      zret.error(R"("{}" key that is not a scalar.)", YAML_TIME_DELAY_KEY);
+    }
+  }
+  return zret;
+}
+
 Errata
 YamlParser::populate_http_message(YAML::Node const &node, HttpHeader &message)
 {

--- a/test/autests/gold_tests/delay/client-side-delay.yaml
+++ b/test/autests/gold_tests/delay/client-side-delay.yaml
@@ -6,6 +6,7 @@ meta:
 
 sessions:
 
+# Verify the user can add a space between the number and the unit.
 - delay: 250 ms
 
 #
@@ -14,10 +15,7 @@ sessions:
 #
   transactions:
 
-    #
-    # Direct the Proxy Verifier client to send a POST request with a body of
-    # 399 bytes.
-    #
+  # Specify a delay of 25 milliseconds using microseconds as the unit.
   - client-request:
       delay: 250000us
 
@@ -30,13 +28,7 @@ sessions:
         - [ Content-Type, image/jpeg ]
         - [ Content-Length, '399' ]
         - [ uuid, first-request ]
-      # A "content" node is not needed if a Content-Length field is specified.
 
-    #
-    # Direct the Proxy Verifier server to verify that the request received from
-    # the proxy has a path in the request target that contains "flower.jpeg"
-    # and has the Content-Length field of any value.
-    #
     proxy-request:
       url:
       - [ path, { value: flower.jpeg, as: contains } ]
@@ -45,30 +37,18 @@ sessions:
         fields:
         - [ Content-Length, { value: '399', as: present } ]
 
-    #
-    # Direct the Proxy Verifier server to reply with a 200 OK response with a body
-    # of 3,432 bytes.
-    #
     server-response:
-        status: 200
-        reason: OK
-        headers:
-          fields:
-          - [ Date, "Sat, 16 Mar 2019 03:11:36 GMT" ]
-          - [ Content-Type, image/jpeg ]
-          - [ Transfer-Encoding, chunked ]
-          - [ Connection, keep-alive ]
-        # Unlike the request which contains a Content-Length, this response
-        # will require a "content" node to specify the size of the body.
-        # Otherwise Proxy Verifier has no way of knowing how large the response
-        # should be.
-        content:
-          size: 3432
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Date, "Sat, 16 Mar 2019 03:11:36 GMT" ]
+        - [ Content-Type, image/jpeg ]
+        - [ Transfer-Encoding, chunked ]
+        - [ Connection, keep-alive ]
+      content:
+        size: 3432
 
-    #
-    # Direct the Proxy Verifier client to verify that it receives a 200 OK from
-    # the proxy with a `Transfer-Encoding: chunked` header field.
-    #
     proxy-response:
       status: 200
       headers:
@@ -76,8 +56,7 @@ sessions:
         - [ Transfer-Encoding, { value: chunked, as: equal } ]
 
 #
-# For the second session, we use a protocol node to configure HTTP/2 using an
-# SNI of # test_sni in the TLS handshake.
+# Specify a session delay for an HTTP/2 conneciton.
 #
 - protocol:
   - name: http
@@ -87,14 +66,11 @@ sessions:
   - name: tcp
   - name: ip
 
+  # Verify the ability to specify seconds as a unit.
   delay: 1s
 
   transactions:
 
-  #
-  # Direct the Proxy Verifier client to send a POST request with a body of
-  # 399 bytes.
-  #
   - client-request:
       delay: 500ms
       headers:
@@ -108,11 +84,6 @@ sessions:
       content:
         size: 399
 
-    #
-    # Direct the Proxy Verifier server to verify that the request received from
-    # the proxy has a path pseudo header field that contains "flower.jpeg"
-    # and has a field "Content-Type: image/jpeg".
-    #
     proxy-request:
       url:
       - [ path, { value: flower.jpeg, as: contains } ]
@@ -125,10 +96,6 @@ sessions:
         - [ :path,        { value: flower.jpeg, as: contains } ]
         - [ Content-Type, { value: image/jpeg,  as: equal } ]
 
-    #
-    # Direct the Proxy Verifier server to reply with a 200 OK response with a body
-    # of 3,432 bytes.
-    #
     server-response:
       headers:
         fields:
@@ -138,9 +105,5 @@ sessions:
       content:
         size: 3432
 
-    #
-    # Direct the Proxy Verifier client to verify that it receives a 200 OK from
-    # the proxy.
-    #
     proxy-response:
       status: 200

--- a/test/autests/gold_tests/delay/delay.test.py
+++ b/test/autests/gold_tests/delay/delay.test.py
@@ -15,18 +15,18 @@ Verify correct handling of session and transaction delay.
 '''
 
 #
-# Test 1: Run a few sessions and transactions with delay.
+# Test 1: Run a few sessions and transactions with client-side delay.
 #
-r = Test.AddTestRun("Verify the handling of the delay specification.")
-client = r.AddClientProcess("client", "delay.yaml")
-server = r.AddServerProcess("server", "delay.yaml")
+r = Test.AddTestRun("Verify the handling of the client-side delay specification.")
+client = r.AddClientProcess("client_client_delay", "client-side-delay.yaml")
+server = r.AddServerProcess("server_client_delay", "client-side-delay.yaml")
 
 # The test proxy is not featureful enough to handle both HTTP/1 and HTTP/2
 # traffic. Thankfully this is easily addressed by running a separate process
 # for each.
-proxy = r.AddProxyProcess("proxy_http", listen_port=client.Variables.http_port,
+proxy = r.AddProxyProcess("proxy_http_client_delay", listen_port=client.Variables.http_port,
                           server_port=server.Variables.http_port)
-proxy = r.AddProxyProcess("proxy_https", listen_port=client.Variables.https_port,
+proxy = r.AddProxyProcess("proxy_https_client_delay", listen_port=client.Variables.https_port,
                           server_port=server.Variables.https_port,
                           use_ssl=True, use_http2_to_2=True)
 
@@ -49,10 +49,57 @@ server.Streams.stdout += Testers.ExcludesExpression(
 #
 # Test 2: Verify that the timing data indicates that the delays took place.
 #
-r = Test.AddTestRun("Verify the replay took an expected amount of time to run.")
+r = Test.AddTestRun("Verify the client-side delay replay took an expected amount of time to run.")
 verifier_script = 'verify_duration.py'
 client_output = client.Streams.stdout.AbsTestPath
 expected_min_delay_ms = "1500"
+r.Processes.Default.Setup.Copy(verifier_script)
+
+r.Processes.Default.Command = \
+        f'python3 {verifier_script} {client_output} {expected_min_delay_ms}'
+r.ReturnCode = 0
+r.Streams.stdout += Testers.ContainsExpression(
+        'Good',
+        f'The verifier script should report success.')
+
+#
+# Test 3: Run a few sessions and transactions with server-side delay.
+#
+r = Test.AddTestRun("Verify the handling of the server-side delay specification.")
+client = r.AddClientProcess("client_server_delay", "server-side-delay.yaml")
+server = r.AddServerProcess("server_server_delay", "server-side-delay.yaml")
+
+# The test proxy is not featureful enough to handle both HTTP/1 and HTTP/2
+# traffic. Thankfully this is easily addressed by running a separate process
+# for each.
+proxy = r.AddProxyProcess("proxy_http_server_delay", listen_port=client.Variables.http_port,
+                          server_port=server.Variables.http_port)
+proxy = r.AddProxyProcess("proxy_https_server_delay", listen_port=client.Variables.https_port,
+                          server_port=server.Variables.https_port,
+                          use_ssl=True, use_http2_to_2=True)
+
+server.Streams.stdout += Testers.ContainsExpression(
+        "Ready with 2 transactions.",
+        "The server should have parsed 2 transactions.")
+
+client.Streams.stdout += Testers.ContainsExpression(
+        "2 transactions in 2 sessions .* in .* milliseconds",
+        "The client should have reported running the transactions with timing data.")
+
+client.Streams.stdout += Testers.ExcludesExpression(
+        "Violation:",
+        "There should be no verification errors because there are none added.")
+
+server.Streams.stdout += Testers.ExcludesExpression(
+        "Violation:",
+        "There should be no verification errors because there are none added.")
+
+#
+# Test 4: Verify that the timing data indicates that the delays took place.
+#
+r = Test.AddTestRun("Verify the server-side delay replay took an expected amount of time to run.")
+client_output = client.Streams.stdout.AbsTestPath
+expected_min_delay_ms = "1000"
 r.Processes.Default.Setup.Copy(verifier_script)
 
 r.Processes.Default.Command = \

--- a/test/autests/gold_tests/delay/server-side-delay.yaml
+++ b/test/autests/gold_tests/delay/server-side-delay.yaml
@@ -1,0 +1,116 @@
+meta:
+    version: '1.0'
+
+# The delays in this file come to about 1 second. (Keep in mind that the two
+# sessions are run in parallel.)
+
+sessions:
+
+#
+# First session: since there is no "protocol" node for this session,
+# HTTP/1.1 over TCP (no TLS) is assumed.
+#
+- transactions:
+
+  - client-request:
+      method: POST
+      url: /pictures/flower.jpeg
+      version: '1.1'
+      headers:
+        fields:
+        - [ Host, www.example.com ]
+        - [ Content-Type, image/jpeg ]
+        - [ Content-Length, '399' ]
+        - [ uuid, first-request ]
+
+    proxy-request:
+      url:
+      - [ path, { value: flower.jpeg, as: contains } ]
+
+      headers:
+        fields:
+        - [ Content-Length, { value: '399', as: present } ]
+
+    #
+    # Specify a 500 ms delayed response.
+    #
+    server-response:
+      delay: 500 ms
+
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Date, "Sat, 16 Mar 2019 03:11:36 GMT" ]
+        - [ Content-Type, image/jpeg ]
+        - [ Transfer-Encoding, chunked ]
+        - [ Connection, keep-alive ]
+      # Unlike the request which contains a Content-Length, this response
+      # will require a "content" node to specify the size of the body.
+      # Otherwise Proxy Verifier has no way of knowing how large the response
+      # should be.
+      content:
+        size: 3432
+
+    #
+    # Direct the Proxy Verifier client to verify that it receives a 200 OK from
+    # the proxy with a `Transfer-Encoding: chunked` header field.
+    #
+    proxy-response:
+      status: 200
+      headers:
+        fields:
+        - [ Transfer-Encoding, { value: chunked, as: equal } ]
+
+#
+# Verify server-response delay in an HTTP/2 transaction.
+#
+- protocol:
+  - name: http
+    version: 2
+  - name: tls
+    sni: test_sni
+  - name: tcp
+  - name: ip
+
+  transactions:
+
+  - client-request:
+      headers:
+        fields:
+        - [ :method, POST ]
+        - [ :scheme, https ]
+        - [ :authority, www.example.com ]
+        - [ :path, /pictures/flower.jpeg ]
+        - [ Content-Type, image/jpeg ]
+        - [ uuid, second-request ]
+      content:
+        size: 399
+
+    proxy-request:
+      url:
+      - [ path, { value: flower.jpeg, as: contains } ]
+
+      headers:
+        fields:
+        - [ :method, POST ]
+        - [ :scheme, https ]
+        - [ :authority, www.example.com ]
+        - [ :path,        { value: flower.jpeg, as: contains } ]
+        - [ Content-Type, { value: image/jpeg,  as: equal } ]
+
+    #
+    # Specify a 1 second delayed response.
+    server-response:
+      delay: 1s
+
+      headers:
+        fields:
+        - [ :status, 200 ]
+        - [ Date, "Sat, 16 Mar 2019 03:11:36 GMT" ]
+        - [ Content-Type, image/jpeg ]
+      content:
+        size: 3432
+
+    proxy-response:
+      status: 200


### PR DESCRIPTION
This commit adds the ability to specify a server-side delay.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
