### PR TITLE
Pin to scons 4.1.0

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -13,5 +13,5 @@ verify_ssl = true
 python_version = "3"
 
 [packages]
-scons = "*"
+scons = "==4.1.0"
 scons-parts = "==0.15.8"


### PR DESCRIPTION
The latest 4.2.x breaks scons-parts.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
