### PR TITLE
Interface support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Table of Contents
             * [--format &lt;format-specification&gt;](#--format-format-specification)
             * [--keys &lt;key1 key2 ... keyn&gt;](#--keys-key1-key2--keyn)
             * [--verbose](#--verbose)
+            * [--interface](#--interface)
             * [--no-proxy](#--no-proxy)
             * [--strict](#--strict)
             * [--rate &lt;requests/second&gt;](#--rate-requestssecond)
@@ -1320,6 +1321,12 @@ verifier-client \
     --verbose diag
 ```
 
+#### --interface \<device\>
+
+Initiate connections from the specified interface. You can enter any name supported by setsockopt BINDTODEVICE, such at eth0:1.
+
+This is a client-side only option.
+
 #### --no-proxy
 
 As explained above, replay files contain traffic information for both client to
@@ -1394,7 +1401,6 @@ execution. By default, Proxy Verifier limits the number of threads for handling
 these connections to 2,000. This limit can be changed via the `--thread-limit`
 option. Setting a value of 1 on the client will effectively cause sessions
 to be replayed in serial.
-
 
 ## Contribute
 

--- a/README.md
+++ b/README.md
@@ -1321,9 +1321,9 @@ verifier-client \
     --verbose diag
 ```
 
-#### --interface \<device\>
+#### --interface \<interface\>
 
-Initiate connections from the specified interface. You can enter any name supported by setsockopt BINDTODEVICE, such at eth0:1.
+Initiate connections from the specified interface, such as eth0:1.
 
 This is a client-side only option.
 

--- a/local/include/core/http.h
+++ b/local/include/core/http.h
@@ -473,7 +473,7 @@ public:
   virtual swoc::Rv<size_t>
   drain_body(HttpHeader const &hdr, size_t expected_content_size, swoc::TextView bytes_read);
 
-  virtual swoc::Errata do_connect(swoc::IPEndpoint const *real_target);
+  virtual swoc::Errata do_connect(swoc::TextView device, swoc::IPEndpoint const *real_target);
 
   /** Write the content in data to the socket.
    *
@@ -510,6 +510,7 @@ public:
 
   virtual swoc::Errata run_transactions(
       std::list<Txn> const &txn,
+      swoc::TextView device,
       swoc::IPEndpoint const *real_target,
       double rate_multiplier);
   virtual swoc::Errata run_transaction(Txn const &json_txn);

--- a/local/include/core/http.h
+++ b/local/include/core/http.h
@@ -78,7 +78,6 @@ BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, HttpHeader const 
 } // namespace SWOC_VERSION_NS
 } // namespace swoc
 
-
 /** Provide the ability to concert an interface name into an IPEndpoint.
  *
  * This provides RAII for the struct ifaddrs allocated via getifaddrs().
@@ -103,14 +102,6 @@ private:
    * matches the specified interface name and family.
    */
   swoc::Rv<struct ifaddrs *> find_matching_interface();
-
-  /** Convert the IPEndpoint to a string.
-   *
-   * @param[in] ip The endpoing to convert to a string.
-   *
-   * @return The string representing the endpoint.
-   */
-  swoc::Rv<std::string> convert_ip_endpoint_to_string(swoc::IPEndpoint const &ip);
 
 private:
   struct ifaddrs *_ifaddr_list_head = nullptr;

--- a/local/include/core/http2.h
+++ b/local/include/core/http2.h
@@ -126,6 +126,7 @@ public:
   swoc::Errata send_connection_settings();
   swoc::Errata run_transactions(
       std::list<Txn> const &txn,
+      swoc::TextView device,
       swoc::IPEndpoint const *real_target,
       double rate_multiplier) override;
   swoc::Errata run_transaction(Txn const &txn) override;

--- a/local/src/core/http2.cc
+++ b/local/src/core/http2.cc
@@ -245,6 +245,7 @@ H2Session::connect()
 Errata
 H2Session::run_transactions(
     std::list<Txn> const &txn_list,
+    swoc::TextView device,
     swoc::IPEndpoint const *real_target,
     double rate_multiplier)
 {
@@ -255,7 +256,7 @@ H2Session::run_transactions(
     Errata txn_errata;
     auto const key{txn._req.get_key()};
     if (this->is_closed()) {
-      txn_errata.note(this->do_connect(real_target));
+      txn_errata.note(this->do_connect(device, real_target));
       if (!txn_errata.is_ok()) {
         txn_errata.error(R"(Failed to reconnect HTTP/2 key={}.)", key);
         // If we don't have a valid connection, there's no point in continuing.

--- a/local/src/server/verifier-server.cc
+++ b/local/src/server/verifier-server.cc
@@ -758,7 +758,7 @@ do_listen(swoc::IPEndpoint &server_addr, bool do_tls)
             auto runner = std::make_unique<std::thread>(TF_Accept, socket_fd, do_tls);
             Accept_Threads.push_back(std::move(runner));
           } else {
-            errata.error(R"(Could not isten to {}: {}.)", server_addr, swoc::bwf::Errno{});
+            errata.error(R"(Could not listen to {}: {}.)", server_addr, swoc::bwf::Errno{});
           }
         } else {
           errata.error(R"(Could not bind to {}: {}.)", server_addr, swoc::bwf::Errno{});


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Supports an options that sends a bound-to device for all client sockets on verifier-client.