### PR TITLE
Fix top-level crash when no arguments provided

### DIFF
--- a/local/src/core/ArgParser.cc
+++ b/local/src/core/ArgParser.cc
@@ -189,6 +189,9 @@ ArgParser::parse(const char **argv)
     }
     command->help_message(msg);
   }
+  if (!ret.has_action()) {
+    _top_level_command.help_message("No command or top-level option provided");
+  }
   return ret;
 }
 


### PR DESCRIPTION
The ArgParser::invoke() function will raise an exception, resulting in a crash, if no top-level arguments are provided to verifier-client or verifier-server. Rather than crashing, this patch exits early with an error string and a help message if no commands or options are provided.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
