### PR TITLE
Print the proxy's incoming ALPN string on the verifier server

### DIFF
--- a/local/src/core/https.cc
+++ b/local/src/core/https.cc
@@ -115,13 +115,15 @@ alpn_select_next_proto_cb(
   if (SSL_select_next_proto(const_cast<unsigned char **>(out), outlen, alpn, alpn_len, in, inlen) ==
       OPENSSL_NPN_NEGOTIATED)
   {
-    errata.note(S_DIAG, "Negotiated alpn: {}", TextView{(char *)*out, (size_t)*outlen});
+    errata.note(S_DIAG, "Negotiated ALPN from client ALPN list: {}: {}",
+        TextView{(char *)in, (size_t)inlen},
+        TextView{(char *)*out, (size_t)*outlen});
     return SSL_TLSEXT_ERR_OK;
   } else {
     errata.note(
         S_ERROR,
         R"(Failed to find a an ALPN match: server ALPN list: "{}", client ALPN list: "{}")",
-        TextView((char *)alpn, (size_t)alpn_len),
+        TextView{(char *)alpn, (size_t)alpn_len},
         TextView{(char *)in, (size_t)inlen});
   }
   *out = nullptr;


### PR DESCRIPTION
Printing the ALPN string from the proxy can be helpful for ALPN
behavior confirmation.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
