### PR TITLE
Updating the HTTP library dependencies.

### DIFF
--- a/Sconstruct
+++ b/Sconstruct
@@ -95,9 +95,9 @@ else:
   Part(
     "openssl",
     "#lib/openssl.part",
-    vcs_type=VcsGit(server="github.com", repository="tatsuhiro-t/openssl",
+    vcs_type=VcsGit(server="github.com", repository="quictls/openssl",
                     protocol="https",
-                    revision="afdc16c82f724e8c0b8384224180b140fe8566fe"
+                    revision="a6e9d76db343605dae9b59d71d2811b195ae7434"
                     ),
     mode=['SKIP_DOCS'],
   )
@@ -111,7 +111,17 @@ else:
         "#lib/nghttp2.part",
         vcs_type=VcsGit(server="github.com", repository="tatsuhiro-t/nghttp2",
                         protocol="https",
-                        revision="d2e570c72e169ed88557ce5108df34d34d4f7f08"
+                        # This commit will be removed whenever the nghttp2
+                        # author rebases origin/quic.  For reference, this
+                        # commit is currently described as:
+                        #
+                        # commit cdf58e370e6a843b0965aabcd75908ca52633b60
+                        # Author: Tatsuhiro Tsujikawa <tatsuhiro.t@gmail.com>
+                        # Date:   Sat Mar 27 23:37:37 2021 +0900
+                        #
+                        #     Compile with the latest ngtcp2
+
+                        revision="cdf58e370e6a843b0965aabcd75908ca52633b60"
                         ),
         mode=['SKIP_DOCS'],
     )

--- a/tools/build_library_dependencies.sh
+++ b/tools/build_library_dependencies.sh
@@ -67,7 +67,18 @@ ${SUDO} make install
 cd ${repo_dir}
 git clone https://github.com/tatsuhiro-t/nghttp2.git
 cd nghttp2
-git checkout d2e570c72e169ed88557ce5108df34d34d4f7f08
+
+# This commit will be removed whenever the nghttp2 author rebases origin/quic.
+# For reference, this commit is currently described as:
+#
+# commit cdf58e370e6a843b0965aabcd75908ca52633b60
+# Author: Tatsuhiro Tsujikawa <tatsuhiro.t@gmail.com>
+# Date:   Sat Mar 27 23:37:37 2021 +0900
+#
+#     Compile with the latest ngtcp2
+
+git checkout cdf58e370e6a843b0965aabcd75908ca52633b60
+
 autoreconf -if
 ./configure \
   PKG_CONFIG_PATH=${install_dir}/openssl/lib/pkgconfig:${install_dir}/ngtcp2/lib/pkgconfig:${install_dir}/nghttp3/lib/pkgconfig \


### PR DESCRIPTION
This updates the OpenSSL and HTTP library dependencies as they have
changed. The nghttp2 commit that was previously referenced got removed
due to a rebase in that repository, so that needed to be updated. Also,
curl and ATS have moved to using quictls/openssl instead of
tatsuhiro-t/openssl for OpenSSL. This updates that as well.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
