### PR TITLE
Revert "Build with openssl-3.0.1-quic. (#182)"

### DIFF
--- a/Sconstruct
+++ b/Sconstruct
@@ -100,8 +100,8 @@ else:
     "#lib/openssl.part",
     vcs_type=VcsGit(server="github.com", repository="quictls/openssl",
                     protocol="https",
-                    # A pinned commit from branch openssl-3.0.1+quic.
-                    revision="ab8b87bdb436b11bf2a10a2a57a897722224f828"
+                    # A pinned commit from branch OpenSSL_1_1_1k+quic.
+                    revision="7c0006ccf891c20cd0b1e9e6a436f9d1f3153b7b"
                     ),
     mode=['SKIP_DOCS'],
   )
@@ -116,15 +116,16 @@ else:
         vcs_type=VcsGit(server="github.com", repository="tatsuhiro-t/nghttp2",
                         protocol="https",
                         # A pinned commit from branch quic.
-                        # commit 8a552631b4e64851018947a44b98fa022133fa81 (HEAD, origin/master, origin/HEAD, master)
-                        # Merge: cff81069 deb390cf
-                        # Author: Tatsuhiro Tsujikawa <404610+tatsuhiro-t@users.noreply.github.com>
-                        # Date:   Tue Jan 11 20:53:08 2022 +0900
+                        # This commit will be removed whenever the nghttp2
+                        # author rebases origin/quic.  For reference, this
+                        # commit is currently described as:
+
+                        # commit 25f29e7634a2c8c5ba5c63432e5d94217a6535ef
+                        # Author: Tatsuhiro Tsujikawa <tatsuhiro.t@gmail.com>
+                        # Date:   Mon Aug 16 16:58:11 2021 +0900
                         #
-                        #     Merge pull request #1667 from nghttp2/keep-hd-table-size
-                        #
-                        #     Fix decoder table size update
-                        revision="8a552631b4e64851018947a44b98fa022133fa81"
+                        #     Compile with the latest ngtcp2
+                        revision="25f29e7634a2c8c5ba5c63432e5d94217a6535ef"
                         ),
         mode=['SKIP_DOCS'],
     )
@@ -139,7 +140,7 @@ else:
     vcs_type=VcsGit(server="github.com", repository="ngtcp2/ngtcp2",
                     protocol="https",
                     # A pinned commit on branch main.
-                    revision="9b6fdfb135475e9ed480d87e98c4717683f63e33"
+                    revision="982502f9ac594a45bc13804416a443522d906f29"
                     ),
     mode=['SKIP_DOCS'],
   )
@@ -154,7 +155,7 @@ else:
     vcs_type=VcsGit(server="github.com", repository="ngtcp2/nghttp3",
                     protocol="https",
                     # A pinned commit on branch main.
-                    revision="69e381358697a5c924860dbc256a2d0ee44448a3"
+                    revision="b9e565cb48e92ded110162a65511f78681fb13c3"
                     ),
     mode=['SKIP_DOCS'],
   )

--- a/lib/openssl.part
+++ b/lib/openssl.part
@@ -25,7 +25,7 @@ else:
     # No path provided.
     PartVersion(
         GitVersionFromTag(
-            "3.0.1",
+            "1.1.1.g",
             regex=r'\d+\_\d+\_\d+[a-z]',
             converter=lambda ver, env: ver.replace("_", ".")
         )
@@ -104,7 +104,6 @@ else:
         configure_args=[
             'enable-tls1_3',
             '--prefix=$CONFIGURE_PREFIX',
-            '--libdir=lib',
         ],
         # this allows us to call make depends to "finialize" what finial makefile. Prevents a rebuild.
         # however this sort of build twice

--- a/local/src/core/https.cc
+++ b/local/src/core/https.cc
@@ -44,7 +44,7 @@ bwformat(BufferWriter &w, bwf::Spec const &spec, bwf::SSLError const &error)
   // Hand rolled, might not be totally compliant everywhere, but probably close
   // enough. The long string will be locally accurate. Clang requires the double
   // braces.
-  static const std::array<std::string_view, 13> SHORT_NAME = {{
+  static const std::array<std::string_view, 11> SHORT_NAME = {{
       "SSL_ERROR_NONE: ",
       "SSL_ERROR_SSL: ",
       "SSL_ERROR_WANT_READ: ",
@@ -56,8 +56,6 @@ bwformat(BufferWriter &w, bwf::Spec const &spec, bwf::SSLError const &error)
       "SSL_ERROR_WANT_ACCEPT: ",
       "SSL_ERROR_WANT_ASYNC: ",
       "SSL_ERROR_WANT_ASYNC_JOB: ",
-      "SSL_ERROR_WANT_CLIENT_HELLO_CB: ",
-      "SSL_ERROR_WANT_RETRY_VERIFY: ",
   }};
 
   auto short_name = [](int n) {
@@ -303,15 +301,14 @@ TLSSession::poll_for_data_on_ssl_socket(chrono::milliseconds timeout, int ssl_er
     zret.diag("Poll called on a closed connection.");
     return zret;
   }
-  if (ssl_error == SSL_ERROR_ZERO_RETURN || ssl_error == SSL_ERROR_SYSCALL ||
-      ssl_error == SSL_ERROR_SSL)
-  {
+  if (ssl_error == SSL_ERROR_ZERO_RETURN || ssl_error == SSL_ERROR_SYSCALL) {
     // Either of these indicates that the peer has closed the connection for
     // writing and no more data can be read.
     zret.diag("Poll called on a TLS session closed by the peer.");
     this->close();
     return zret;
   }
+
   if (ssl_error != SSL_ERROR_WANT_READ && ssl_error != SSL_ERROR_WANT_WRITE) {
     zret.error(
         R"(SSL operation failed: {}, errno: {})",

--- a/tools/build_library_dependencies.sh
+++ b/tools/build_library_dependencies.sh
@@ -32,12 +32,10 @@ mkdir -p ${repo_dir}
 
 # 1. OpenSSL version that supports quic.
 cd ${repo_dir}
-git clone -b openssl-3.0.1+quic --depth 1 https://github.com/quictls/openssl.git openssl
+git clone -b OpenSSL_1_1_1m+quic --depth 1 https://github.com/quictls/openssl.git openssl
 cd openssl
-git checkout ab8b87bdb436b11bf2a10a2a57a897722224f828
-# Installing to lib instead of the default system lib64 makes linking work
-# better in our setup.
-./config --prefix=${install_dir}/openssl --libdir=lib
+git checkout 7c0006ccf891c20cd0b1e9e6a436f9d1f3153b7b
+./config --prefix=${install_dir}/openssl
 make -j4
 ${SUDO} make install_sw
 
@@ -45,7 +43,7 @@ ${SUDO} make install_sw
 cd ${repo_dir}
 git clone https://github.com/ngtcp2/nghttp3
 cd nghttp3/
-git checkout 69e381358697a5c924860dbc256a2d0ee44448a3
+git checkout b9e565cb48e92ded110162a65511f78681fb13c3
 autoreconf -i
 ./configure --prefix=${install_dir}/nghttp3 --enable-lib-only
 make -j4
@@ -55,10 +53,10 @@ ${SUDO} make install
 cd ${repo_dir}
 git clone https://github.com/ngtcp2/ngtcp2
 cd ngtcp2
-git checkout 9b6fdfb135475e9ed480d87e98c4717683f63e33
+git checkout 982502f9ac594a45bc13804416a443522d906f29
 autoreconf -i
 ./configure \
-  PKG_CONFIG_PATH=${install_dir}/openssl/lib64/pkgconfig:${install_dir}/openssl/lib/pkgconfig:${install_dir}/nghttp3/lib/pkgconfig \
+  PKG_CONFIG_PATH=${install_dir}/openssl/lib/pkgconfig:${install_dir}/nghttp3/lib/pkgconfig \
   LDFLAGS="-Wl,-rpath,${install_dir}/openssl/lib" \
   --prefix=${install_dir}/ngtcp2 \
   --enable-lib-only
@@ -73,15 +71,12 @@ cd nghttp2
 # This commit will be removed whenever the nghttp2 author rebases origin/quic.
 # For reference, this commit is currently described as:
 #
-# commit 8a552631b4e64851018947a44b98fa022133fa81 (HEAD -> master, origin/master, origin/HEAD)
-# Merge: cff81069 deb390cf
-# Author: Tatsuhiro Tsujikawa <404610+tatsuhiro-t@users.noreply.github.com>
-# Date:   Tue Jan 11 20:53:08 2022 +0900
+# commit 25f29e7634a2c8c5ba5c63432e5d94217a6535ef
+# Author: Tatsuhiro Tsujikawa <tatsuhiro.t@gmail.com>
+# Date:   Mon Aug 16 16:58:11 2021 +0900
 #
-#     Merge pull request #1667 from nghttp2/keep-hd-table-size
-#
-#     Fix decoder table size update
-git checkout 8a552631b4e64851018947a44b98fa022133fa81
+#     Compile with the latest ngtcp2
+git checkout 25f29e7634a2c8c5ba5c63432e5d94217a6535ef
 
 autoreconf -if
 ./configure \


### PR DESCRIPTION
openssl-3.0.1-quic introduces a bad performance regression to
proxy-verifier. I'll hold off on the upgrade until later.

This reverts commits:

e5e7430333fec57befb33da9072cc5d6932bb25d
797d4fe3b24bf69281afc6d7ef7463a96dbcf0a8
b5bb466040319be039a624a51ab44fd68949dc69


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
