### PR TITLE
Fix HTTP/1.x explicit version replay.

### DIFF
--- a/local/include/core/YamlParser.h
+++ b/local/include/core/YamlParser.h
@@ -63,6 +63,7 @@ static const std::string YAML_HTTP_STATUS_KEY{"status"};
 static const std::string YAML_HTTP_REASON_KEY{"reason"};
 static const std::string YAML_HTTP_METHOD_KEY{"method"};
 static const std::string YAML_HTTP_SCHEME_KEY{"scheme"};
+static const std::string YAML_HTTP_VERSION_KEY{"version"};
 static const std::string YAML_HTTP_AWAIT_KEY{"await"};
 static const std::string YAML_HTTP2_KEY{"http2"};
 static const std::string YAML_HTTP2_PSEUDO_METHOD_KEY{":method"};

--- a/local/src/core/YamlParser.cc
+++ b/local/src/core/YamlParser.cc
@@ -277,6 +277,23 @@ YamlParser::populate_http_message(YAML::Node const &node, HttpHeader &message)
     }
   }
 
+  if (auto const &version_node{headers_frame[YAML_HTTP_VERSION_KEY]}; version_node) {
+    if (version_node.IsScalar()) {
+      message._http_version = Localizer::localize(version_node.Scalar());
+      // The message._http_protocol will already, by default, be HTTP_1. For
+      // HTTP/2 and HTTP/3, it is the responsibility of session-parsing (as
+      // opposed to this transaction parsing) to set the _http_protocol
+      // correctly via set_is_http2() or set_is_http3().
+      assert(message.is_http1());
+    } else {
+      errata.note(
+          S_ERROR,
+          R"("{}" value at {} must be a string.)",
+          YAML_HTTP_VERSION_KEY,
+          version_node.Mark());
+    }
+  }
+
   if (headers_frame[YAML_HDR_KEY]) {
     auto hdr_node{headers_frame[YAML_HDR_KEY]};
     if (hdr_node[YAML_FIELDS_KEY]) {

--- a/test/autests/gold_tests/http/http.test.py
+++ b/test/autests/gold_tests/http/http.test.py
@@ -50,28 +50,32 @@ proxy = r.AddProxyProcess("proxy2", listen_port=client.Variables.http_port,
 
 
 client.Streams.stdout = Testers.ContainsExpression(
-    "6 transactions in 4 sessions",
-    "Verify that 6 transactions were parsed.")
+    "7 transactions in 5 sessions",
+    "Verify that 7 transactions were parsed.")
 
 client.Streams.stdout += Testers.ContainsExpression(
-    "Loading 2 replay files.",
-    "Verify that 2 replay files were parsesd.")
+    "Loading 3 replay files.",
+    "Verify that 3 replay files were parsesd.")
 
 client.Streams.stdout += Testers.ContainsExpression(
     "204 No Content",
     "Verify the No Content reason string.")
+
+client.Streams.stdout += Testers.ContainsExpression(
+    "POST /some/request HTTP/1.0",
+    "Verify that we sent the HTTP/1.0 version.")
 
 client.Streams.stdout += Testers.ExcludesExpression(
     "Violation:",
     "There should be no verification errors because there are none added.")
 
 server.Streams.stdout = Testers.ContainsExpression(
-    "Ready with 6 transactions.",
-    "Verify that 6 transactions were parsed.")
+    "Ready with 7 transactions.",
+    "Verify that 7 transactions were parsed.")
 
 server.Streams.stdout += Testers.ContainsExpression(
-    "Loading 2 replay files",
-    "Verify that 2 replay files were parsed.")
+    "Loading 3 replay files",
+    "Verify that 3 replay files were parsed.")
 
 server.Streams.stdout += Testers.ExcludesExpression(
     "Violation:",

--- a/test/autests/gold_tests/http/replay_files/multiple_transactions/file3.yaml
+++ b/test/autests/gold_tests/http/replay_files/multiple_transactions/file3.yaml
@@ -1,0 +1,32 @@
+# @file
+#
+# Copyright 2022, Verizon Media
+# SPDX-License-Identifier: Apache-2.0
+#
+
+meta:
+  version: "1.0"
+
+sessions:
+- transactions:
+  - client-request:
+      method: "POST"
+      version: "1.0"
+      url: /some/request
+      headers:
+        fields:
+        - [ Host, example.com ]
+        - [ Content-Length, 32 ]
+        - [ uuid, 51 ]
+        - [ X-Request, request ]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Content-Length, 16 ]
+        - [ X-Response, response ]
+
+    proxy-response:
+      status: 200


### PR DESCRIPTION
This fixes the explicit setting of the HTTP/1.0 or HTTP/1.1 string in the replay file via the version string.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
