### PR TITLE
build_library_dependencies.sh: chmod the install dir

### DIFF
--- a/tools/build_library_dependencies.sh
+++ b/tools/build_library_dependencies.sh
@@ -43,6 +43,7 @@ SUDO=""
     mkdir -p ${install_dir} || \
     sudo mkdir -p ${install_dir}
 [ -w "${install_dir}" ] || SUDO=sudo
+sudo chmod -R ugo+rX ${install_dir}
 
 mkdir -p ${install_dir}
 repo_dir=/var/tmp/http3_dependency_repos_$$


### PR DESCRIPTION
For users whose root mask is restricted, we chmod the output directies so they are group/other readable. This applies that chmod to the install dir itself.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
