### PR TITLE
hw.physicalcpu -> hw.logicalcpu

### DIFF
--- a/tools/build_library_dependencies.sh
+++ b/tools/build_library_dependencies.sh
@@ -26,7 +26,7 @@ then
   num_threads=$(nproc)
 else
   # MacOS.
-  num_threads=$(sysctl -n hw.physicalcpu)
+  num_threads=$(sysctl hw.logicalcpu)
 fi
 
 [ $# -eq 1 ] || fail "Please provide a directory in which to install the libraries."

--- a/tools/build_static
+++ b/tools/build_static
@@ -32,7 +32,7 @@ then
   num_threads=$(nproc)
 else
   # MacOS.
-  num_threads=$(sysctl -n hw.physicalcpu)
+  num_threads=$(sysctl hw.logicalcpu)
 fi
 [ -f Sconstruct ] || fail "Not in the root directory of proxy-verifier."
 


### PR DESCRIPTION
On a mac, better to use the number of hyperthreaded cores, not just
physical cores.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
