### PR TITLE
Fix client-request delay when h2 frames specfied

### DIFF
--- a/local/src/core/YamlParser.cc
+++ b/local/src/core/YamlParser.cc
@@ -153,8 +153,8 @@ YamlParser::populate_http_message(YAML::Node const &node, HttpHeader &message)
     }
   }
 
-  YAML::Node headers_frame = node;
-  YAML::Node data_frame = node;
+  YAML::Node headers_frame;
+  YAML::Node data_frame;
   YAML::Node rst_stream_frame;
   YAML::Node goaway_frame;
   int rst_stream_index = -1;
@@ -204,6 +204,15 @@ YamlParser::populate_http_message(YAML::Node const &node, HttpHeader &message)
           YAML_FRAMES_KEY,
           frames_node.Mark());
     }
+  }
+
+  // If frame elements didn't set the headers and data frames, set them from
+  // the top level node.
+  if (headers_frame.IsNull()) {
+    headers_frame = node;
+  }
+  if (!data_frame.IsNull()) {
+    data_frame = node;
   }
 
   if (headers_frame[YAML_HTTP_STATUS_KEY]) {

--- a/local/src/core/http2.cc
+++ b/local/src/core/http2.cc
@@ -347,6 +347,11 @@ H2Session::run_transactions(
       auto current_time = ClockType::now();
       auto next_time = current_time + delay_time;
       if (txn._user_specified_delay_duration > 0us) {
+        txn_errata.note(
+            S_DIAG,
+            "Delaying transaction per transaction delay specification: {}ms",
+            duration_cast<milliseconds>(txn._user_specified_delay_duration).count());
+
         delay_time = txn._user_specified_delay_duration;
         next_time = current_time + delay_time;
       } else {

--- a/test/autests/gold_tests/delay/client-side-delay.yaml
+++ b/test/autests/gold_tests/delay/client-side-delay.yaml
@@ -72,15 +72,58 @@ sessions:
   transactions:
 
   - client-request:
-      delay: 500ms
+      delay: 1000ms
+
+      frames:
+      - HEADERS:
+          headers:
+            fields:
+            - [ :method, POST ]
+            - [ :scheme, https ]
+            - [ :authority, www.example.com ]
+            - [ :path, /pictures/flower.jpeg ]
+            - [ Content-Type, image/jpeg ]
+            - [ uuid, second-request ]
+      content:
+        size: 399
+
+    proxy-request:
+      url:
+      - [ path, { value: flower.jpeg, as: contains } ]
+
       headers:
         fields:
         - [ :method, POST ]
         - [ :scheme, https ]
         - [ :authority, www.example.com ]
-        - [ :path, /pictures/flower.jpeg ]
+        - [ :path,        { value: flower.jpeg, as: contains } ]
+        - [ Content-Type, { value: image/jpeg,  as: equal } ]
+
+    server-response:
+      headers:
+        fields:
+        - [ :status, 200 ]
+        - [ Date, "Sat, 16 Mar 2019 03:11:36 GMT" ]
         - [ Content-Type, image/jpeg ]
-        - [ uuid, second-request ]
+      content:
+        size: 3432
+
+    proxy-response:
+      status: 200
+
+  - client-request:
+      delay: 1000000us
+
+      frames:
+      - HEADERS:
+          headers:
+            fields:
+            - [ :method, POST ]
+            - [ :scheme, https ]
+            - [ :authority, www.example.com ]
+            - [ :path, /pictures/flower.jpeg ]
+            - [ Content-Type, image/jpeg ]
+            - [ uuid, third-request ]
       content:
         size: 399
 

--- a/test/autests/gold_tests/delay/delay.test.py
+++ b/test/autests/gold_tests/delay/delay.test.py
@@ -28,11 +28,11 @@ proxy = r.AddProxyProcess("proxy_https_client_delay", listen_port=client.Variabl
                           use_ssl=True, use_http2_to_2=True)
 
 server.Streams.stdout += Testers.ContainsExpression(
-    "Ready with 2 transactions.",
+    "Ready with 3 transactions.",
     "The server should have parsed 2 transactions.")
 
 client.Streams.stdout += Testers.ContainsExpression(
-    "2 transactions in 2 sessions .* in .* milliseconds",
+    "3 transactions in 2 sessions .* in .* milliseconds",
     "The client should have reported running the transactions with timing data.")
 
 client.Streams.stdout += Testers.ExcludesExpression(
@@ -49,7 +49,7 @@ server.Streams.stdout += Testers.ExcludesExpression(
 r = Test.AddTestRun("Verify the client-side delay replay took an expected amount of time to run.")
 verifier_script = 'verify_duration.py'
 client_output = client.Streams.stdout.AbsTestPath
-expected_min_delay_ms = "1500"
+expected_min_delay_ms = "3000"
 r.Processes.Default.Setup.Copy(verifier_script)
 
 r.Processes.Default.Command = \


### PR DESCRIPTION
This fixes the parsing of delay specification when HTTP/2 frames nodes are used.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
