### PR TITLE
Fix response status string parsing

### DIFF
--- a/local/src/core/http.cc
+++ b/local/src/core/http.cc
@@ -633,7 +633,7 @@ HttpHeader::parse_response(swoc::TextView data)
       _status = swoc::svtou(status);
       _status_string = std::string(status);
 
-      auto reason{status_start.ltrim_if(&isspace).take_prefix_if(&isspace)};
+      auto reason{status_start.trim_if(&isspace)};
       _reason = reason;
       set_is_response();
 

--- a/test/autests/gold_tests/http/http.test.py
+++ b/test/autests/gold_tests/http/http.test.py
@@ -57,6 +57,10 @@ client.Streams.stdout += Testers.ContainsExpression(
     "Loading 2 replay files.",
     "Verify that 2 replay files were parsesd.")
 
+client.Streams.stdout += Testers.ContainsExpression(
+    "204 No Content",
+    "Verify the No Content reason string.")
+
 client.Streams.stdout += Testers.ExcludesExpression(
     "Violation:",
     "There should be no verification errors because there are none added.")


### PR DESCRIPTION
We only printed the first word of the response status string. This fixes HTTP/1 response string parsing to include multiple words.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
