### PR TITLE
Pinning to scons-parts 0.15.8

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -14,4 +14,4 @@ python_version = "3"
 
 [packages]
 scons = "*"
-scons-parts = "*"
+scons-parts = "==0.15.8"


### PR DESCRIPTION
The latest scons-parts (0.16.0) does not work with the our parts files
as is.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
