### PR TITLE
Added PROXY protocol support

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -14,4 +14,4 @@ python_version = "3"
 
 [packages]
 scons = "*"
-scons-parts = "==v0.17.0"
+scons-parts = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -14,4 +14,4 @@ python_version = "3"
 
 [packages]
 scons = "*"
-scons-parts = "*"
+scons-parts = "==v0.17.0"

--- a/local/include/core/YamlParser.h
+++ b/local/include/core/YamlParser.h
@@ -44,6 +44,7 @@ static const std::string YAML_SSN_PROTOCOL_NAME{"name"};
 static const std::string YAML_SSN_PROTOCOL_VERSION{"version"};
 static const std::string YAML_SSN_PROTOCOL_TLS_NAME{"tls"};
 static const std::string YAML_SSN_PROTOCOL_HTTP_NAME{"http"};
+static const std::string YAML_SSN_PROTOCOL_PP_NAME{"proxy-protocol"};
 static const std::string YAML_SSN_TLS_SNI_KEY{"sni"};
 static const std::string YAML_SSN_TLS_ALPN_PROTOCOLS_KEY{"alpn-protocols"};
 static const std::string YAML_SSN_TLS_VERIFY_MODE_KEY{"verify-mode"};

--- a/local/include/core/http.h
+++ b/local/include/core/http.h
@@ -698,8 +698,7 @@ public:
 
   virtual swoc::Rv<std::shared_ptr<HttpHeader>> read_and_parse_request(swoc::FixedBufferWriter &w);
 
-  /**
-   * Peeks at the socket for PROXY header data. Consume from the session socket
+  /** Peeks at the socket for PROXY header data. Consume from the session socket
    * and parse it if it detects a valid header.
    */
   virtual swoc::Errata read_and_parse_proxy_hdr();
@@ -708,7 +707,6 @@ public:
    *
    * @param[in] real_target The target of the session
    * @param[in] pp_version The version of the PROXY protocol to use
-   *
    */
   virtual swoc::Errata send_proxy_header(
       swoc::IPEndpoint const *real_target,

--- a/local/include/core/http.h
+++ b/local/include/core/http.h
@@ -180,8 +180,13 @@ inline namespace SWOC_VERSION_NS
 {
 BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, HttpHeader const &h);
 
-// formatter for ProxyProtocolUtil which prety-prints the proxy protocol in v1
-// format
+/** Formatter for ProxyProtocolUtil which pretty-prints the proxy protocol in
+ * the human-readable v1 format
+ * @param[out] w The BufferWriter to write to.
+ * @param[in] spec Format specifier for output.
+ * @param[in] h The ProxyProtocolUtil to print out.
+ * @return w The BufferWriter passed in.
+ */
 BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, ProxyProtocolUtil const &h);
 } // namespace SWOC_VERSION_NS
 } // namespace swoc
@@ -621,8 +626,8 @@ struct Ssn
   bool is_tls = false;
   bool is_h2 = false;
   bool is_h3 = false;
-  // The PROXY protocol version to use for this session. If NONE, no PROXY
-  // header is sent
+  /// The PROXY protocol version to use for this session. If NONE, no PROXY
+  /// header is sent.
   ProxyProtocolVersion pp_version = ProxyProtocolVersion::NONE;
 
   swoc::Errata post_process_transactions();

--- a/local/include/core/http3.h
+++ b/local/include/core/http3.h
@@ -297,7 +297,10 @@ public:
 
   /** Establish a QUIC connection from the given interface to the given IP
    * address. */
-  swoc::Errata do_connect(swoc::TextView interface, swoc::IPEndpoint const *target) override;
+  swoc::Errata do_connect(
+      swoc::TextView interface,
+      swoc::IPEndpoint const *target,
+      ProxyProtocolVersion pp_version = ProxyProtocolVersion::NONE) override;
 
   /** Perform HTTP/3 global initialization.
    *

--- a/local/include/core/http3.h
+++ b/local/include/core/http3.h
@@ -296,7 +296,12 @@ public:
   swoc::Errata connect() override;
 
   /** Establish a QUIC connection from the given interface to the given IP
-   * address. */
+   * address.
+   *
+   * @note: the pp_version parameter is added to fit the override signature of
+   * do_connect(). There is no current support for PROXY Protocol for QUIC
+   * connections.
+   */
   swoc::Errata do_connect(
       swoc::TextView interface,
       swoc::IPEndpoint const *target,

--- a/local/include/core/proxy_protocol_util.h
+++ b/local/include/core/proxy_protocol_util.h
@@ -1,5 +1,5 @@
 /** @file
- * Common data structures and definitions for Proxy Verifier tools.
+ * Common data structures and definitions for the PROXY protocol utility
  *
  * Copyright 2023, Verizon Media
  * SPDX-License-Identifier: Apache-2.0

--- a/local/include/core/proxy_protocol_util.h
+++ b/local/include/core/proxy_protocol_util.h
@@ -1,0 +1,118 @@
+/** @file
+ * Common data structures and definitions for Proxy Verifier tools.
+ *
+ * Copyright 2023, Verizon Media
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "swoc/Errata.h"
+#include "swoc/BufferWriter.h"
+#include "swoc/TextView.h"
+#include "swoc/swoc_ip.h"
+
+// PROXY header version
+enum class ProxyProtocolVersion { NONE = 0, V1 = 1, V2 = 2 };
+
+// PROXY header v1 end of header.
+static constexpr swoc::TextView PROXY_V1_EOH{"\r\n"};
+
+// The maximum size of a PROXY header(v1 and v2) without the TLV support.  This
+// is used to specify the data size to peek from the socket.
+static constexpr size_t MAX_PP_HDR_SIZE = 108;
+
+// V1 and V2 header signatures
+using namespace std::literals;
+static const swoc::TextView V1SIG("PROXY");
+constexpr swoc::TextView V2SIG = "\x0D\x0A\x0D\x0A\x00\x0D\x0A\x51\x55\x49\x54\x0A"sv;
+
+static constexpr char PP_V1_DELIMITER = ' ';
+
+// This is the union taken from the RFC that specifies v1 and v2 PROXY header.
+// Note that the linux socket address is removed from the v2 header, as it is
+// not supported in Proxy Verifier.
+union ProxyHdr {
+  struct
+  {
+    char line[108];
+  } v1;
+  struct
+  {
+    uint8_t sig[12];
+    uint8_t ver_cmd;
+    uint8_t fam;
+    uint16_t len;
+    union {
+      struct
+      { /* for TCP/UDP over IPv4, len = 12 */
+        uint32_t src_addr;
+        uint32_t dst_addr;
+        uint16_t src_port;
+        uint16_t dst_port;
+      } ip4;
+      struct
+      { /* for TCP/UDP over IPv6, len = 36 */
+        uint8_t src_addr[16];
+        uint8_t dst_addr[16];
+        uint16_t src_port;
+        uint16_t dst_port;
+      } ip6;
+    } addr;
+  } v2;
+};
+
+class ProxyProtocolUtil
+{
+public:
+  ProxyProtocolUtil() = default;
+  ProxyProtocolUtil(swoc::IPEndpoint src_ep, swoc::IPEndpoint dst_ep, ProxyProtocolVersion version)
+    : _version(version)
+    , _src_addr(src_ep)
+    , _dst_addr(dst_ep){};
+
+  /** Parse the data as a PROXY header
+   *
+   * @param[in] data The data to parse.
+   * @return return the number of bytes of parsed PROXY header if it is valid or
+   * -1 otherwise.
+   */
+  swoc::Rv<ssize_t> parse_header(swoc::TextView data);
+
+  /** Serialize the PROXY header into the buffer.
+   *
+   * @param[out] buf The buffer to write the PROXY header.
+   */
+  swoc::Errata serialize(swoc::BufferWriter &buf) const;
+  ProxyProtocolVersion get_version() const;
+  swoc::IPEndpoint get_src_ep() const;
+  swoc::IPEndpoint get_dst_ep() const;
+
+private:
+  swoc::Rv<ssize_t> parse_pp_header_v1(swoc::TextView data);
+  swoc::Rv<ssize_t> parse_pp_header_v2(swoc::TextView data);
+  swoc::Errata construct_v1_header(swoc::BufferWriter &buf) const;
+  swoc::Errata construct_v2_header(swoc::BufferWriter &buf) const;
+
+  ProxyProtocolVersion _version = ProxyProtocolVersion::NONE;
+  swoc::IPEndpoint _src_addr;
+  swoc::IPEndpoint _dst_addr;
+};
+
+inline ProxyProtocolVersion
+ProxyProtocolUtil::get_version() const
+{
+  return _version;
+}
+
+inline swoc::IPEndpoint
+ProxyProtocolUtil::get_src_ep() const
+{
+  return _src_addr;
+}
+
+inline swoc::IPEndpoint
+ProxyProtocolUtil::get_dst_ep() const
+{
+  return _dst_addr;
+}

--- a/local/include/core/proxy_protocol_util.h
+++ b/local/include/core/proxy_protocol_util.h
@@ -12,26 +12,28 @@
 #include "swoc/TextView.h"
 #include "swoc/swoc_ip.h"
 
-// PROXY header version
+/// PROXY header version
 enum class ProxyProtocolVersion { NONE = 0, V1 = 1, V2 = 2 };
 
-// PROXY header v1 end of header.
+/// PROXY header v1 end of header.
 static constexpr swoc::TextView PROXY_V1_EOH{"\r\n"};
 
-// The maximum size of a PROXY header(v1 and v2) without the TLV support.  This
-// is used to specify the data size to peek from the socket.
+/// The maximum size of a PROXY header(v1 and v2) without the TLV support.  This
+/// is used to specify the data size to peek from the socket.
 static constexpr size_t MAX_PP_HDR_SIZE = 108;
 
-// V1 and V2 header signatures
+/// V1 and V2 header signatures
 using namespace std::literals;
 static const swoc::TextView V1SIG("PROXY");
 constexpr swoc::TextView V2SIG = "\x0D\x0A\x0D\x0A\x00\x0D\x0A\x51\x55\x49\x54\x0A"sv;
 
 static constexpr char PP_V1_DELIMITER = ' ';
 
-// This is the union taken from the RFC that specifies v1 and v2 PROXY header.
-// Note that the linux socket address is removed from the v2 header, as it is
-// not supported in Proxy Verifier.
+/// This is the union structure taken from the PROXY protocol specification that
+/// defines v1 and v2 PROXY header:
+/// https://github.com/haproxy/haproxy/blob/master/doc/proxy-protocol.txt. Note
+/// that the linux socket address is removed from the v2 header, as it is not
+/// supported in Proxy Verifier.
 union ProxyHdr {
   struct
   {
@@ -84,8 +86,25 @@ public:
    * @param[out] buf The buffer to write the PROXY header.
    */
   swoc::Errata serialize(swoc::BufferWriter &buf) const;
+
+  /** Return the version of the parsed PROXY header.
+   *
+   * @return the version of the PROXY header.
+   */
   ProxyProtocolVersion get_version() const;
+
+  /** Return the IP endpoint representing the source address
+   * in the PROXY header.
+   *
+   * @return the source IP endpoint.
+   */
   swoc::IPEndpoint get_src_ep() const;
+
+  /** Return the IP endpoint representing the destination address
+   * in the PROXY header.
+   *
+   * @return the destination IP endpoint.
+   */
   swoc::IPEndpoint get_dst_ep() const;
 
 private:

--- a/local/src/client/verifier-client.cc
+++ b/local/src/client/verifier-client.cc
@@ -293,7 +293,11 @@ ClientReplayFileHandler::ssn_open(YAML::Node const &node)
             (pp_version_node.Scalar() == "1") ? ProxyProtocolVersion::V1 : ProxyProtocolVersion::V2;
       } else {
         // unspecified or invalid versions
-        errata.note(S_ERROR, "Invalid PROXY protocol version specified.");
+        errata.note(
+            S_ERROR,
+            R"(Invalid PROXY protocol version specified in session at "{}":{}.)",
+            _path,
+            _ssn->_line_no);
         return errata;
       }
     }

--- a/local/src/core/core.part
+++ b/local/src/core/core.part
@@ -43,5 +43,6 @@ def build(env):
             "ProxyVerifier.cc",
             "verification.cc",
             "YamlParser.cc",
+            "proxy_protocol_util.cc",
         ])
     )

--- a/local/src/core/http.cc
+++ b/local/src/core/http.cc
@@ -21,10 +21,13 @@
 #include <sys/uio.h>
 #include <thread>
 #include <unistd.h>
+#include <locale>
+#include <codecvt>
 
 #include "swoc/bwf_ex.h"
 #include "swoc/bwf_ip.h"
 #include "swoc/bwf_std.h"
+#include "swoc/swoc_ip.h"
 
 using swoc::Errata;
 using swoc::TextView;
@@ -76,6 +79,21 @@ bwformat(BufferWriter &w, bwf::Spec const & /* spec */, HttpHeader const &h)
     }
     w.print(R"({}: {}{})", key, value, '\n');
   }
+  return w;
+}
+// custom formatting for the proxy header
+BufferWriter &
+bwformat(BufferWriter &w, bwf::Spec const & /*spec*/, ProxyProtocolUtil const &h)
+{
+  auto src_addr = h.get_src_ep();
+  auto dst_addr = h.get_dst_ep();
+  w.print("Received PROXY header v{}:\n", static_cast<int>(h.get_version()));
+  w.print(
+      "PROXY {}{} {2::a} {3::a} {2::p} {3::p}",
+      swoc::bwf::If(src_addr.is_ip4(), "TCP4"),
+      swoc::bwf::If(src_addr.is_ip6(), "TCP6"),
+      src_addr,
+      dst_addr);
   return w;
 }
 } // namespace SWOC_VERSION_NS
@@ -417,7 +435,8 @@ HttpHeader::verify_headers(swoc::TextView transaction_key, HttpFields const &rul
         }
       } else {
         if (!rule_check
-                 ->test(transaction_key, field_iter->first, swoc::TextView(field_iter->second))) {
+                 ->test(transaction_key, field_iter->first, swoc::TextView(field_iter->second)))
+        {
           issue_exists = true;
         }
       }
@@ -684,7 +703,8 @@ HttpHeader::Binding::operator()(BufferWriter &w, const swoc::bwf::Spec &spec) co
   if (name.starts_with_nocase(FIELD_PREFIX)) {
     name.remove_prefix(FIELD_PREFIX.size());
     if (auto spot{_hdr._fields_rules->_fields.find(name)};
-        spot != _hdr._fields_rules->_fields.end()) {
+        spot != _hdr._fields_rules->_fields.end())
+    {
       bwformat(w, spec, spot->second);
     } else {
       bwformat(w, spec, TRANSACTION_KEY_NOT_SET);
@@ -708,6 +728,45 @@ Session::~Session()
   this->close();
 }
 
+swoc::Rv<ssize_t>
+Session::peek(swoc::MemSpan<char> span)
+{
+  // This is pretty similar to the Session::read() method but here we are
+  // calling recv() with MSG_PEEK to get the data without removing it from the
+  // socket buffer.
+  swoc::Rv<ssize_t> zret{::recv(_fd, span.data(), span.size(), MSG_PEEK)};
+  if (zret == 0) {
+    // End of file.
+    this->close();
+  } else if (zret < 0) {
+    if (errno == EAGAIN || errno == EWOULDBLOCK) {
+      auto &&[poll_return, poll_errata] = poll_for_data_on_socket(Poll_Timeout);
+      zret.note(std::move(poll_errata));
+      if (!zret.is_ok()) {
+        zret.note(std::move(poll_errata));
+        zret.note(S_ERROR, "Failed to poll for data.");
+        this->close();
+      } else if (poll_return > 0) {
+        // Simply repeat the read now that poll says something is ready.
+        return peek(span);
+      } else if (poll_return == 0) {
+        zret.note(S_ERROR, "Poll timed out waiting for content.");
+        this->close();
+      } else if (poll_return < 0) {
+        // Connection was closed. Nothing to do.
+        zret.note(S_DIAG, "The peer closed the connection while reading during poll.");
+      }
+    } else if (errno == ECONNRESET) {
+      // The other end closed the connection.
+      zret.note(S_DIAG, "The peer closed the connection while reading.");
+      this->close();
+    } else {
+      zret.note(S_ERROR, "Error reading from socket: {}", swoc::bwf::Errno{});
+      this->close();
+    }
+  }
+  return zret;
+}
 swoc::Rv<ssize_t>
 Session::read(swoc::MemSpan<char> span)
 {
@@ -776,6 +835,42 @@ Session::read_and_parse_request(swoc::FixedBufferWriter &buffer)
   return zret;
 }
 
+swoc::Errata
+Session::read_and_parse_proxy_hdr()
+{
+  // reading the PROXY data if any. A signle recv() should be sufficient as mentioned in the RFC
+  swoc::Errata errata;
+  swoc::LocalBufferWriter<MAX_PP_HDR_SIZE> w;
+  // Peek at the data to make sure it's a PROXY header
+  errata.note(S_DIAG, "Peeking at the socketdata to check PROXY header");
+  auto zret = peek(w.aux_span());
+  if (!zret.is_ok()) {
+    errata.note(S_ERROR, "Failed to peek at the socket data");
+    errata.note(std::move(zret.errata()));
+    return errata;
+  }
+  errata.note(std::move(zret.errata()));
+  if (zret.result() <= 0) {
+    // peek gets no data
+    return errata;
+  }
+  w.commit(zret.result());
+  // try to parse the PROXY header
+  ProxyProtocolUtil ppUtil;
+  errata.note(S_DIAG, "Attempting to parse PROXY header", w.size());
+  auto &&[ppNumBytes, ppParseErrata] = ppUtil.parse_header(w.view());
+  errata.note(std::move(ppParseErrata));
+  if (ppNumBytes > 0) {
+    errata.note(S_DIAG, "Got {} of pp bytes. consuming it from socket.", ppNumBytes);
+    char unusedBuf[ppNumBytes];
+    recv(_fd, unusedBuf, ppNumBytes, 0); // Peek at the data
+    // print the proxy message
+    errata.note(S_INFO, "{}", ppUtil);
+  } else {
+    errata.note(S_DIAG, "No valid PROXY header found, passing through.");
+  }
+  return errata;
+}
 swoc::Rv<ssize_t>
 Session::write(TextView view)
 {
@@ -816,6 +911,26 @@ Session::write(TextView view)
     }
   }
   return zret;
+}
+swoc::Errata
+Session::send_proxy_header(swoc::IPEndpoint const *real_target, ProxyProtocolVersion pp_version)
+{
+  swoc::Errata errata;
+  // get source/local endpoint
+  struct sockaddr addr;
+  socklen_t len = sizeof(addr);
+  getsockname(_fd, &addr, &len);
+  swoc::IPEndpoint source_endpoint{&addr};
+  // construct the PROXY header
+  ProxyProtocolUtil ppUtil(source_endpoint, *real_target, pp_version);
+  swoc::LocalBufferWriter<MAX_PP_HDR_SIZE> w;
+  auto pp_serialize_errata = ppUtil.serialize(w);
+  errata.note(std::move(pp_serialize_errata));
+  // send the data
+  errata.note(S_DIAG, "Sending PROXY header from {} to {}", source_endpoint, *real_target);
+  // write to socket
+  Session::write(w.view());
+  return errata;
 }
 
 swoc::Rv<ssize_t>
@@ -1552,7 +1667,10 @@ InterfaceNameToEndpoint::find_ip_endpoint()
 }
 
 Errata
-Session::do_connect(TextView interface, swoc::IPEndpoint const *real_target)
+Session::do_connect(
+    TextView interface,
+    swoc::IPEndpoint const *real_target,
+    ProxyProtocolVersion pp_version)
 {
   Errata errata;
   int socket_fd = socket(real_target->family(), SOCK_STREAM, 0);
@@ -1587,6 +1705,16 @@ Session::do_connect(TextView interface, swoc::IPEndpoint const *real_target)
           static const int ONE = 1;
           setsockopt(socket_fd, IPPROTO_TCP, TCP_NODELAY, &ONE, sizeof(ONE));
           if (0 == ::fcntl(socket_fd, F_SETFL, fcntl(socket_fd, F_GETFL, 0) | O_NONBLOCK)) {
+            if (pp_version != ProxyProtocolVersion::NONE) {
+              // The following sleep is to allow the client to postpone
+              // initiating the SSL handshake later. It's observed previously
+              // that sometimes the client would timeout and close the
+              // connection.  Commenting it out works fine currently so this
+              // might be resolved but just leaving it in here in case this
+              // issue arise in the future.
+              // std::this_thread::sleep_for(std::chrono::seconds(1));
+              send_proxy_header(real_target, pp_version);
+            }
             errata.note(this->connect());
           } else {
             errata.note(

--- a/local/src/core/http.cc
+++ b/local/src/core/http.cc
@@ -1706,13 +1706,6 @@ Session::do_connect(
           setsockopt(socket_fd, IPPROTO_TCP, TCP_NODELAY, &ONE, sizeof(ONE));
           if (0 == ::fcntl(socket_fd, F_SETFL, fcntl(socket_fd, F_GETFL, 0) | O_NONBLOCK)) {
             if (pp_version != ProxyProtocolVersion::NONE) {
-              // The following sleep is to allow the client to postpone
-              // initiating the SSL handshake later. It's observed previously
-              // that sometimes the client would timeout and close the
-              // connection.  Commenting it out works fine currently so this
-              // might be resolved but just leaving it in here in case this
-              // issue arise in the future.
-              // std::this_thread::sleep_for(std::chrono::seconds(1));
               send_proxy_header(real_target, pp_version);
             }
             errata.note(this->connect());

--- a/local/src/core/http3.cc
+++ b/local/src/core/http3.cc
@@ -1538,7 +1538,10 @@ H3Session::configure_udp_socket(swoc::TextView interface, swoc::IPEndpoint const
 }
 
 Errata
-H3Session::do_connect(swoc::TextView interface, swoc::IPEndpoint const *target)
+H3Session::do_connect(
+    swoc::TextView interface,
+    swoc::IPEndpoint const *target,
+    ProxyProtocolVersion /*pp_version*/)
 {
   Errata errata = configure_udp_socket(interface, target);
   if (!errata.is_ok()) {
@@ -1865,14 +1868,16 @@ H3Session::~H3Session()
   }
 }
 
-swoc::Rv<ssize_t> H3Session::read(swoc::MemSpan<char> /* span */)
+swoc::Rv<ssize_t>
+H3Session::read(swoc::MemSpan<char> /* span */)
 {
   swoc::Rv<ssize_t> zret{0};
   zret.note(S_ERROR, "HTTP/3 read() called for the unsupported MemSpan overload.");
   return zret;
 }
 
-swoc::Rv<ssize_t> H3Session::write(TextView /* data */)
+swoc::Rv<ssize_t>
+H3Session::write(TextView /* data */)
 {
   swoc::Rv<ssize_t> zret{0};
   zret.note(S_ERROR, "HTTP/3 write() called for the unsupported TextView overload.");

--- a/local/src/core/proxy_protocol_util.cc
+++ b/local/src/core/proxy_protocol_util.cc
@@ -1,3 +1,10 @@
+/** @file
+ * Implementation for the PROXY protocol utility functions.
+ *
+ * Copyright 2023, Verizon Media
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include "core/proxy_protocol_util.h"
 #include "core/ProxyVerifier.h"
 #include <codecvt>
@@ -9,9 +16,6 @@
 using swoc::Errata;
 using swoc::TextView;
 using swoc::IPAddr;
-using swoc::IP4Addr;
-using swoc::IP6Addr;
-using swoc::IPEndpoint;
 
 swoc::Rv<ssize_t>
 ProxyProtocolUtil::parse_pp_header_v1(swoc::TextView data)
@@ -115,8 +119,8 @@ ProxyProtocolUtil::parse_pp_header_v2(swoc::TextView data)
     case 0x21: /* TCPv6 */
     {
       // IPv6 address doesn't have to handle endianess
-      IPAddr srcAddr(reinterpret_cast<const in6_addr&>(hdr->v2.addr.ip6.src_addr));
-      IPAddr dstAddr(reinterpret_cast<const in6_addr&>(hdr->v2.addr.ip6.dst_addr));
+      IPAddr srcAddr(reinterpret_cast<const in6_addr &>(hdr->v2.addr.ip6.src_addr));
+      IPAddr dstAddr(reinterpret_cast<const in6_addr &>(hdr->v2.addr.ip6.dst_addr));
       _src_addr.assign(srcAddr, hdr->v2.addr.ip6.src_port);
       _dst_addr.assign(dstAddr, hdr->v2.addr.ip6.dst_port);
       break;

--- a/local/src/core/proxy_protocol_util.cc
+++ b/local/src/core/proxy_protocol_util.cc
@@ -1,0 +1,223 @@
+#include "core/proxy_protocol_util.h"
+#include "core/ProxyVerifier.h"
+#include <codecvt>
+#include <locale>
+#include "swoc/bwf_ex.h"
+#include "swoc/bwf_ip.h"
+#include "swoc/swoc_ip.h"
+
+using swoc::Errata;
+using swoc::TextView;
+using swoc::IPAddr;
+using swoc::IP4Addr;
+using swoc::IP6Addr;
+using swoc::IPEndpoint;
+
+swoc::Rv<ssize_t>
+ProxyProtocolUtil::parse_pp_header_v1(swoc::TextView data)
+{
+  // parse the data as a PROXY header v1. The data is expected to contain the v1
+  // signature to to enter this function
+  swoc::Rv<ssize_t> zret{-1};
+  size_t size = 0;
+  _version = ProxyProtocolVersion::V1;
+  auto offset = data.find(PROXY_V1_EOH);
+  if (offset == TextView::npos) {
+    // partial or invalid header
+    zret.note(S_ERROR, "Incomplete or invalid PROXY header");
+    return zret;
+  }
+
+  size = offset + PROXY_V1_EOH.size();
+  // Assuming the PROXY header has already been validated, we can just skip the
+  // "PROXY "
+  data += V1SIG.size() + 1;
+  // parse family
+  auto familyView = data.split_prefix_at(PP_V1_DELIMITER);
+  if (familyView.empty()) {
+    zret.note(S_ERROR, "Invalid PROXY header: expecting network family");
+    return zret;
+  }
+
+  // parse source IP address
+  auto srcIPView = data.split_prefix_at(PP_V1_DELIMITER);
+  if (srcIPView.empty()) {
+    zret.note(S_ERROR, "Invalid PROXY header: expecting source IP");
+    return zret;
+  }
+  IPAddr srcIP(srcIPView);
+
+  // parse dest IP address
+  auto dstIPView = data.split_prefix_at(PP_V1_DELIMITER);
+  if (dstIPView.empty()) {
+    zret.note(S_ERROR, "Invalid PROXY header: expecting destination IP");
+    return zret;
+  }
+  IPAddr dstIP(dstIPView);
+
+  // parse the port
+  zret.note(S_DIAG, "before the source port content: {}", data);
+  auto srcPortView = data.split_prefix_at(PP_V1_DELIMITER);
+  if (srcPortView.empty()) {
+    zret.note(S_ERROR, "Invalid PROXY header: expecting source port");
+    return zret;
+  }
+  auto srcPort = swoc::svto_radix<10>(srcPortView);
+  // parse the dest port
+  zret.note(S_DIAG, "before the dest port content: {:x}", data);
+  auto dstPortView = data.split_prefix_at('\r');
+  if (dstPortView.empty()) {
+    zret.note(S_ERROR, "Invalid PROXY header: expecting destination port");
+    return zret;
+  }
+  auto dstPort = swoc::svto_radix<10>(dstPortView);
+  // assign the source and destination addresses
+  _src_addr.assign(srcIP, htons(srcPort));
+  _dst_addr.assign(dstIP, htons(dstPort));
+  // return the size of the PROXY header
+  zret = size;
+  return zret;
+}
+
+swoc::Rv<ssize_t>
+ProxyProtocolUtil::parse_pp_header_v2(swoc::TextView data)
+{
+  // parse the data as a PROXY header v2. The data is expected to contain the v2
+  // signature to to enter this function
+  swoc::Rv<ssize_t> zret{-1};
+  auto receivedBytes = data.size();
+  auto const *hdr = reinterpret_cast<const ProxyHdr *>(data.data());
+  size_t size = 0;
+  // PROXY header v2
+  _version = ProxyProtocolVersion::V2;
+  // this size of the header
+  size = 16 + ntohs(hdr->v2.len);
+  if (receivedBytes < size) {
+    // truncated or too large header
+    return zret;
+  }
+  switch (hdr->v2.ver_cmd & 0xF) {
+  case 0x01: /* PROXY command */
+    switch (hdr->v2.fam) {
+    case 0x11: /* TCPv4 */
+      // the ntohl() is needed because the address is stored in network byte
+      // order and IPAddr expects a host byte order, which would in turn get
+      // converted to network byte order in IPEndpoint.assign()
+      _src_addr.assign(
+          IPAddr(reinterpret_cast<in_addr_t>(ntohl(hdr->v2.addr.ip4.src_addr))),
+          hdr->v2.addr.ip4.src_port);
+      _dst_addr.assign(
+          IPAddr(reinterpret_cast<in_addr_t>(ntohl(hdr->v2.addr.ip4.dst_addr))),
+          hdr->v2.addr.ip4.dst_port);
+      break;
+    case 0x21: /* TCPv6 */
+    {
+      IP6Addr srcAddrNetworkOrder(
+          swoc::TextView(reinterpret_cast<const char *>(hdr->v2.addr.ip6.src_addr), 16));
+      IP6Addr dstAddrNetworkOrder(
+          swoc::TextView(reinterpret_cast<const char *>(hdr->v2.addr.ip6.dst_addr), 16));
+      // the network_order() is essentially reordering the byte order. In this
+      // case, the function converts from address in network byte order to host
+      // byte order. This is confusing, but seems to be a convenient way to do
+      // this operation for IPv6.
+      _src_addr.assign(IP6Addr(srcAddrNetworkOrder.network_order()), hdr->v2.addr.ip6.src_port);
+      _dst_addr.assign(IP6Addr(dstAddrNetworkOrder.network_order()), hdr->v2.addr.ip6.dst_port);
+      break;
+    }
+    default:
+      /* unsupported transport protocol */
+      zret.note(S_DIAG, "unsupported transport found in PROXY header");
+      break;
+    }
+    break;
+  default:
+    zret.note(S_DIAG, "unsupported command found in PROXY header");
+    return zret; /* not a supported command */
+  }
+  // return the size of the PROXY v2 header
+  zret = size;
+  return zret;
+}
+
+swoc::Rv<ssize_t>
+ProxyProtocolUtil::parse_header(swoc::TextView data)
+{
+  swoc::Rv<ssize_t> zret{-1};
+  auto receivedBytes = data.size();
+  if (receivedBytes >= 16 && (data.starts_with(V2SIG))) {
+    return parse_pp_header_v2(data);
+  } else if (receivedBytes >= 8 && data.starts_with(V1SIG)) {
+    return parse_pp_header_v1(data);
+  }
+  zret.note(S_DIAG, "No valid PROXY protocol detected.");
+  return zret;
+}
+
+swoc::Errata
+ProxyProtocolUtil::serialize(swoc::BufferWriter &buf) const
+{
+  swoc::Errata errata;
+  if (_version == ProxyProtocolVersion::V1) {
+    return construct_v1_header(buf);
+  } else if (_version == ProxyProtocolVersion::V2) {
+    return construct_v2_header(buf);
+  }
+  errata.note(S_ERROR, "unknown proxy protocol version.");
+  return errata;
+};
+
+swoc::Errata
+ProxyProtocolUtil::construct_v1_header(swoc::BufferWriter &buf) const
+{
+  swoc::Errata errata;
+  buf.print(
+      "PROXY {}{} {2::a} {3::a} {2::p} {3::p}\r\n",
+      swoc::bwf::If(_src_addr.is_ip4(), "TCP4"),
+      swoc::bwf::If(_src_addr.is_ip6(), "TCP6"),
+      _src_addr,
+      _dst_addr);
+  errata.note(
+      S_INFO,
+      "construcuting {} bytes of proxy protocol v1 header content {}",
+      buf.size(),
+      buf);
+  return errata;
+}
+
+swoc::Errata
+ProxyProtocolUtil::construct_v2_header(swoc::BufferWriter &buf) const
+{
+  swoc::Errata errata;
+  ProxyHdr proxy_hdr;
+  memcpy(proxy_hdr.v2.sig, V2SIG.data(), V2SIG.size());
+  // only support the PROXY command
+  proxy_hdr.v2.ver_cmd = 0x21;
+  int addr_len = 0;
+  if (_src_addr.is_ip4()) {
+    proxy_hdr.v2.fam = 0x11;
+    addr_len = sizeof(proxy_hdr.v2.addr.ip4);
+    proxy_hdr.v2.len = htons(addr_len);
+    proxy_hdr.v2.addr.ip4.src_addr = _src_addr.sa4.sin_addr.s_addr;
+    proxy_hdr.v2.addr.ip4.dst_addr = _dst_addr.sa4.sin_addr.s_addr;
+    proxy_hdr.v2.addr.ip4.src_port = _src_addr.network_order_port();
+    proxy_hdr.v2.addr.ip4.dst_port = _dst_addr.network_order_port();
+  } else {
+    // ipv6
+    proxy_hdr.v2.fam = 0x21;
+    addr_len = sizeof(proxy_hdr.v2.addr.ip6);
+    proxy_hdr.v2.len = htons(addr_len);
+    memcpy(
+        proxy_hdr.v2.addr.ip6.src_addr,
+        reinterpret_cast<const uint8_t *>(&_src_addr.sa6.sin6_addr),
+        16);
+    memcpy(
+        proxy_hdr.v2.addr.ip6.dst_addr,
+        reinterpret_cast<const uint8_t *>(&_src_addr.sa6.sin6_addr),
+        16);
+    proxy_hdr.v2.addr.ip6.src_port = _src_addr.network_order_port();
+    proxy_hdr.v2.addr.ip6.dst_port = _dst_addr.network_order_port();
+  }
+  buf.write(&proxy_hdr, addr_len + 16);
+  errata.note(S_INFO, "construcuting {} bytes of proxy protocol v2 header", buf.size());
+  return errata;
+}

--- a/test/autests/gold_tests/autest-site/proxy_http2.py
+++ b/test/autests/gold_tests/autest-site/proxy_http2.py
@@ -20,7 +20,7 @@ import threading
 import traceback
 
 from proxy_http1 import ProxyRequestHandler
-from proxy_protocol_context import ProxyProtocolUtil
+from proxy_protocol_context import ProxyProtocolUtil, ProxyProtocolVersion
 
 import eventlet
 from eventlet.green.OpenSSL import SSL, crypto
@@ -49,7 +49,8 @@ class WrapSSSLContext(ssl.SSLContext):
 
     def wrap_socket(self, sock, *args, **kwargs):
         # send proxy protocol header first before TLS handshake
-        ProxyProtocolUtil.send_proxy_header(
+        if ProxyProtocolUtil.pp_version != ProxyProtocolVersion.NONE:
+            ProxyProtocolUtil.send_proxy_header(
             sock, ProxyProtocolUtil.pp_version)
         kwargs['server_hostname'] = self._server_hostname
         return super().wrap_socket(sock, *args, **kwargs)
@@ -324,7 +325,8 @@ class Http2ConnectionManager(object):
 
                     def new_wrap_socket(sock, *args, **kwargs):
                         # send proxy protocol header first before TLS handshake
-                        ProxyProtocolUtil.send_proxy_header(
+                        if ProxyProtocolUtil.pp_version != ProxyProtocolVersion.NONE:
+                            ProxyProtocolUtil.send_proxy_header(
                             sock, ProxyProtocolUtil.pp_version)
                         kwargs['server_hostname'] = self.client_sni
                         return ssl_context.old_wrap_socket(sock, *args, **kwargs)

--- a/test/autests/gold_tests/autest-site/proxy_protocol_context.py
+++ b/test/autests/gold_tests/autest-site/proxy_protocol_context.py
@@ -1,3 +1,13 @@
+'''
+Implement the PROXY protocol utility class and the socket wrapper class.
+'''
+# @file
+#
+# Copyright 2023, Verizon Media
+# SPDX-License-Identifier: Apache-2.0
+#
+
+
 import socket
 import struct
 import time

--- a/test/autests/gold_tests/autest-site/proxy_protocol_context.py
+++ b/test/autests/gold_tests/autest-site/proxy_protocol_context.py
@@ -1,0 +1,256 @@
+import socket
+import struct
+import time
+from enum import Enum
+import threading
+
+PP_V2_PREFIX = b'\x0d\x0a\x0d\x0a\x00\x0d\x0a\x51\x55\x49\x54\x0a'
+# The maximum size of the proxy protocol header is 108 bytes(assuming TLV and
+# linux socket address are not used)
+PP_MAX_DATA_SIZE = 108
+
+
+class ProxyProtocolVersion(Enum):
+    NONE = 0
+    V1 = 1
+    V2 = 2
+
+
+class ProxyProtocolUtil:
+    """Utility class for parsing and encoding the PROXY protocol header. The
+    parsing code is largely adopted from Brian Neradt's proxy_protocol_server in
+    the ATS repo.
+    """
+
+    # The Proxy header version to be sent to the origin server. This is set when
+    # a PROXY header is received by the proxy. Needs to be thread-local as
+    # connections can be concurrent
+    pp_version = threading.local()
+
+    @staticmethod
+    def wrap_socket(sock, use_ssl=False, ssl_ctx=None):
+        return PP_socket(sock, use_ssl, ssl_ctx)
+
+    # utility methods for parsing or encoding the PROXY protocol header
+    @staticmethod
+    def parse_pp_v1(pp_bytes: bytes) -> int:
+        """Parse and print the Proxy Protocol v1 string.
+        :param pp_bytes: The bytes containing the Proxy Protocol string. There may
+        be more bytes than the Proxy Protocol string.
+        :returns: The number of bytes occupied by the proxy v1 protocol.
+        """
+        # Proxy Protocol v1 string ends with CRLF.
+        end = pp_bytes.find(b'\r\n')
+        if end == -1:
+            raise ValueError("Proxy Protocol v1 string ending not found")
+        print(pp_bytes[:end].decode("utf-8"))
+        return end + 2
+
+    @staticmethod
+    def parse_pp_v2(pp_bytes: bytes) -> int:
+        """Parse and print the Proxy Protocol v2 string.
+        :param pp_bytes: The bytes containing the Proxy Protocol string. There may
+        be more bytes than the Proxy Protocol string.
+        :returns: The number of bytes occupied by the proxy v2 protocol string.
+        """
+
+        # Skip the 12 byte header.
+        pp_bytes = pp_bytes[12:]
+        version_command = pp_bytes[0]
+        pp_bytes = pp_bytes[1:]
+        family_protocol = pp_bytes[0]
+        pp_bytes = pp_bytes[1:]
+        tuple_length = int.from_bytes(pp_bytes[:2], byteorder='big')
+        pp_bytes = pp_bytes[2:]
+
+        # Of version_command, the higher 4 bits is the version and the lower 4
+        # is the command.
+        version = version_command >> 4
+        command = version_command & 0x0F
+
+        if version != 2:
+            raise ValueError(
+                f'Invalid version: {version} (by spec, should always be 0x02)')
+
+        if command == 0x0:
+            command_description = 'LOCAL'
+        elif command == 0x1:
+            command_description = 'PROXY'
+        else:
+            raise ValueError(
+                f'Invalid command: {command} (by spec, should be 0x00 or 0x01)')
+
+        # Of address_family, the higher 4 bits is the address family and the
+        # lower 4 is the transport protocol.
+        if family_protocol == 0x0:
+            transport_protocol_description = 'UNSPEC'
+        elif family_protocol == 0x11:
+            transport_protocol_description = 'TCP4'
+        elif family_protocol == 0x12:
+            transport_protocol_description = 'UDP4'
+        elif family_protocol == 0x21:
+            transport_protocol_description = 'TCP6'
+        elif family_protocol == 0x22:
+            transport_protocol_description = 'UDP6'
+        elif family_protocol == 0x31:
+            transport_protocol_description = 'UNIX_STREAM'
+        elif family_protocol == 0x32:
+            transport_protocol_description = 'UNIX_DGRAM'
+        else:
+            raise ValueError(
+                f'Invalid address family: {family_protocol} (by spec, should be '
+                '0x00, 0x11, 0x12, 0x21, 0x22, 0x31, or 0x32)')
+
+        if family_protocol in (0x11, 0x12):
+            if tuple_length != 12:
+                raise ValueError(
+                    "Unexpected tuple length for TCP4/UDP4: "
+                    f"{tuple_length} (by) spec, should be 12)"
+                )
+            src_addr = socket.inet_ntop(socket.AF_INET, pp_bytes[:4])
+            pp_bytes = pp_bytes[4:]
+            dst_addr = socket.inet_ntop(socket.AF_INET, pp_bytes[:4])
+            pp_bytes = pp_bytes[4:]
+            src_port = int.from_bytes(pp_bytes[:2], byteorder='big')
+            pp_bytes = pp_bytes[2:]
+            dst_port = int.from_bytes(pp_bytes[:2], byteorder='big')
+            pp_bytes = pp_bytes[2:]
+
+        tuple_description = f'{src_addr} {dst_addr} {src_port} {dst_port}'
+        print(
+            f'{command_description} {transport_protocol_description} '
+            f'{tuple_description}')
+
+        return 16 + tuple_length
+
+    @staticmethod
+    def construct_proxy_header_v1(src_addr, dst_addr, family):
+        """ Construct a Proxy Protocol v1 string.
+        :param src_addr: the source socket address
+        :param dst_addr: the destination socket address
+        :param family: the socket family
+        :returns: The bytes containing the Proxy Protocol v1 string.
+        """
+        # Construct the PROXY protocol v1 header
+        family_desc = 'TCP4' if family == socket.AF_INET else 'TCP6'
+        return f"PROXY {family_desc} {src_addr[0]} {dst_addr[0]} {src_addr[1]} {dst_addr[1]}\r\n".encode()
+
+    @staticmethod
+    def construct_proxy_header_v2(src_addr, dst_addr, family):
+        """ Construct a Proxy Protocol v2 string.
+        :param src_addr: the source socket address
+        :param dst_addr: the destination socket address
+        :param family: the socket family
+        :returns: The bytes containing the Proxy Protocol v2 string.
+        """
+        # Construct the PROXY protocol v2 header
+        header = PP_V2_PREFIX
+        # Protocol version 2 + PROXY command
+        header += b'\x21'
+        # TCP over IPv4 or IPv6
+        header += b'\x11' if family == socket.AF_INET else b'\x21'
+        # address length
+        header += b'\x00\x0C'
+        header += socket.inet_pton(socket.AF_INET, src_addr[0])
+        header += socket.inet_pton(socket.AF_INET, dst_addr[0])
+        header += struct.pack('!H', src_addr[1])
+        header += struct.pack('!H', dst_addr[1])
+        return header
+
+    @staticmethod
+    def send_proxy_header(sock, proxy_protocol_version):
+        """ Send the PROXY header to the stream
+        :param sock: the socket of the stream
+        :param proxy_protocol_version: the version of the proxy protocol to send
+        """
+        # get source ip and port from socket
+        print(f'Sending PROXY protocol version {proxy_protocol_version.value}')
+        proxy_header_construcut_func = ProxyProtocolUtil.construct_proxy_header_v1 if proxy_protocol_version == ProxyProtocolVersion.V1 else ProxyProtocolUtil.construct_proxy_header_v2
+        proxy_header_data = proxy_header_construcut_func(
+            sock.getsockname(), sock.getpeername(), sock.family)
+        sock.sendall(proxy_header_data)
+        time.sleep(1)
+
+    @staticmethod
+    def read_pp_header_if_present(sock):
+        """ Consume the PROXY header from the socket if present
+        :param sock: the socket of the stream
+        """
+        # peek at the file content to check for proxy protocol header
+        data = sock.recv(PP_MAX_DATA_SIZE, socket.MSG_PEEK)
+        pp_num_bytes = ProxyProtocolUtil.check_for_proxy_header(data)
+        if pp_num_bytes > 0:
+            # read the pp header bytes from the file
+            sock.recv(pp_num_bytes)
+        return
+
+    @staticmethod
+    def check_for_proxy_header(data):
+        """ Examine the data to see if it contains a proxy protocol header
+        :param data: the data to examine
+        :returns: the number of bytes in the proxy protocol header if present, 0 otherwise
+        """
+        print("checking for PROXY protocol header")
+        pp_length = 0
+        ProxyProtocolUtil.pp_version = ProxyProtocolVersion.NONE
+
+        if (data.startswith(b'PROXY') and b'\r\n' in data):
+            pp_length = ProxyProtocolUtil.parse_pp_v1(data)
+            ProxyProtocolUtil.pp_version = ProxyProtocolVersion.V1
+        if data.startswith(PP_V2_PREFIX):
+            pp_length = ProxyProtocolUtil.parse_pp_v2(data)
+            ProxyProtocolUtil.pp_version = ProxyProtocolVersion.V2
+        if pp_length > 0:
+            print(
+                f"Received {pp_length} bytes of Proxy Protocol V{ProxyProtocolUtil.pp_version.value}")
+        return pp_length
+
+    @staticmethod
+    def create_connection_and_send_pp(address, timeout,
+                                      source_address):
+        """ This is a wraper of the socket.create_connection method, which in
+        addition sends a PROXY protocol header as the connection is established.
+        :param address: the address to connect to
+        :param timeout: the timeout for the connection
+        :param source_address: the source address to bind to
+        :returns: the socket of the established connection
+        """
+        sock = socket.create_connection(
+            address, timeout, source_address)
+        if ProxyProtocolUtil.pp_version != ProxyProtocolVersion.NONE:
+            # send the PROXY protocol header
+            ProxyProtocolUtil.send_proxy_header(
+                sock, ProxyProtocolUtil.pp_version)
+        return sock
+
+
+class PP_socket(socket.socket):
+    """A minimal socket wrapper that reads the proxy protocol header. The most
+    notable override is the accept method."""
+
+    def __init__(self, sock, use_ssl, ssl_ctx):
+        self._socket = sock
+        self._use_ssl = use_ssl
+        self._ssl_ctx = ssl_ctx
+        super().__init__()
+
+    def getsockname(self, *args, **kwargs):
+        return self._socket.getsockname(*args, **kwargs)
+
+    def fileno(self):
+        return self._socket.fileno()
+
+    def accept(self):
+        """ stripes off any proxy protocol header before returning the accepted
+        client socket
+        """
+        client_sock, client_addr = self._socket.accept()
+        ProxyProtocolUtil.read_pp_header_if_present(client_sock)
+        if self._use_ssl:
+            print("wrapping the socket with ssl")
+            client_sock = self._ssl_ctx.wrap_socket(
+                client_sock, server_side=True)
+        # Returning the accepted client socket here, since we are done with
+        # proxy protocol processing and can yield control back to the raw socket
+        # beyond this point
+        return client_sock, client_addr

--- a/test/autests/gold_tests/proxy-protocol/gold/http_single_transaction_client.gold
+++ b/test/autests/gold_tests/proxy-protocol/gold/http_single_transaction_client.gold
@@ -1,0 +1,29 @@
+``
+``
+``Parsed 1 transaction in 1 session.
+``
+``cb9b4e94-5d42-43d4-8545-320033298ba2-226381119``
+POST http://example.com/client.do HTTP/1.1
+content-length: 399
+content-type: application/octet-stream
+host: example.com
+connection: Keep-Alive
+x-candy: cane
+x-someid: fda39dfad1
+uuid: cb9b4e94-5d42-43d4-8545-320033298ba2-226381119
+
+``399 byte body [CL]``
+``
+``response for key cb9b4e94-5d42-43d4-8545-320033298ba2-226381119``
+HTTP/1.1 200 OK
+date: Sat, 16 Mar 2019 03:11:36 GMT
+x-testheader: from_server_response
+content-type: application/octet-stream
+content-length: 10
+age: 0
+via: http/1.1 example.data1.com, http/1.1 example.data2.com
+server: ATS
+connection: keep-alive
+
+``body of 10 bytes``
+``

--- a/test/autests/gold_tests/proxy-protocol/gold/http_single_transaction_proxy.gold
+++ b/test/autests/gold_tests/proxy-protocol/gold/http_single_transaction_proxy.gold
@@ -1,0 +1,28 @@
+``
+POST http://example.com/client.do HTTP/1.1
+content-length: 399
+content-type: application/octet-stream
+host: example.com
+connection: Keep-Alive
+x-candy: cane
+x-someid: fda39dfad1
+uuid: cb9b4e94-5d42-43d4-8545-320033298ba2-226381119
+
+
+==== REQUEST BODY ====
+b'0000000 0000001 0000002 0000003 0000004 0000005 0000006 0000007 0000008 0000009 000000a 000000b 000000c 000000d 000000e 000000f 0000010 0000011 0000012 0000013 0000014 0000015 0000016 0000017 0000018 0000019 000001a 000001b 000001c 000001d 000001e 000001f 0000020 0000021 0000022 0000023 0000024 0000025 0000026 0000027 0000028 0000029 000002a 000002b 000002c 000002d 000002e 000002f 0000030 0000031'
+
+HTTP/1.1 200 OK
+date: Sat, 16 Mar 2019 03:11:36 GMT
+x-testheader: from_server_response
+content-type: application/octet-stream
+content-length: 10
+age: 0
+via: http/1.1 example.data1.com, http/1.1 example.data2.com
+server: ATS
+connection: keep-alive
+
+
+==== RESPONSE BODY ====
+b'0000000 00'
+``

--- a/test/autests/gold_tests/proxy-protocol/gold/http_single_transaction_server.gold
+++ b/test/autests/gold_tests/proxy-protocol/gold/http_single_transaction_server.gold
@@ -1,0 +1,29 @@
+``
+``Ready with 1 transaction.
+``
+``cb9b4e94-5d42-43d4-8545-320033298ba2-226381119``
+POST /client.do HTTP/1.1
+Accept-Encoding: identity
+content-length: 399
+content-type: application/octet-stream
+host: example.com
+connection: Keep-Alive
+x-candy: cane
+x-someid: fda39dfad1
+uuid: cb9b4e94-5d42-43d4-8545-320033298ba2-226381119
+
+``body of 399 bytes``
+``
+``headers for key cb9b4e94-5d42-43d4-8545-320033298ba2-226381119``
+HTTP/1.1 200 OK
+date: Sat, 16 Mar 2019 03:11:36 GMT
+x-testheader: from_server_response
+content-type: application/octet-stream
+content-length: 10
+age: 0
+via: http/1.1 example.data1.com, http/1.1 example.data2.com
+server: ATS
+connection: keep-alive
+
+``10 byte body``
+``

--- a/test/autests/gold_tests/proxy-protocol/gold/https_single_transaction_client.gold
+++ b/test/autests/gold_tests/proxy-protocol/gold/https_single_transaction_client.gold
@@ -1,0 +1,24 @@
+``
+``Connecting via TLS.
+``
+POST https://example.data.com/a/path HTTP/1.1
+content-type: application/json; charset=utf-8
+content-length: 10
+host: example.com
+connection: Keep-Alive
+accept-encoding: gzip
+uuid: 1
+
+``
+0000000 00
+``
+HTTP/1.1 200 OK
+content-type: multipart/form-data;snoopy=123456
+date: Sat, 16 Mar 2019 01:33:27 GMT
+age: 1
+connection: keep-alive
+content-length: 12
+
+``
+0000000 0000
+``1 transaction in 1 session ``

--- a/test/autests/gold_tests/proxy-protocol/gold/https_single_transaction_proxy.gold
+++ b/test/autests/gold_tests/proxy-protocol/gold/https_single_transaction_proxy.gold
@@ -1,0 +1,19 @@
+``
+Client SNI: test_sni
+``
+POST https://example.data.com/a/path HTTP/1.1
+``
+content-length: 10
+``
+uuid: 1
+``
+==== REQUEST BODY ====
+b'0000000 00'
+
+HTTP/1.1 200 OK
+``
+content-length: 12
+``
+==== RESPONSE BODY ====
+b'0000000 0000'
+``

--- a/test/autests/gold_tests/proxy-protocol/gold/https_single_transaction_server.gold
+++ b/test/autests/gold_tests/proxy-protocol/gold/https_single_transaction_server.gold
@@ -1,0 +1,25 @@
+``
+``Ready with 1 transaction.
+``Listening `` 127.0.0.1:``
+``
+POST /a/path HTTP/1.1
+content-type: application/json; charset=utf-8
+content-length: 10
+host: example.com
+connection: Keep-Alive
+accept-encoding: gzip
+uuid: 1
+
+``
+0000000 00
+``
+HTTP/1.1 200 OK
+content-type: multipart/form-data;snoopy=123456
+date: Sat, 16 Mar 2019 01:33:27 GMT
+age: 1
+connection: keep-alive
+content-length: 12
+
+``
+0000000 0000
+``

--- a/test/autests/gold_tests/proxy-protocol/gold/ipv6_client.gold
+++ b/test/autests/gold_tests/proxy-protocol/gold/ipv6_client.gold
@@ -1,0 +1,15 @@
+``
+GET http://example.one/config/settings.yaml HTTP/1.1
+content-length: 0
+host: example.one
+x-test-request: request
+uuid: 1
+
+``
+HTTP/1.1 200 OK
+content-type: text/html
+content-length: 16
+x-test-response: response
+uuid: 1
+
+``

--- a/test/autests/gold_tests/proxy-protocol/gold/ipv6_server.gold
+++ b/test/autests/gold_tests/proxy-protocol/gold/ipv6_server.gold
@@ -1,0 +1,18 @@
+``
+``Listening `` [::1]:``
+``
+GET http://example.one/config/settings.yaml HTTP/1.1
+content-length: 0
+host: example.one
+x-test-request: request
+uuid: 1
+
+``Request with key 1 passed validation.
+``
+HTTP/1.1 200 OK
+content-type: text/html
+content-length: 16
+x-test-response: response
+uuid: 1
+
+``

--- a/test/autests/gold_tests/proxy-protocol/proxy_protocol.test.py
+++ b/test/autests/gold_tests/proxy-protocol/proxy_protocol.test.py
@@ -121,3 +121,51 @@ proxy.Streams.stdout += Testers.ExcludesExpression(
 server.Streams.stdout += Testers.ExcludesExpression(
     "Received PROXY header",
     "The server should not receive the PROXY header.")
+
+#
+# Test 6: Verify the PROXY v1 message can be sent and received on IPv6
+# connection.
+#
+r = Test.AddTestRun("Verify the PROXY message can be sent and received on IPv6 connection")
+server = r.AddServerProcess("ipv6-server1", "replay_files/single_transaction_ipv6_pp_v1.replay.yaml",
+                            use_ipv6=True)
+client = r.AddClientProcess("ipv6-client1", "replay_files/single_transaction_ipv6_pp_v1.replay.yaml",
+                            use_ipv6=True, http_ports=[server.Variables.http_port],
+                            other_args="--no-proxy")
+
+# Verify successful transaction despite PROXY protocol processing
+client.Streams.stdout = "gold/ipv6_client.gold"
+server.Streams.stdout = "gold/ipv6_server.gold"
+
+# Verify the PROXY protocol related logs
+client.Streams.stdout += Testers.ContainsExpression(
+    f"Sending PROXY header from \[::a00:.*:0:0\]:[0-9]+ to \[::1\]:{server.Variables.http_port}",
+    "Verify that the PROXY header is sent from the client to the server.")
+
+server.Streams.stdout += Testers.ContainsExpression(
+    f"Received PROXY header v1:.*\nPROXY TCP6 ::a00:.*:0:0 ::1 [0-9]+ {server.Variables.http_port}",
+    "Verify that the server receives the PROXY header and parsed sucessfully.", reflags=re.MULTILINE)
+
+#
+# Test 6: Verify the PROXY v2 message can be sent and received on IPv6
+# connection.
+#
+r = Test.AddTestRun("Verify the PROXY message can be sent and received on IPv6 connection")
+server = r.AddServerProcess("ipv6-server2", "replay_files/single_transaction_ipv6_pp_v2.replay.yaml",
+                            use_ipv6=True)
+client = r.AddClientProcess("ipv6-client2", "replay_files/single_transaction_ipv6_pp_v2.replay.yaml",
+                            use_ipv6=True, http_ports=[server.Variables.http_port],
+                            other_args="--no-proxy")
+
+# Verify successful transaction despite PROXY protocol processing
+client.Streams.stdout = "gold/ipv6_client.gold"
+server.Streams.stdout = "gold/ipv6_server.gold"
+
+# Verify the PROXY protocol related logs
+client.Streams.stdout += Testers.ContainsExpression(
+    f"Sending PROXY header from \[::a00:.*:0:0\]:[0-9]+ to \[::1\]:{server.Variables.http_port}",
+    "Verify that the PROXY header is sent from the client to the server.")
+
+server.Streams.stdout += Testers.ContainsExpression(
+    f"Received PROXY header v2:.*\nPROXY TCP6 ::a00:.*:0:0 ::1 [0-9]+ {server.Variables.http_port}",
+    "Verify that the server receives the PROXY header and parsed sucessfully.", reflags=re.MULTILINE)

--- a/test/autests/gold_tests/proxy-protocol/proxy_protocol.test.py
+++ b/test/autests/gold_tests/proxy-protocol/proxy_protocol.test.py
@@ -1,0 +1,123 @@
+'''
+Verify basic PROXY protocol functionality.
+'''
+# @file
+#
+# Copyright 2023, Verizon Media
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import re
+
+Test.Summary = '''
+Verify basic PROXY protocol functionality.
+'''
+
+
+class PPTest:
+    # static id for client, server and proxy processes
+    test_id = 1
+
+    def __init__(self, testBaseName, ppVersion, isHTTPS, testRunDesc=""):
+        self.testRun = Test.AddTestRun(testRunDesc)
+        self.testBaseName = testBaseName
+        self.ppVersion = ppVersion
+        self.replayFile = f'replay_files/{testBaseName}_pp_v{ppVersion}.replay.yaml'
+        self.isHTTPS = isHTTPS
+
+    def setupClient(self, isHTTPS):
+        self.client = self.testRun.AddClientProcess(
+            f"client-{PPTest.test_id}", self.replayFile, configure_http=not isHTTPS, configure_https=isHTTPS)
+
+    def setupServer(self, isHTTPS):
+        self.server = self.testRun.AddServerProcess(
+            f"server-{PPTest.test_id}", self.replayFile, configure_http=not isHTTPS, configure_https=isHTTPS)
+
+    def setupProxy(self, isHTTPS):
+        self.proxyListenPort = self.client.Variables.https_port if isHTTPS else self.client.Variables.http_port
+        self.serverListenPort = self.server.Variables.https_port if isHTTPS else self.server.Variables.http_port
+        self.proxy = self.testRun.AddProxyProcess(
+            f"proxy-{PPTest.test_id}", listen_port=self.proxyListenPort, server_port=self.serverListenPort, use_ssl=isHTTPS)
+
+    def setupTransactionLogsVerification(self):
+        # Verify that the http trasactions are successful(not hindered by the
+        # PROXY protocol processing).
+        self.proxy.Streams.stdout = f"gold/{self.testBaseName}_proxy.gold"
+        self.client.Streams.stdout = f"gold/{self.testBaseName}_client.gold"
+        self.server.Streams.stdout = f"gold/{self.testBaseName}_server.gold"
+
+    def setupPPLogsVerification(self):
+        # Verify the PROXY protocol related logs
+        self.client.Streams.stdout += Testers.ContainsExpression(
+            f"Sending PROXY header from 127\.0\.0\.1:[0-9]+ to 127\.0\.0\.1:{self.proxyListenPort}",
+            "Verify that the PROXY header is sent from the client to the proxy.")
+
+        self.proxy.Streams.stdout += Testers.ContainsExpression(
+            f"Received .* bytes of Proxy Protocol V{self.ppVersion}",
+            "Verify that the PROXY header is received by the proxy.")
+        self.proxy.Streams.stdout += Testers.ContainsExpression(
+            f"PROXY TCP4 127\.0\.0\.1 127\.0\.0\.1 [0-9]+ {self.proxyListenPort}",
+            "Verify the client sends a valid PROXY header.")
+
+        self.server.Streams.stdout += Testers.ContainsExpression(
+            f"Received PROXY header v{self.ppVersion}:.*\nPROXY TCP4 127\.0\.0\.1 127\.0\.0\.1 [0-9]+ {self.serverListenPort}",
+            "Verify that the server receives the PROXY header and parsed sucessfully.", reflags=re.MULTILINE)
+
+    def run(self):
+        self.setupClient(self.isHTTPS)
+        self.setupServer(self.isHTTPS)
+        self.setupProxy(self.isHTTPS)
+        self.setupTransactionLogsVerification()
+        self.setupPPLogsVerification()
+        PPTest.test_id += 1
+
+
+# # Test 1: Verify the PROXY header v1 is sent and received in a HTTP transaction.
+PPTest("http_single_transaction", ppVersion=1, isHTTPS=False,
+       testRunDesc="Verify PROXY protocol v1 is sent and received in a HTTP connection").run()
+
+# # Test 2: Verify the PROXY header v2 is sent and received in a HTTP transaction.
+PPTest("http_single_transaction", ppVersion=2, isHTTPS=False,
+       testRunDesc="Verify PROXY protocol v2 is sent and received in a HTTP connection").run()
+
+# # Test 3: Verify the PROXY header v1 is sent and received in a HTTPS
+# # transaction.
+PPTest("https_single_transaction", ppVersion=1, isHTTPS=True,
+       testRunDesc="Verify PROXY protocol v1 is sent and received in a HTTPS connection").run()
+
+# # Test 4: Verify the PROXY header v2 is sent and received in a HTTPS
+# # transaction.
+PPTest("https_single_transaction", ppVersion=2, isHTTPS=True,
+       testRunDesc="Verify PROXY protocol v2 is sent and received in a HTTPS connection").run()
+
+# Test 5: Verify the PROXY protocol is not sent when not specified in the replay
+# file
+r = Test.AddTestRun(
+    "Verify the PROXY protocol is not sent when not specified in the replay file")
+
+# Add configure_https=False to verify ATS client and server work when the https
+# optional arguments are not provided.
+client = r.AddClientProcess("no-pp-client1", "replay_files/http_single_transaction_no_pp.replay.yaml",
+                            configure_https=False)
+server = r.AddServerProcess("no-pp-server1", "replay_files/http_single_transaction_no_pp.replay.yaml",
+                            configure_https=False)
+proxy = r.AddProxyProcess("no-pp-proxy1", listen_port=client.Variables.http_port,
+                          server_port=server.Variables.http_port)
+
+# Verify the http transaction finishes successfully.
+proxy.Streams.stdout = "gold/http_single_transaction_proxy.gold"
+client.Streams.stdout = "gold/http_single_transaction_client.gold"
+server.Streams.stdout = "gold/http_single_transaction_server.gold"
+
+# Verify the PROXY protocol related logs. Since the replay file does not have
+# the PROXY protocol related configuration, the client, proxy and server should
+# not have these logs
+client.Streams.stdout += Testers.ExcludesExpression(
+    "Sending PROXY header from",
+    "Client should not send PROXY header if not asked to.")
+proxy.Streams.stdout += Testers.ExcludesExpression(
+    "Received .* bytes of Proxy Protocol",
+    "Proxy should not receive the PROXY header.")
+server.Streams.stdout += Testers.ExcludesExpression(
+    "Received PROXY header",
+    "The server should not receive the PROXY header.")

--- a/test/autests/gold_tests/proxy-protocol/replay_files/http_single_transaction_no_pp.replay.yaml
+++ b/test/autests/gold_tests/proxy-protocol/replay_files/http_single_transaction_no_pp.replay.yaml
@@ -1,3 +1,9 @@
+# @file
+#
+# Copyright 2023, Verizon Media
+# SPDX-License-Identifier: Apache-2.0
+#
+
 meta:
   version: '1.0'
 

--- a/test/autests/gold_tests/proxy-protocol/replay_files/http_single_transaction_no_pp.replay.yaml
+++ b/test/autests/gold_tests/proxy-protocol/replay_files/http_single_transaction_no_pp.replay.yaml
@@ -1,0 +1,85 @@
+meta:
+  version: '1.0'
+
+# This file is taken largely from a sample Traffic Dump file.
+
+# Notice there is no proxy-protocol specified in the protocol stack
+sessions:
+- connection-time: 1552705896896003926
+  protocol: [ { name: tcp }, {name: ip} ]
+
+  transactions:
+  - start-time: 1552705896896042340
+    uuid: cb9b4e94-5d42-43d4-8545-320033298ba2-226381119
+
+    client-request:
+      method: POST
+      url: http://example.com/client.do
+      version: '1.1'
+      headers:
+        encoding: esc_json
+        fields:
+        - [ Content-Length, '399' ]
+        - [ Content-Type, application/octet-stream ]
+        - [ Host, example.com ]
+        - [ Connection, Keep-Alive ]
+        - [ X-CANDY, cane ]
+        - [ X-SomeID, fda39dfad1 ]
+        - [ uuid, cb9b4e94-5d42-43d4-8545-320033298ba2-226381119 ]
+      content:
+        encoding: plain
+        size: 399
+
+    proxy-request:
+      content:
+        encoding: plain
+        size: 399
+      headers:
+        encoding: esc_json
+        fields:
+        - [ Content-Length, '399' ]
+        - [ Content-Type, application/octet-stream ]
+        - [ Host, example.com ]
+        - [ Client-ip, 10.10.10.1 ]
+        - [ X-Forwarded-For, 10.10.10.2 ]
+        - [ Via, http/1.1 example.data.com (Poland) ]
+        - [ X-SomeId, fda39dfad1 ]
+        - [ uuid, cb9b4e94-5d42-43d4-8545-320033298ba2-226381119 ]
+      method: POST
+      url: /proxy.do
+      version: '1.1'
+
+    proxy-response:
+      content:
+        encoding: plain
+        size: 0
+      headers:
+        encoding: esc_json
+        fields:
+        - [ Date, "Sat, 16 Mar 2019 03:11:36 GMT" ]
+        - [ X-TestHeader, from_proxy_response ]
+        - [ Content-Type, application/octet-stream ]
+        - [ Content-Length, '10' ]
+        - [ Age, '0' ]
+        - [ Server, ATS ]
+        - [ Connection, keep-alive ]
+      reason: OK
+      status: 200
+
+    server-response:
+      content:
+        encoding: plain
+        size: 0
+      headers:
+        encoding: esc_json
+        fields:
+        - [ Date, "Sat, 16 Mar 2019 03:11:36 GMT" ]
+        - [ X-TestHeader, from_server_response ]
+        - [ Content-Type, application/octet-stream ]
+        - [ Content-Length, '10' ]
+        - [ Age, '0' ]
+        - [ Via, "http/1.1 example.data1.com, http/1.1 example.data2.com" ]
+        - [ Server, ATS ]
+        - [ Connection, keep-alive ]
+      reason: OK
+      status: 200

--- a/test/autests/gold_tests/proxy-protocol/replay_files/http_single_transaction_pp_v1.replay.yaml
+++ b/test/autests/gold_tests/proxy-protocol/replay_files/http_single_transaction_pp_v1.replay.yaml
@@ -1,0 +1,83 @@
+meta:
+  version: '1.0'
+
+# This file is taken largely from a sample Traffic Dump file.
+sessions:
+- connection-time: 1552705896896003926
+  protocol: [ { name: tcp }, {name: ip}, {name: proxy-protocol, version: 1} ]
+
+  transactions:
+  - start-time: 1552705896896042340
+    uuid: cb9b4e94-5d42-43d4-8545-320033298ba2-226381119
+
+    client-request:
+      method: POST
+      url: http://example.com/client.do
+      version: '1.1'
+      headers:
+        encoding: esc_json
+        fields:
+        - [ Content-Length, '399' ]
+        - [ Content-Type, application/octet-stream ]
+        - [ Host, example.com ]
+        - [ Connection, Keep-Alive ]
+        - [ X-CANDY, cane ]
+        - [ X-SomeID, fda39dfad1 ]
+        - [ uuid, cb9b4e94-5d42-43d4-8545-320033298ba2-226381119 ]
+      content:
+        encoding: plain
+        size: 399
+
+    proxy-request:
+      content:
+        encoding: plain
+        size: 399
+      headers:
+        encoding: esc_json
+        fields:
+        - [ Content-Length, '399' ]
+        - [ Content-Type, application/octet-stream ]
+        - [ Host, example.com ]
+        - [ Client-ip, 10.10.10.1 ]
+        - [ X-Forwarded-For, 10.10.10.2 ]
+        - [ Via, http/1.1 example.data.com (Poland) ]
+        - [ X-SomeId, fda39dfad1 ]
+        - [ uuid, cb9b4e94-5d42-43d4-8545-320033298ba2-226381119 ]
+      method: POST
+      url: /proxy.do
+      version: '1.1'
+
+    proxy-response:
+      content:
+        encoding: plain
+        size: 0
+      headers:
+        encoding: esc_json
+        fields:
+        - [ Date, "Sat, 16 Mar 2019 03:11:36 GMT" ]
+        - [ X-TestHeader, from_proxy_response ]
+        - [ Content-Type, application/octet-stream ]
+        - [ Content-Length, '10' ]
+        - [ Age, '0' ]
+        - [ Server, ATS ]
+        - [ Connection, keep-alive ]
+      reason: OK
+      status: 200
+
+    server-response:
+      content:
+        encoding: plain
+        size: 0
+      headers:
+        encoding: esc_json
+        fields:
+        - [ Date, "Sat, 16 Mar 2019 03:11:36 GMT" ]
+        - [ X-TestHeader, from_server_response ]
+        - [ Content-Type, application/octet-stream ]
+        - [ Content-Length, '10' ]
+        - [ Age, '0' ]
+        - [ Via, "http/1.1 example.data1.com, http/1.1 example.data2.com" ]
+        - [ Server, ATS ]
+        - [ Connection, keep-alive ]
+      reason: OK
+      status: 200

--- a/test/autests/gold_tests/proxy-protocol/replay_files/http_single_transaction_pp_v1.replay.yaml
+++ b/test/autests/gold_tests/proxy-protocol/replay_files/http_single_transaction_pp_v1.replay.yaml
@@ -1,3 +1,9 @@
+# @file
+#
+# Copyright 2023, Verizon Media
+# SPDX-License-Identifier: Apache-2.0
+#
+
 meta:
   version: '1.0'
 

--- a/test/autests/gold_tests/proxy-protocol/replay_files/http_single_transaction_pp_v2.replay.yaml
+++ b/test/autests/gold_tests/proxy-protocol/replay_files/http_single_transaction_pp_v2.replay.yaml
@@ -1,3 +1,9 @@
+# @file
+#
+# Copyright 2023, Verizon Media
+# SPDX-License-Identifier: Apache-2.0
+#
+
 meta:
   version: '1.0'
 

--- a/test/autests/gold_tests/proxy-protocol/replay_files/http_single_transaction_pp_v2.replay.yaml
+++ b/test/autests/gold_tests/proxy-protocol/replay_files/http_single_transaction_pp_v2.replay.yaml
@@ -1,0 +1,83 @@
+meta:
+  version: '1.0'
+
+# This file is taken largely from a sample Traffic Dump file.
+sessions:
+- connection-time: 1552705896896003926
+  protocol: [ { name: tcp }, {name: ip}, {name: proxy-protocol, version: 2} ]
+
+  transactions:
+  - start-time: 1552705896896042340
+    uuid: cb9b4e94-5d42-43d4-8545-320033298ba2-226381119
+
+    client-request:
+      method: POST
+      url: http://example.com/client.do
+      version: '1.1'
+      headers:
+        encoding: esc_json
+        fields:
+        - [ Content-Length, '399' ]
+        - [ Content-Type, application/octet-stream ]
+        - [ Host, example.com ]
+        - [ Connection, Keep-Alive ]
+        - [ X-CANDY, cane ]
+        - [ X-SomeID, fda39dfad1 ]
+        - [ uuid, cb9b4e94-5d42-43d4-8545-320033298ba2-226381119 ]
+      content:
+        encoding: plain
+        size: 399
+
+    proxy-request:
+      content:
+        encoding: plain
+        size: 399
+      headers:
+        encoding: esc_json
+        fields:
+        - [ Content-Length, '399' ]
+        - [ Content-Type, application/octet-stream ]
+        - [ Host, example.com ]
+        - [ Client-ip, 10.10.10.1 ]
+        - [ X-Forwarded-For, 10.10.10.2 ]
+        - [ Via, http/1.1 example.data.com (Poland) ]
+        - [ X-SomeId, fda39dfad1 ]
+        - [ uuid, cb9b4e94-5d42-43d4-8545-320033298ba2-226381119 ]
+      method: POST
+      url: /proxy.do
+      version: '1.1'
+
+    proxy-response:
+      content:
+        encoding: plain
+        size: 0
+      headers:
+        encoding: esc_json
+        fields:
+        - [ Date, "Sat, 16 Mar 2019 03:11:36 GMT" ]
+        - [ X-TestHeader, from_proxy_response ]
+        - [ Content-Type, application/octet-stream ]
+        - [ Content-Length, '10' ]
+        - [ Age, '0' ]
+        - [ Server, ATS ]
+        - [ Connection, keep-alive ]
+      reason: OK
+      status: 200
+
+    server-response:
+      content:
+        encoding: plain
+        size: 0
+      headers:
+        encoding: esc_json
+        fields:
+        - [ Date, "Sat, 16 Mar 2019 03:11:36 GMT" ]
+        - [ X-TestHeader, from_server_response ]
+        - [ Content-Type, application/octet-stream ]
+        - [ Content-Length, '10' ]
+        - [ Age, '0' ]
+        - [ Via, "http/1.1 example.data1.com, http/1.1 example.data2.com" ]
+        - [ Server, ATS ]
+        - [ Connection, keep-alive ]
+      reason: OK
+      status: 200

--- a/test/autests/gold_tests/proxy-protocol/replay_files/https_single_transaction_pp_v1.replay.yaml
+++ b/test/autests/gold_tests/proxy-protocol/replay_files/https_single_transaction_pp_v1.replay.yaml
@@ -1,0 +1,40 @@
+---
+meta:
+  version: '1.0'
+
+sessions:
+- protocol: [ {name: http, version: 1.1}, {name: tls, sni: test_sni}, {name: tcp}, {name: ip}, {name: proxy-protocol, version: 1} ]
+  transactions:
+
+  - client-request:
+      version: '1.1'
+      scheme: https
+      method: POST
+      url: https://example.data.com/a/path
+      content:
+        encoding: plain
+        size: 10
+      headers:
+        encoding: esc_json
+        fields:
+        - [ Content-Type, application/json; charset=utf-8 ]
+        - [ Content-Length, '10' ]
+        - [ Host, example.com ]
+        - [ Connection, Keep-Alive ]
+        - [ Accept-Encoding, gzip ]
+        - [ uuid, 1 ]
+
+    server-response:
+      status: 200
+      reason: OK
+      content:
+        encoding: plain
+        size: 12
+      headers:
+        encoding: esc_json
+        fields:
+        - [ Content-Type, multipart/form-data;snoopy=123456 ]
+        - [ Date, "Sat, 16 Mar 2019 01:33:27 GMT" ]
+        - [ Age, '1' ]
+        - [ Connection, keep-alive ]
+        - [ Content-Length, '12' ]

--- a/test/autests/gold_tests/proxy-protocol/replay_files/https_single_transaction_pp_v1.replay.yaml
+++ b/test/autests/gold_tests/proxy-protocol/replay_files/https_single_transaction_pp_v1.replay.yaml
@@ -1,3 +1,8 @@
+# @file
+#
+# Copyright 2023, Verizon Media
+# SPDX-License-Identifier: Apache-2.0
+#
 ---
 meta:
   version: '1.0'

--- a/test/autests/gold_tests/proxy-protocol/replay_files/https_single_transaction_pp_v2.replay.yaml
+++ b/test/autests/gold_tests/proxy-protocol/replay_files/https_single_transaction_pp_v2.replay.yaml
@@ -1,0 +1,40 @@
+---
+meta:
+  version: '1.0'
+
+sessions:
+- protocol: [ {name: http, version: 1.1}, {name: tls, sni: test_sni}, {name: tcp}, {name: ip}, {name: proxy-protocol, version: 2} ]
+  transactions:
+
+  - client-request:
+      version: '1.1'
+      scheme: https
+      method: POST
+      url: https://example.data.com/a/path
+      content:
+        encoding: plain
+        size: 10
+      headers:
+        encoding: esc_json
+        fields:
+        - [ Content-Type, application/json; charset=utf-8 ]
+        - [ Content-Length, '10' ]
+        - [ Host, example.com ]
+        - [ Connection, Keep-Alive ]
+        - [ Accept-Encoding, gzip ]
+        - [ uuid, 1 ]
+
+    server-response:
+      status: 200
+      reason: OK
+      content:
+        encoding: plain
+        size: 12
+      headers:
+        encoding: esc_json
+        fields:
+        - [ Content-Type, multipart/form-data;snoopy=123456 ]
+        - [ Date, "Sat, 16 Mar 2019 01:33:27 GMT" ]
+        - [ Age, '1' ]
+        - [ Connection, keep-alive ]
+        - [ Content-Length, '12' ]

--- a/test/autests/gold_tests/proxy-protocol/replay_files/https_single_transaction_pp_v2.replay.yaml
+++ b/test/autests/gold_tests/proxy-protocol/replay_files/https_single_transaction_pp_v2.replay.yaml
@@ -1,3 +1,8 @@
+# @file
+#
+# Copyright 2023, Verizon Media
+# SPDX-License-Identifier: Apache-2.0
+#
 ---
 meta:
   version: '1.0'

--- a/test/autests/gold_tests/proxy-protocol/replay_files/single_transaction_ipv6_pp_v1.replay.yaml
+++ b/test/autests/gold_tests/proxy-protocol/replay_files/single_transaction_ipv6_pp_v1.replay.yaml
@@ -1,0 +1,49 @@
+meta:
+  version: "1.0"
+
+sessions:
+- protocol: [ { name: tcp }, {name: ip}, {name: proxy-protocol, version: 1}]
+  transactions:
+  - all: { headers: { fields: [ [ uuid, 1 ] ] } }
+
+    client-request:
+      version: "1.1"
+      scheme: "http"
+      method: "GET"
+      url: "http://example.one/config/settings.yaml"
+      headers:
+        fields:
+        - [ Host, example.one ]
+        - [ X-Test-Request, request ]
+        - [ Content-Length, 0 ]
+
+    proxy-request:
+      version: "1.1"
+      scheme: "http"
+      method: "GET"
+      url: "http://example.one/config/settings.yaml"
+      headers:
+        fields:
+        - [ Content-Length, 0 ]
+        - [ Host, { value: example.one, as: equal } ]
+        - [ X-Test-Request, { value: request, as: equal } ]
+
+    server-response:
+      status: 200
+      reason: OK
+      content:
+        size: 16
+      headers:
+        fields:
+        - [ Content-Type, text/html ]
+        - [ Content-Length, 16 ]
+        - [ X-Test-Response, response ]
+
+    proxy-response:
+      status: 200
+      reason: OK
+      content:
+        size: 16
+      headers:
+        fields:
+        - [ X-Test-Response, { value: response, as: equal } ]

--- a/test/autests/gold_tests/proxy-protocol/replay_files/single_transaction_ipv6_pp_v1.replay.yaml
+++ b/test/autests/gold_tests/proxy-protocol/replay_files/single_transaction_ipv6_pp_v1.replay.yaml
@@ -1,3 +1,9 @@
+# @file
+#
+# Copyright 2023, Verizon Media
+# SPDX-License-Identifier: Apache-2.0
+#
+
 meta:
   version: "1.0"
 

--- a/test/autests/gold_tests/proxy-protocol/replay_files/single_transaction_ipv6_pp_v2.replay.yaml
+++ b/test/autests/gold_tests/proxy-protocol/replay_files/single_transaction_ipv6_pp_v2.replay.yaml
@@ -1,3 +1,9 @@
+# @file
+#
+# Copyright 2023, Verizon Media
+# SPDX-License-Identifier: Apache-2.0
+#
+
 meta:
   version: "1.0"
 

--- a/test/autests/gold_tests/proxy-protocol/replay_files/single_transaction_ipv6_pp_v2.replay.yaml
+++ b/test/autests/gold_tests/proxy-protocol/replay_files/single_transaction_ipv6_pp_v2.replay.yaml
@@ -1,0 +1,49 @@
+meta:
+  version: "1.0"
+
+sessions:
+- protocol: [ { name: tcp }, {name: ip}, {name: proxy-protocol, version: 2}]
+  transactions:
+  - all: { headers: { fields: [ [ uuid, 1 ] ] } }
+
+    client-request:
+      version: "1.1"
+      scheme: "http"
+      method: "GET"
+      url: "http://example.one/config/settings.yaml"
+      headers:
+        fields:
+        - [ Host, example.one ]
+        - [ X-Test-Request, request ]
+        - [ Content-Length, 0 ]
+
+    proxy-request:
+      version: "1.1"
+      scheme: "http"
+      method: "GET"
+      url: "http://example.one/config/settings.yaml"
+      headers:
+        fields:
+        - [ Content-Length, 0 ]
+        - [ Host, { value: example.one, as: equal } ]
+        - [ X-Test-Request, { value: request, as: equal } ]
+
+    server-response:
+      status: 200
+      reason: OK
+      content:
+        size: 16
+      headers:
+        fields:
+        - [ Content-Type, text/html ]
+        - [ Content-Length, 16 ]
+        - [ X-Test-Response, response ]
+
+    proxy-response:
+      status: 200
+      reason: OK
+      content:
+        size: 16
+      headers:
+        fields:
+        - [ X-Test-Response, { value: response, as: equal } ]


### PR DESCRIPTION
Added PROXY protocol support in proxy verifier:

- The verifier can send a PROXY header to the target it's connecting to if specified in the replay file
- The server will detect the PROXY header at the beginning of the connection and displays it when it sees a valid header

Note that at this point, sending custom PROXY protocol content is not supported. The PROXY header the client sends would have the source address and port set to it's local address, and the destination address and port set to the target address it's connecting to, which similar to what the `--haproxy-protocol` does in `curl`.


I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
