### PR TITLE
Fixes body handling for raw chunked bodies

### DIFF
--- a/local/include/core/http.h
+++ b/local/include/core/http.h
@@ -403,6 +403,9 @@ public:
 
   /// Body is chunked.
   bool _chunked_p = false;
+  /// Whether there is a "Transfer-Encoding: chunked" HTTP header field in this
+  /// message.
+  bool _has_transfer_encoding_chunked = false;
   /// No Content-Length - close after sending body.
   bool _content_length_p = false;
 

--- a/local/src/core/YamlParser.cc
+++ b/local/src/core/YamlParser.cc
@@ -240,6 +240,10 @@ YamlParser::populate_http_message(YAML::Node const &node, HttpHeader &message)
         if (0 == strcasecmp("chunked"_tv, xf)) {
           message._chunked_p = true;
         } else if (0 == strcasecmp("plain"_tv, xf)) {
+          // The user may be specifying raw chunk body content (i.e.,
+          // specifying the chunk header with CRLF's, etc.). We set this to
+          // false so that later, when the body is written, we don't
+          // automagically try to frame the body as chunked for the user.
           message._chunked_p = false;
         } else {
           errata.error(

--- a/test/autests/gold_tests/body/body.yaml
+++ b/test/autests/gold_tests/body/body.yaml
@@ -206,3 +206,31 @@ sessions:
         fields:
         - [ Transfer-Encoding, { value: chunked, as: equal } ]
         - [ X-Response, { value: "fourth_response", as: equal } ]
+
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /for/http
+      headers:
+        fields:
+        - [ Host, example.com ]
+        - [ Transfer-Encoding, chunked ]
+        - [ uuid, 5 ]
+      content:
+        transfer: plain
+        encoding: uri
+        data: 3%0D%0Aabc%0D%0A0%0D%0A%0D%0A
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Transfer-Encoding, chunked ]
+      content:
+        transfer: plain
+        encoding: uri
+        data: 4%0D%0Adefg%0D%0Ab%0D%0A0123456789a%0D%0A0%0D%0A%0D%0A
+
+    proxy-response:
+      status: 200

--- a/test/autests/gold_tests/body/gold/body_client.gold
+++ b/test/autests/gold_tests/body/gold/body_client.gold
@@ -15,3 +15,8 @@
 * Bullet
 * Points
 ``
+``Drained 15 chunked body bytes with chunk stream: f
+defg0123456789a
+0
+
+``

--- a/test/autests/gold_tests/body/gold/body_proxy.gold
+++ b/test/autests/gold_tests/body/gold/body_proxy.gold
@@ -23,3 +23,9 @@ b'0123456789'
 ==== RESPONSE BODY ====
 b'1f\r\n### Heading\n\n* Bullet\n* Points\n\r\n0\r\n\r\n'
 ``
+==== REQUEST BODY ====
+b'3\r\nabc\r\n0\r\n\r\n'
+``
+==== RESPONSE BODY ====
+b'f\r\ndefg0123456789a\r\n0\r\n\r\n'
+``

--- a/test/autests/gold_tests/body/gold/body_server.gold
+++ b/test/autests/gold_tests/body/gold/body_server.gold
@@ -13,3 +13,8 @@
 ``
 ``Drained``: 0123456789
 ``
+``Drained 3 chunked body bytes with chunk stream: 3
+abc
+0
+
+``


### PR DESCRIPTION
This fixes the handling of raw specified chunked bodies so that the
writing of the message understands that if transfer encoding is chunked
then the connection doesn't need to be aborted.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
