### PR TITLE
Updated to libswoc 1.3.7

### DIFF
--- a/Sconstruct
+++ b/Sconstruct
@@ -173,7 +173,7 @@ if path_nghttp3 is not None:
   custom_rpath.append(path_nghttp3 + "/lib")
 SetOptionDefault("RPATH",  custom_rpath)
 
-Part("code/libswoc.part",vcs_type=VcsGit(server="github.com", repository="SolidWallOfCode/libswoc", tag="1.3.4"), package_group="proxy-verifier")
+Part("code/libswoc.part",vcs_type=VcsGit(server="github.com", repository="SolidWallOfCode/libswoc", tag="1.3.7"), package_group="proxy-verifier")
 
 pv_mode = []
 if GetOption("enable_asan"):


### PR DESCRIPTION
This fixes compiler warnings from later compilers, such as gcc 11.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
