### PR TITLE
Make chunk processing more strict.

### DIFF
--- a/local/include/core/http.h
+++ b/local/include/core/http.h
@@ -698,6 +698,11 @@ public:
   std::tuple<ssize_t, std::error_code>
   transmit(Session &session, swoc::TextView data, size_t chunk_size = 4096);
 
+public:
+  /** The content of a zero-sized chunk, which is the final chunk that is sent.
+   */
+  static constexpr swoc::TextView ZERO_CHUNK{"0\r\n\r\n"};
+
 protected:
   size_t _size = 0; ///< Size of the current chunking being decoded.
   size_t _off = 0;  ///< Number of bytes in the current chunk already sent to the callback.


### PR DESCRIPTION
Enforce at least an empty chunk response body for chunked responses.
This will catch issues from the proxy.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
