### PR TITLE
HTTP/2 timing fix for --rate

### DIFF
--- a/local/src/core/http2.cc
+++ b/local/src/core/http2.cc
@@ -19,7 +19,6 @@ using swoc::Errata;
 using swoc::TextView;
 using namespace swoc::literals;
 using namespace std::literals;
-using std::this_thread::sleep_for;
 
 namespace chrono = std::chrono;
 using ClockType = std::chrono::system_clock;
@@ -286,7 +285,6 @@ H2Session::run_transactions(
             duration_cast<milliseconds>(delay_time));
         current_time = ClockType::now();
         delay_time = next_time - current_time;
-        sleep_for(delay_time);
       }
     }
     txn_errata.note(this->run_transaction(txn));
@@ -586,7 +584,6 @@ receive_nghttp2_request(
         session_data->close();
         return (ssize_t)total_recv;
       } else if (poll_return == 0) {
-        errata.error("Timed out waiting to SSL_read for HTTP/2 request headers after {}.", timeout);
         return (ssize_t)total_recv;
       }
       // Poll succeeded. Repeat the attempt to read.


### PR DESCRIPTION
We had a sleep_for to space out HTTP/2 transactions (streams) within a
session to adhere to the --rate parameter. This caused delays, though,
for reading responses for other streams. The sleep_for is unnecessary:
the reading from the socket has a timeout that corresponds to our delay
anyway. Simply remove the sleep_for to fix the timing issue.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
