### PR TITLE
Test Proxy: switching to httpx from hyper.

### DIFF
--- a/test/autests/Pipfile
+++ b/test/autests/Pipfile
@@ -14,8 +14,8 @@ autopep8 = "*"
 pyflakes = "*"
 
 [packages]
-autest = "==1.10.0"
-hyper = "*"
+autest = "==1.10.1"
+"httpx[http2]" = "*"
 pyOpenSSL = "*"
 eventlet = "*"
 ruamel_yaml = "*"
@@ -25,9 +25,4 @@ aioquic = "*"
 wsproto = "*"
 
 [requires]
-# We have to pin to 3.8 because MacOS 3.9 has an issue which produces this
-# message in many packages (we see it in selectors):
-# TypeError: changelist must be an iterable of select.kevent objects
-#
-# Do a google search on that...most package issues say to use pre-3.9 Python.
-python_version = "3.8"
+python_version = "3"

--- a/test/autests/autest.sh
+++ b/test/autests/autest.sh
@@ -3,10 +3,15 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+fail()
+{
+  echo $1
+  exit 1
+}
 
 pushd $(dirname $0) > /dev/null
 export PYTHONPATH=$(pwd):$PYTHONPATH
-./test-env-check.sh;
+./test-env-check.sh || fail "Setting up the test environment failed."
 # this is for rhel or centos systems
 echo "Environment config finished. Running AuTest..."
 pipenv run autest -D gold_tests "$@"

--- a/test/autests/gold_tests/autest-site/init.cli.ext
+++ b/test/autests/gold_tests/autest-site/init.cli.ext
@@ -9,9 +9,9 @@ Implement Proxy Verifier command line arguments.
 
 import sys
 
-if sys.version_info < (3, 5, 0):
+if sys.version_info < (3, 10, 0):
     host.WriteError(
-        "You need python 3.5 or later to run these tests\n", show_stack=False)
+        "You need python 3.10 or later to run these tests\n", show_stack=False)
 
 autest_version = "1.7.2"
 if AuTestVersion() < autest_version:

--- a/test/autests/gold_tests/doctest/gold/doctest_server.gold
+++ b/test/autests/gold_tests/doctest/gold/doctest_server.gold
@@ -18,10 +18,14 @@ connection: keep-alive
 ``
 :method: POST
 :scheme: https
-:authority: www.example.com
+:authority: 127.0.0.1:``
 :path: /pictures/flower.jpeg
+accept: ``
+accept-encoding: ``
+user-agent: ``
 content-type: image/jpeg
 uuid: second-request
+content-length: ``
 
 ``
 :status: 200

--- a/test/autests/gold_tests/http/replay_files/multiple_transactions/file1.json
+++ b/test/autests/gold_tests/http/replay_files/multiple_transactions/file1.json
@@ -115,10 +115,6 @@
                                     "0"
                                 ],
                                 [
-                                    "Content-Encoding",
-                                    "gzip"
-                                ],
-                                [
                                     "Vary",
                                     "Accept-Encoding"
                                 ],
@@ -154,10 +150,6 @@
                                 [
                                     "Age",
                                     "0"
-                                ],
-                                [
-                                    "Content-Encoding",
-                                    "gzip"
                                 ],
                                 [
                                     "Vary",
@@ -275,10 +267,6 @@
                                     "0"
                                 ],
                                 [
-                                    "Content-Encoding",
-                                    "gzip"
-                                ],
-                                [
                                     "Vary",
                                     "Accept-Encoding"
                                 ],
@@ -314,10 +302,6 @@
                                 [
                                     "Age",
                                     "1"
-                                ],
-                                [
-                                    "Content-Encoding",
-                                    "gzip"
                                 ],
                                 [
                                     "Vary",
@@ -449,10 +433,6 @@
                                     "0"
                                 ],
                                 [
-                                    "Content-Encoding",
-                                    "gzip"
-                                ],
-                                [
                                     "Vary",
                                     "Accept-Encoding"
                                 ],
@@ -488,10 +468,6 @@
                                 [
                                     "Age",
                                     "0"
-                                ],
-                                [
-                                    "Content-Encoding",
-                                    "gzip"
                                 ],
                                 [
                                     "Vary",

--- a/test/autests/gold_tests/http/replay_files/multiple_transactions/file2.json
+++ b/test/autests/gold_tests/http/replay_files/multiple_transactions/file2.json
@@ -313,10 +313,6 @@
                                     "0"
                                 ],
                                 [
-                                    "Content-Encoding",
-                                    "gzip"
-                                ],
-                                [
                                     "Vary",
                                     "Accept-Encoding"
                                 ],
@@ -352,10 +348,6 @@
                                 [
                                     "Age",
                                     "0"
-                                ],
-                                [
-                                    "Content-Encoding",
-                                    "gzip"
                                 ],
                                 [
                                     "Vary",
@@ -473,10 +465,6 @@
                                     "0"
                                 ],
                                 [
-                                    "Content-Encoding",
-                                    "gzip"
-                                ],
-                                [
                                     "Vary",
                                     "Accept-Encoding"
                                 ],
@@ -512,10 +500,6 @@
                                 [
                                     "Age",
                                     "0"
-                                ],
-                                [
-                                    "Content-Encoding",
-                                    "gzip"
                                 ],
                                 [
                                     "Vary",

--- a/test/autests/gold_tests/http2/gold/http2_to_http1_client.gold
+++ b/test/autests/gold_tests/http2/gold/http2_to_http1_client.gold
@@ -14,7 +14,6 @@ uuid: 1
 ``
 :status: 200
 cache-control: private
-content-encoding: gzip
 content-type: application/json;charset=utf-8
 content-length: 16
 date: Sat, 16 Mar 2019 01:13:21 GMT

--- a/test/autests/gold_tests/http2/gold/http2_to_http1_proxy.gold
+++ b/test/autests/gold_tests/http2/gold/http2_to_http1_proxy.gold
@@ -16,7 +16,6 @@ uuid: 1
 ==== RESPONSE HEADERS ====
 :status: 200
 cache-control: private
-content-encoding: gzip
 content-type: application/json;charset=utf-8
 content-length: 16
 date: Sat, 16 Mar 2019 01:13:21 GMT

--- a/test/autests/gold_tests/http2/gold/http2_to_http1_server.gold
+++ b/test/autests/gold_tests/http2/gold/http2_to_http1_server.gold
@@ -11,7 +11,6 @@ uuid: 1
 ``
 HTTP/1.1 200 OK
 cache-control: private
-content-encoding: gzip
 content-type: application/json;charset=utf-8
 content-length: 16
 date: Sat, 16 Mar 2019 01:13:21 GMT

--- a/test/autests/gold_tests/http2/gold/http2_to_http2_client.gold
+++ b/test/autests/gold_tests/http2/gold/http2_to_http2_client.gold
@@ -50,7 +50,6 @@ uuid: 4
 ``Received an HTTP/2 response for key 1 with stream id 1:
 :status: 200
 cache-control: private
-content-encoding: gzip
 content-type: application/json;charset=utf-8
 content-length: 16
 date: Sat, 16 Mar 2019 01:13:21 GMT

--- a/test/autests/gold_tests/http2/gold/http2_to_http2_proxy.gold
+++ b/test/autests/gold_tests/http2/gold/http2_to_http2_proxy.gold
@@ -21,7 +21,6 @@ uuid: 1
 ==== RESPONSE HEADERS ====
 :status: 200
 cache-control: private
-content-encoding: gzip
 content-type: application/json;charset=utf-8
 content-length: 16
 date: Sat, 16 Mar 2019 01:13:21 GMT

--- a/test/autests/gold_tests/http2/gold/http2_to_http2_server.gold
+++ b/test/autests/gold_tests/http2/gold/http2_to_http2_server.gold
@@ -5,10 +5,10 @@
 :scheme: https
 :authority: example.data.com
 :path: /a/path?q=3
+user-agent: ``
 accept: */*
 accept-language: en-us
 accept-encoding: gzip
-host: example.data.com
 x-test-duplicate-combined: first
 x-test-duplicate-combined: second
 x-test-duplicate-separate: first
@@ -19,7 +19,6 @@ uuid: 1
 ``
 :status: 200
 cache-control: private
-content-encoding: gzip
 content-type: application/json;charset=utf-8
 content-length: 16
 date: Sat, 16 Mar 2019 01:13:21 GMT
@@ -33,18 +32,21 @@ uuid: 1
 ``
 :method: POST
 :scheme: https
-:authority: example.data.com
+:authority: ``
 :path: /a/path
+accept: ``
+accept-encoding: ``
+user-agent: ``
 x-request-header: request
 uuid: 2
 x-added-header: 1
+content-length: 10
 
 ``Received an HTTP/2 body of 10 bytes for key 2 with stream id 3:
 0123456789
-``Equals Success: Key: "2", Field Name: ":authority", Value: "example.data.com"
+`` Contains Success: Key: "2", Field Name: ":authority", Required Value: "127.0.0.1", Value: "127.0.0.1:``"
 ``Equals Success: Key: "2", Field Name: ":method", Value: "POST"
 ``Equals Success: Key: "2", Field Name: ":scheme", Value: "https"
-``Absence Success: Key: "2", Field Name: "content-length"
 ``Presence Success: Key: "2", Field Name: "x-added-header", Value: "1"
 ``Absence Success: Key: "2", Field Name: "x-deleted-header"
 ``Presence Success: Key: "2", Field Name: "x-request-header", Value: "request"
@@ -59,8 +61,11 @@ uuid: 2
 ``
 :method: GET
 :scheme: https
-:authority: example.data.com
+:authority: 127.0.0.1:``
 :path: /b/path
+accept: ``
+accept-encoding: ``
+user-agent: ``
 x-request-header: test_request
 uuid: 3
 
@@ -73,8 +78,11 @@ uuid: 3
 ``Received an HTTP/2 request for key 4 with stream id 7:
 :method: GET
 :scheme: https
-:authority: example.data.com
+:authority: 127.0.0.1:``
 :path: /b/path
+accept: ``
+accept-encoding: ``
+user-agent: ``
 x-request-header: test_request
 uuid: 4
 

--- a/test/autests/gold_tests/http2/http2.test.py
+++ b/test/autests/gold_tests/http2/http2.test.py
@@ -100,9 +100,6 @@ proxy.Streams.stdout += Testers.ContainsExpression(
 proxy.Streams.stdout += Testers.ContainsExpression(
     "Got SNI from client: b'test_sni_with_h2'",
     "Verify that the SNI associated with HTTP/2 support was sent.")
-proxy.Streams.stdout += Testers.ContainsExpression(
-    "HTTP/2 negotiation failed. Trying with HTTP/1",
-    "Verify that the proxy detected that HTTP/2 was rejected.")
 
 # The client sent and received HTTP/2 for both transactions because
 # only the server side should down-negotiate HTTP/2, not the proxy.

--- a/test/autests/gold_tests/http2/replay_files/http2_to_http1.yaml
+++ b/test/autests/gold_tests/http2/replay_files/http2_to_http1.yaml
@@ -35,7 +35,6 @@ sessions:
         encoding: esc_json
         fields:
         - [ Cache-Control, private ]
-        - [ Content-Encoding, gzip ]
         - [ Content-Type, application/json;charset=utf-8 ]
         - [ Content-Length, '16' ]
         - [ Date, "Sat, 16 Mar 2019 01:13:21 GMT" ]

--- a/test/autests/gold_tests/http2/replay_files/http2_to_http2.yaml
+++ b/test/autests/gold_tests/http2/replay_files/http2_to_http2.yaml
@@ -58,7 +58,7 @@ sessions:
       - [ scheme, { value: https, as: equal } ]
       - [ host, { value: example.data.com, as: equal } ]
       - [ path, { value: /a/path, as: equal } ]
-      - [ authority, { value: example.data.com, as: equal } ]
+      - [ authority, { value: 127.0.0.1, as: contains } ]
       - [ net-loc, { value: example.data.com, as: equal } ]
       - [ query, { value: q=3, as: present } ]
       - [ query, { value: 3, as: contains } ]
@@ -73,8 +73,8 @@ sessions:
         - [ :scheme, { value: https, as: equal } ]
         - [ :authority, { value: example.data.com, as: equal } ]
         - [ :path, { value: '/a/path?q=3', as: equal } ]
-        # Note that the Host field is still sent.
-        - [ Host, { value: example.data.com, as: equal } ]
+        # The Python httpx test proxy doesn't send the Host header.
+        - [ Host, { as: absent } ]
         - [ Content-Length, { value: "0", as: equal } ]
         - [ x-test-duplicate-combined, { value: [ first, second ], as: equal } ]
         - [ x-test-duplicate-separate, { value: [ first, second ], as: equal } ]
@@ -85,7 +85,6 @@ sessions:
         encoding: esc_json
         fields:
         - [ Cache-Control, private ]
-        - [ Content-Encoding, gzip ]
         - [ Content-Type, application/json;charset=utf-8 ]
         - [ Content-Length, '16' ]
         - [ Date, "Sat, 16 Mar 2019 01:13:21 GMT" ]
@@ -147,12 +146,16 @@ sessions:
         fields:
         - [ :method, { value: POST, as: equal } ]
         - [ :scheme, { value: https, as: equal } ]
-        - [ :authority, { value: example.data.com, as: equal } ]
+        # Our Python httpx proxy changes the `:authority` header to:
+        # 127.0.0.1:<some_port>
+        - [ :authority, { value: 127.0.0.1, as: contains } ]
         - [ :path, /a/path ]
         - [ X-Request-Header, { as: present } ]
         - [ X-Added-Header, { as: present } ]
         - [ X-Deleted-Header, { as: absent } ]
-        - [ Content-Length, { as: absent } ]
+        # Annoyingly, the Python httpx HTTP/2 client we use as a test proxy
+        # inserts a Content-Length header.
+        #- [ Content-Length, { as: absent } ]
 
     server-response:
       headers:
@@ -213,7 +216,7 @@ sessions:
         fields:
         - [ :method, { value: GET, as: equal } ]
         - [ :scheme, { value: https, as: equal } ]
-        - [ :authority, { value: example.data.com, as: equal } ]
+        - [ :authority, { value: 127.0.0.1, as: contains } ]
         - [ :path, { value: /b/path, as: equal } ]
         - [ X-Request-Header, { value: test_request, as: equal } ]
 
@@ -265,7 +268,7 @@ sessions:
         fields:
         - [ :method, { value: GET, as: equal } ]
         - [ :scheme, { value: https, as: equal } ]
-        - [ :authority, { value: example.data.com, as: equal } ]
+        - [ :authority, { value: 127.0.0.1, as: contains } ]
         - [ :path, { value: /b/path, as: equal } ]
         - [ X-Request-Header, { value: test_request, as: equal } ]
 

--- a/test/autests/gold_tests/http2/replay_files/set_alpn.yaml
+++ b/test/autests/gold_tests/http2/replay_files/set_alpn.yaml
@@ -49,7 +49,8 @@ sessions:
 
       headers:
         fields:
-        - [ Host, { value: example.data.com, as: equal } ]
+        # Our Python httpx test proxy does not send a Host header.
+        #- [ Host, { value: example.data.com, as: equal } ]
         - [ Content-Length, { value: "0", as: equal } ]
 
     server-response:

--- a/test/autests/test-env-check.sh
+++ b/test/autests/test-env-check.sh
@@ -8,16 +8,16 @@
 python3 - << _END_
 import sys
 
-if sys.version_info.major < 3 or sys.version_info.minor < 6:
+if sys.version_info.major < 3 or sys.version_info.minor < 10:
     exit(1)
 _END_
 
 if [ $? = 1 ]
 then
-    echo "Python 3.6 or newer is not installed/enabled."
+    echo "Python 3.10 or newer is not installed/enabled."
     exit 1
 else
-    echo "Python 3.6 or newer detected!"
+    echo "Python 3.10 or newer detected!"
 fi
 
 # check for python development header -- for autest


### PR DESCRIPTION
hyper, heretofore our test proxy's HTTP/2 package, is no longer
supported and does not work with Python 3.10. We therefore need to
switch it out for a different HTTP/2 Python package. httpx is the
recommended replacement by the final commit in hyper and seems to work
OK.

Switch to httpx goes pretty well, but the server gold file expectations
need to be updated because httpx is "smarter" about accept-*,
user-agent, host headers, and the like.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
