### PR TITLE
Add the interface for client RST_STREAM await.

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,7 +460,7 @@ sessions:
 ```
 
 Note that this example specifies the following:
-* Specifies a sequence of frames to be sent under the `client-request` node. The order
+* A sequence of frames to be sent under the `client-request` node. The order
   of the frames listed is the order of the frames that Proxy Verifier will send during
   the traffic replay of the stream.
 * Thus, in this case, the client terminates the stream after sending the DATA frame since
@@ -486,11 +486,30 @@ The available options for `error-code` are:
 * INADEQUATE_SECURITY
 * HTTP_1_1_REQUIRED
 
+Finer grained frame ordering with respect to the server's response frames can
+also be specified via an `await` node which specifies which server response
+frame to wait for before sending the `RST_STREAM`. For example, to await
+sending a `RST_STREAM` until the server's response `HEADERS` frame is sent,
+specify an `await: HEADERS` directive like so:
+
+```YAML
+      - RST_STREAM:
+          error-code: INTERNAL_ERROR
+          await: HEADERS
+```
+
+Currently, the following values are supported for the `await` directive in `RST_STREAM` nodes:
+
+* `HEADERS`: await response headers from the server before sending a
+  `RST_STREAM` frame.
+* `DATA_COMPLETE`: await the entire response body via all `DATA` frames before
+  sending a `RST_STREAM` frame.
+
 #### GOAWAY frame
 
-The `GOAWAY` frame acts similar to the `RST_STREAM` frame shown above. But rather than terminating
-a stream, `GOAWAY` frame terminates the connection. It also uses the same set of `error-code` listed
-above.
+The `GOAWAY` frame acts similar to the `RST_STREAM` frame shown above. However, rather than terminating
+a stream, `GOAWAY` frame terminates the connection. It supports `error-code` and `await` as described
+for `RST_STREAM` above.
 
 #### Await
 

--- a/local/include/core/http.h
+++ b/local/include/core/http.h
@@ -159,6 +159,21 @@ static const swoc::Lexicon<H2ErrorCode> H2ErrorCodeNames{
     "INVALID_ERROR_CODE",
     H2ErrorCode::INVALID};
 
+/// Possible frame types that RST_STREAM can await upon.
+enum class H2AwaitOptions {
+  HEADERS,
+  DATA_COMPLETE,
+  INVALID = -1,
+};
+
+static const std::string H2_AWAIT_OPTION_HEADERS{"HEADERS"};
+static const std::string H2_AWAIT_OPTION_DATA_COMPLETE{"DATA_COMPLETE"};
+
+static const swoc::Lexicon<H2AwaitOptions> H2AwaitOptionNames{
+    {{H2AwaitOptions::HEADERS, H2_ERROR_CODE_NO_ERROR},
+     {H2AwaitOptions::DATA_COMPLETE, H2_AWAIT_OPTION_DATA_COMPLETE}},
+    "INVALID_AWAIT_OPTION", H2AwaitOptions::INVALID};
+
 static constexpr size_t MAX_HDR_SIZE = 131072; // The max ATS is configured for.
 static constexpr size_t MAX_DRAIN_BUFFER_SIZE = 1 << 20;
 /// HTTP end of line.
@@ -527,6 +542,9 @@ public:
   int _client_goaway_error = -1;
   int _server_goaway_after = -1;
   int _server_goaway_error = -1;
+
+  /// What response frame to await upon before sending the RST_STREAM, if any.
+  H2AwaitOptions _client_rst_stream_await = H2AwaitOptions::INVALID;
 
   /// Body is chunked.
   bool _chunked_p = false;

--- a/local/src/core/YamlParser.cc
+++ b/local/src/core/YamlParser.cc
@@ -359,6 +359,28 @@ YamlParser::populate_http_message(YAML::Node const &node, HttpHeader &message)
             YAML_ERROR_CODE_KEY,
             error_code_node.Mark());
       }
+
+      auto await_node{rst_stream_frame[YAML_HTTP_AWAIT_KEY]};
+      if (await_node.IsScalar()) {
+        auto await_str = Localizer::localize_upper(error_code_node.Scalar());
+        auto await_value = H2AwaitOptionNames[await_str];
+        if (await_value != H2AwaitOptions::INVALID) {
+          message._client_rst_stream_await = await_value;
+        } else {
+          errata.note(
+              S_ERROR,
+              R"("{}" value at {} is not a valid await option.)",
+              Localizer::localize_upper(await_str),
+              await_node.Mark());
+        }
+      } else {
+        errata.note(
+            S_ERROR,
+            R"("{}" value at {} must be a string.)",
+            YAML_HTTP_AWAIT_KEY,
+            await_node.Mark());
+      }
+
     } else {
       errata.note(S_ERROR, "The RST_STREAM frame node must NOT be the first in the frame sequence");
     }


### PR DESCRIPTION
Adds the interface for specifying that the client should await upon a response frame before sending the RST_STREAM.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
