### PR TITLE
Add the await directive for HTTP/2 streams.

### DIFF
--- a/local/include/core/YamlParser.h
+++ b/local/include/core/YamlParser.h
@@ -63,6 +63,7 @@ static const std::string YAML_HTTP_STATUS_KEY{"status"};
 static const std::string YAML_HTTP_REASON_KEY{"reason"};
 static const std::string YAML_HTTP_METHOD_KEY{"method"};
 static const std::string YAML_HTTP_SCHEME_KEY{"scheme"};
+static const std::string YAML_HTTP_AWAIT_KEY{"await"};
 static const std::string YAML_HTTP2_KEY{"http2"};
 static const std::string YAML_HTTP2_PSEUDO_METHOD_KEY{":method"};
 static const std::string YAML_HTTP2_PSEUDO_SCHEME_KEY{":scheme"};

--- a/local/include/core/http.h
+++ b/local/include/core/http.h
@@ -534,6 +534,13 @@ public:
 
   bool _verify_strictly;
 
+  /** The keys upon which to await a response before running this transaction.
+   *
+   * Since HTTP/1 transactions are serialized anyway, this has no impact there.
+   * But for HTTP/2 and HTTP/3 transactions, this can be helpful.
+   */
+  std::vector<std::string> _keys_to_await;
+
 protected:
   class Binding : public swoc::bwf::NameBinding
   {

--- a/local/include/core/http2.h
+++ b/local/include/core/http2.h
@@ -17,6 +17,7 @@
 #include <nghttp2/nghttp2.h>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 
 #include "swoc/BufferWriter.h"
 #include "swoc/Errata.h"
@@ -156,8 +157,10 @@ public:
    *
    * @param[in] stream_id The stream identifier for which the end stream has
    * been processed.
+   *
+   * @param[in] key The key for the finished stream.
    */
-  void set_stream_has_ended(int32_t stream_id);
+  void set_stream_has_ended(int32_t stream_id, std::string_view key);
 
   /// Whether an entire stream has been received and is ready for processing.
   bool get_a_stream_has_ended() const;
@@ -198,6 +201,13 @@ private:
   nghttp2_nv tv_to_nv(char const *name, swoc::TextView v);
   void set_expected_response_for_last_request(HttpHeader const &response);
 
+  /** Determine whether the transaction is still awaiting upon other configured streams.
+   *
+   * @param[in] txn The transaction to check.
+   * @return Whether the transaction is still awaiting upon other configured streams.
+   */
+  bool request_has_outstanding_stream_dependencies(HttpHeader const &request) const;
+
 private:
   /// Whether this session is for a listening server.
   bool _is_server = false;
@@ -228,4 +238,7 @@ private:
 
   /// The system status code. This is set to non-zero if problems are detected.
   static int *process_exit_code;
+
+  /// The set of streams which have completed already.
+  std::unordered_set<std::string> _finished_streams;
 };

--- a/local/include/core/http3.h
+++ b/local/include/core/http3.h
@@ -20,6 +20,7 @@
 #include <random>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "swoc/BufferWriter.h"
@@ -343,8 +344,10 @@ public:
    *
    * @param[in] stream_id The stream identifier for which the end stream has
    * been processed.
+   *
+   * @param[in] key The key for the stream which ended.
    */
-  void set_stream_has_ended(int64_t stream_id);
+  void set_stream_has_ended(int64_t stream_id, std::string_view key);
 
   /// Whether an entire stream has been received and is ready for processing.
   bool get_a_stream_has_ended() const;
@@ -390,12 +393,22 @@ private:
 
   swoc::Errata receive_responses();
 
+  /** Determine whether the transaction is still awaiting upon other configured streams.
+   *
+   * @param[in] txn The transaction to check.
+   * @return Whether the transaction is still awaiting upon other configured streams.
+   */
+  bool request_has_outstanding_stream_dependencies(HttpHeader const &request) const;
+
 private:
   /** The streams which have completed */
   std::deque<int64_t> _ended_streams;
   swoc::IPEndpoint const *_endpoint = nullptr;
 
   std::shared_ptr<H3StreamState> _last_added_stream;
+
+  /// The set of streams which have completed already.
+  std::unordered_set<std::string> _finished_streams;
 
   /** The client context to use for HTTP/3 connections.
    *

--- a/local/src/core/YamlParser.cc
+++ b/local/src/core/YamlParser.cc
@@ -129,6 +129,30 @@ YamlParser::populate_http_message(YAML::Node const &node, HttpHeader &message)
     }
   }
 
+  if (auto const &await{node[YAML_HTTP_AWAIT_KEY]}; await) {
+    if (await.IsScalar()) {
+      message._keys_to_await.emplace_back(await.Scalar());
+    } else if (await.IsSequence()) {
+      for (auto const &key : await) {
+        if (key.IsScalar()) {
+          message._keys_to_await.emplace_back(key.Scalar());
+        } else {
+          errata.note(
+              S_ERROR,
+              R"("{}" value at {} must be a scalar or a sequence of scalars.)",
+              YAML_HTTP_AWAIT_KEY,
+              key.Mark());
+        }
+      }
+    } else {
+      errata.note(
+          S_ERROR,
+          R"("{}" at {} must be a scalar or sequence.)",
+          YAML_HTTP_AWAIT_KEY,
+          await.Mark());
+    }
+  }
+
   YAML::Node headers_frame = node;
   YAML::Node data_frame = node;
   YAML::Node rst_stream_frame;

--- a/test/autests/gold_tests/await/await.replay.yaml
+++ b/test/autests/gold_tests/await/await.replay.yaml
@@ -1,0 +1,121 @@
+# @file
+#
+# Copyright 2022, Verizon Media
+# SPDX-License-Identifier: Apache-2.0
+#
+
+meta:
+    version: '1.0'
+
+sessions:
+
+- protocol:
+  - name: http
+    version: 2
+  - name: tls
+    sni: test_sni
+  - name: tcp
+  - name: ip
+
+  transactions:
+
+  - client-request:
+      headers:
+        fields:
+        - [ :method, GET ]
+        - [ :scheme, https ]
+        - [ :authority, www.example.com ]
+        - [ :path, /pictures/flower.jpeg ]
+        - [ Content-Type, image/jpeg ]
+        - [ uuid, first-request ]
+
+    proxy-request:
+      url:
+      - [ path, { value: flower.jpeg, as: contains } ]
+
+    server-response:
+
+      # Make the server slow to respond in order to verify that the await
+      # directive worked as expected.
+      delay: 2s
+      headers:
+        fields:
+        - [ :status, 200 ]
+        - [ Content-Type, image/jpeg ]
+        - [ X-Response, first-response ]
+      content:
+        size: 3432
+
+    proxy-response:
+      status: 200
+      headers:
+        fields:
+        - [ X-Response, first-response ]
+
+  - client-request:
+
+      # This await should cause the client to hold off on sending this request until
+      # first-request is completed.
+      await: first-request
+
+      headers:
+        fields:
+        - [ :method, GET ]
+        - [ :scheme, https ]
+        - [ :authority, www.example.com ]
+        - [ :path, /pictures/flower.jpeg ]
+        - [ Content-Type, image/jpeg ]
+        - [ uuid, second-request ]
+
+    proxy-request:
+      url:
+      - [ path, { value: flower.jpeg, as: contains } ]
+
+    server-response:
+      headers:
+        fields:
+        - [ :status, 200 ]
+        - [ Content-Type, image/jpeg ]
+        - [ X-Response, second-response ]
+      content:
+        size: 3432
+
+    proxy-response:
+      status: 200
+      headers:
+        fields:
+        - [ X-Response, second-response ]
+
+  - client-request:
+
+      # This await should cause the client to hold off on sending this request
+      # until both first-request and second-request responses are received.
+      await: [first-request, second-request]
+
+      headers:
+        fields:
+        - [ :method, GET ]
+        - [ :scheme, https ]
+        - [ :authority, www.example.com ]
+        - [ :path, /pictures/flower.jpeg ]
+        - [ Content-Type, image/jpeg ]
+        - [ uuid, third-request ]
+
+    proxy-request:
+      url:
+      - [ path, { value: flower.jpeg, as: contains } ]
+
+    server-response:
+      headers:
+        fields:
+        - [ :status, 200 ]
+        - [ Content-Type, image/jpeg ]
+        - [ X-Response, third-response ]
+      content:
+        size: 3432
+
+    proxy-response:
+      status: 200
+      headers:
+        fields:
+        - [ X-Response, third-response ]

--- a/test/autests/gold_tests/await/await.test.py
+++ b/test/autests/gold_tests/await/await.test.py
@@ -1,0 +1,42 @@
+'''
+Verify correct handling of the transaction await directive.
+'''
+# @file
+#
+# Copyright 2022, Verizon Media
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import re
+
+Test.Summary = __doc__
+
+#
+# Test 1: Run a few transactions with the await directive.
+#
+r = Test.AddTestRun("Verify correct handling of the await directive")
+client = r.AddClientProcess("client_await", "await.replay.yaml")
+server = r.AddServerProcess("server_await", "await.replay.yaml")
+proxy = r.AddProxyProcess(
+    "proxy_await",
+    listen_port=client.Variables.https_port,
+    server_port=server.Variables.https_port,
+    use_ssl=True,
+    use_http2_to_2=True)
+
+server.Streams.stdout += Testers.ContainsExpression(
+    "Ready with 3 transactions.",
+    "The server should have parsed 3 transactions.")
+
+# Make sure that the entire first-request finishes before second-request
+# starts. And, further, that the entire second-request finishes before
+# third-request starts.
+client.Streams.stdout += Testers.ContainsExpression(
+    "Sent the following HTTP/2 request headers for key first-request.*"
+    "Received an HTTP/2 body of 3432 bytes for key first-request.*"
+    "Sent the following HTTP/2 request headers for key second-request.*"
+    "Received an HTTP/2 body of 3432 bytes for key second-request.*",
+    "Sent the following HTTP/2 request headers for key third-request.*"
+    "Received an HTTP/2 body of 3432 bytes for key third-request.*",
+    "second-request should start only after first-request finishes.",
+    reflags=re.MULTILINE | re.DOTALL)


### PR DESCRIPTION
Add the ability to specify that a stream should not be sent until the responses for a set of streams are received.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
