### PR TITLE
add address specification for PROXY protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Table of Contents
             * [GOAWAY frame](#goaway-frame)
             * [Await](#await)
          * [Protocol Specification](#protocol-specification)
+            * [PROXY protocol support](#proxy-protocol-support)
          * [Session and Transaction Delay Specification](#session-and-transaction-delay-specification)
       * [Traffic Verification Specification](#traffic-verification-specification)
          * [Field Verification](#field-verification)

--- a/README.md
+++ b/README.md
@@ -705,6 +705,15 @@ If there is no `protocol` node specified, then Proxy Verifier will default to
 establishing an HTTP/1 connection over TCP (no TLS).
 
 #### PROXY protocol support
+Generally speaking, a server sitting downstream from a proxy does not have
+visibility into the client's network socket information that lies behind the
+proxy. PROXY Protocol provides a mechanism to provide visibility for this. PROXY
+protocol is a network protocol that communicates a client's source and
+destination IP and port information via a set of bytes at the start of a TCP
+connection from a proxy. Here is a link to the protocol description:
+
+https://github.com/haproxy/haproxy/blob/master/doc/proxy-protocol.txt
+
 Proxy Verifier supports sending and receiving the PROXY protocol, which can be
 helpful to verify the PROXY protocol behavior of the proxy under test.
 The feature can be enabled by specifying the `proxy-protocol` protocol node as

--- a/README.md
+++ b/README.md
@@ -660,18 +660,22 @@ TLS client hello handshake. Further, this should be transported over TCP on IP.
 
 The following nodes are supported for `protocol`:
 
-| Name   | Node                         | Supported Values    | Description
-| -----  |--------                      | ----------------    | -----------
-| http   |                              |                     |
-|        | version                      | {1, 2}              | Whether to use HTTP/1 or HTTP/2.
-| tls    |                              |                     |
-|        | sni                          | string              | The SNI to send in the TLS handshake.
-|        | request-certificate          | boolean             | Whether the client or server should request a certificate from the proxy.
-|        | proxy-provided-certificate   | boolean             | This directs the same behavior as the request-certificate directive. This alias is helpful when the node describes what happened in the past, such as in the context of a replay file specified by [Traffic Dump](https://docs.trafficserver.apache.org/en/latest/admin-guide/plugins/traffic_dump.en.html).
-|        | verify-mode                  | {0-15}              | The value to pass directly to OpenSSL's `SSL_set_verify` to control peer verification in the TLS handshake. This allows fine grained control over TLS verification behavior.  `0` corresponds with SSL_VERIFY_NONE, `1` corresponds with SSL_VERIFY_PEER, `2` corresponds with SSL_VERIFY_FAIL_IF_NO_PEER_CERT, `4` corresponds with SSL_VERIFY_CLIENT_ONCE, and `8` corresponds with SSL_VERIFY_POST_HANDSHAKE. Any bitwise OR'd value of these values can be provided. For details about their behavior, see OpenSSL's [SSL_verify_cb](https://www.openssl.org/docs/man1.1.1/man3/SSL_verify_cb.html) documentation.
-|        | alpn-protocols               | sequence of strings | This specifies the server's protocol list used in ALPN selection. See OpenSSL's [SSL_select_next_proto](https://www.openssl.org/docs/man1.0.2/man3/SSL_select_next_proto.html) documentation for details.
-| tcp    |                              |                     |
-| ip     |                              |                     |
+| Name            | Node                         | Supported Values    | Description
+| -----           |--------                      | ----------------    | -----------
+| http            |                              |                     |
+|                 | version                      | {1, 2}              | Whether to use HTTP/1 or HTTP/2.
+| tls             |                              |                     |
+|                 | sni                          | string              | The SNI to send in the TLS handshake.
+|                 | request-certificate          | boolean             | Whether the client or server should request a certificate from the proxy.
+|                 | proxy-provided-certificate   | boolean             | This directs the same behavior as the request-certificate directive. This alias is helpful when the node describes what happened in the past, such as in the context of a replay file specified by [Traffic Dump](https://docs.trafficserver.apache.org/en/latest/admin-guide/plugins/traffic_dump.en.html).
+|                 | verify-mode                  | {0-15}              | The value to pass directly to OpenSSL's `SSL_set_verify` to control peer verification in the TLS handshake. This allows fine grained control over TLS verification behavior.  `0` corresponds with SSL_VERIFY_NONE, `1` corresponds with SSL_VERIFY_PEER, `2` corresponds with SSL_VERIFY_FAIL_IF_NO_PEER_CERT, `4` corresponds with SSL_VERIFY_CLIENT_ONCE, and `8` corresponds with SSL_VERIFY_POST_HANDSHAKE. Any bitwise OR'd value of these values can be provided. For details about their behavior, see OpenSSL's [SSL_verify_cb](https://www.openssl.org/docs/man1.1.1/man3/SSL_verify_cb.html) documentation.
+|                 | alpn-protocols               | sequence of strings | This specifies the server's protocol list used in ALPN selection. See OpenSSL's [SSL_select_next_proto](https://www.openssl.org/docs/man1.0.2/man3/SSL_select_next_proto.html) documentation for details.
+| proxy-protocol  |                              |                     |
+|                 | version                      | {1, 2}              | Whether to use PROXY header v1 or v2
+|                 | src-addr                     | string              | The source address and port in the PROXY header. Specified in the format of `111.111.111.111:11111`.
+|                 | dst-addr                     | string              | The destination address and port in the PROXY header. Specified in the same format of `src-addr`.
+| tcp             |                              |                     |
+| ip              |                              |                     |
 
 
 The following protocol specification features are not currently implemented:
@@ -691,10 +695,25 @@ The following protocol specification features are not currently implemented:
   recorded in issue [100](https://github.com/yahoo/proxy-verifier/issues/100).
 * Only TCP is supported. There have been recent discussions about adding
   HTTP/3 support, which is over UDP, but work for that has not yet started.
+* the PROXY protocol support is limited to the `PROXY` command via TCP over IPv4 or IPv6. Therefore,
+  * No support for `AF_UNIX` socket address as either source and destination address.
+  * No support for UDP transport type.
+  * No support for `LOCAL` command(in v2 header).
 
 If there is no `protocol` node specified, then Proxy Verifier will default to
 establishing an HTTP/1 connection over TCP (no TLS).
 
+#### PROXY protocol support
+Proxy Verifier supports sending and receiving the PROXY protocol, which can be
+helpful to verify the PROXY protocol functionalities of the proxy under test.
+The feature can be enabled by specifying the `proxy-protocol` protocol node as
+outlined above. If enabled, the Verifier client would send out the PROXY
+protocol header at the beginning of the connection. Upon receiving a PROXY
+protocol header, the Verifier server would display it in the human-readable v1
+format. Note that the specification of source and destination addresses are
+supported but not required; if not specified, the Proxy Verifier client would
+send out PROXY message with the source and destination addresses matching the
+underlying socket, similar to how `curl --haproxy-protocol` behaves.
 ### Session and Transaction Delay Specification
 
 A user can also stipulate per session and/or per transaction delays to be

--- a/README.md
+++ b/README.md
@@ -695,7 +695,7 @@ The following protocol specification features are not currently implemented:
   recorded in issue [100](https://github.com/yahoo/proxy-verifier/issues/100).
 * Only TCP is supported. There have been recent discussions about adding
   HTTP/3 support, which is over UDP, but work for that has not yet started.
-* the PROXY protocol support is limited to the `PROXY` command via TCP over IPv4 or IPv6. Therefore,
+* The PROXY protocol support is limited to the `PROXY` command via TCP over IPv4 or IPv6. Therefore,
   * No support for `AF_UNIX` socket address as either source and destination address.
   * No support for UDP transport type.
   * No support for `LOCAL` command(in v2 header).
@@ -705,7 +705,7 @@ establishing an HTTP/1 connection over TCP (no TLS).
 
 #### PROXY protocol support
 Proxy Verifier supports sending and receiving the PROXY protocol, which can be
-helpful to verify the PROXY protocol functionalities of the proxy under test.
+helpful to verify the PROXY protocol behavior of the proxy under test.
 The feature can be enabled by specifying the `proxy-protocol` protocol node as
 outlined above. If enabled, the Verifier client would send out the PROXY
 protocol header at the beginning of the connection. Upon receiving a PROXY
@@ -714,6 +714,7 @@ format. Note that the specification of source and destination addresses are
 supported but not required; if not specified, the Proxy Verifier client would
 send out PROXY message with the source and destination addresses matching the
 underlying socket, similar to how `curl --haproxy-protocol` behaves.
+
 ### Session and Transaction Delay Specification
 
 A user can also stipulate per session and/or per transaction delays to be

--- a/README.md
+++ b/README.md
@@ -707,7 +707,7 @@ establishing an HTTP/1 connection over TCP (no TLS).
 #### PROXY protocol support
 Generally speaking, a server sitting downstream from a proxy does not have
 visibility into the client's network socket information that lies behind the
-proxy. PROXY Protocol provides a mechanism to provide visibility for this. PROXY
+proxy. PROXY Protocol is a mechanism to provide visibility for this. PROXY
 protocol is a network protocol that communicates a client's source and
 destination IP and port information via a set of bytes at the start of a TCP
 connection from a proxy. Here is a link to the protocol description:

--- a/local/include/core/YamlParser.h
+++ b/local/include/core/YamlParser.h
@@ -45,6 +45,8 @@ static const std::string YAML_SSN_PROTOCOL_VERSION{"version"};
 static const std::string YAML_SSN_PROTOCOL_TLS_NAME{"tls"};
 static const std::string YAML_SSN_PROTOCOL_HTTP_NAME{"http"};
 static const std::string YAML_SSN_PROTOCOL_PP_NAME{"proxy-protocol"};
+static const std::string YAML_SSN_PP_SRC_ADDR_KEY{"src-addr"};
+static const std::string YAML_SSN_PP_DST_ADDR_KEY{"dst-addr"};
 static const std::string YAML_SSN_TLS_SNI_KEY{"sni"};
 static const std::string YAML_SSN_TLS_ALPN_PROTOCOLS_KEY{"alpn-protocols"};
 static const std::string YAML_SSN_TLS_VERIFY_MODE_KEY{"verify-mode"};

--- a/local/include/core/http.h
+++ b/local/include/core/http.h
@@ -626,10 +626,9 @@ struct Ssn
   bool is_tls = false;
   bool is_h2 = false;
   bool is_h3 = false;
-  /// The PROXY protocol version to use for this session. If NONE, no PROXY
-  /// header is sent.
-  ProxyProtocolVersion pp_version = ProxyProtocolVersion::NONE;
-
+  /// The PROXY protocol message to send in this session. nullptr if no PROXY
+  /// protocol message is to be sent.
+  std::unique_ptr<ProxyProtocolUtil> _pp_hdr;
   swoc::Errata post_process_transactions();
 };
 
@@ -703,14 +702,13 @@ public:
    */
   virtual swoc::Errata read_and_parse_proxy_hdr();
 
+  // TODO: update doc
   /** Send the PROXY header to the target as the connection is established.
    *
    * @param[in] real_target The target of the session
    * @param[in] pp_version The version of the PROXY protocol to use
    */
-  virtual swoc::Errata send_proxy_header(
-      swoc::IPEndpoint const *real_target,
-      ProxyProtocolVersion pp_version);
+  virtual swoc::Errata send_proxy_header(ProxyProtocolUtil const &pp_msg);
 
   /** Read body bytes out of the socket.
    *
@@ -731,10 +729,12 @@ public:
       swoc::TextView bytes_read,
       std::shared_ptr<RuleCheck> rule_check = nullptr);
 
+  // TODO: may change the name of pp_msg, and possibly the ProxyProtocolUtil
+  // type name
   virtual swoc::Errata do_connect(
       swoc::TextView interface,
       swoc::IPEndpoint const *real_target,
-      ProxyProtocolVersion pp_version = ProxyProtocolVersion::NONE);
+      ProxyProtocolUtil *pp_msg = nullptr);
 
   /** Write the content in data to the socket.
    *

--- a/local/include/core/http3.h
+++ b/local/include/core/http3.h
@@ -298,14 +298,14 @@ public:
   /** Establish a QUIC connection from the given interface to the given IP
    * address.
    *
-   * @note: the pp_version parameter is added to fit the override signature of
+   * @note: the pp_msg parameter is added to fit the override signature of
    * do_connect(). There is no current support for PROXY Protocol for QUIC
    * connections.
    */
   swoc::Errata do_connect(
       swoc::TextView interface,
       swoc::IPEndpoint const *target,
-      ProxyProtocolVersion pp_version = ProxyProtocolVersion::NONE) override;
+      ProxyProtocolUtil *pp_msg = nullptr) override;
 
   /** Perform HTTP/3 global initialization.
    *

--- a/local/include/core/http3.h
+++ b/local/include/core/http3.h
@@ -305,7 +305,7 @@ public:
   swoc::Errata do_connect(
       swoc::TextView interface,
       swoc::IPEndpoint const *target,
-      ProxyProtocolUtil *pp_msg = nullptr) override;
+      ProxyProtocolMsg *pp_msg = nullptr) override;
 
   /** Perform HTTP/3 global initialization.
    *

--- a/local/include/core/proxy_protocol_util.h
+++ b/local/include/core/proxy_protocol_util.h
@@ -64,10 +64,12 @@ union ProxyHdr {
   } v2;
 };
 
+// TODO: may need to change the name to ProxyProtocolMsg or ProxyProtocolHdr
 class ProxyProtocolUtil
 {
 public:
   ProxyProtocolUtil() = default;
+  ProxyProtocolUtil(ProxyProtocolVersion version) : _version(version){};
   ProxyProtocolUtil(swoc::IPEndpoint src_ep, swoc::IPEndpoint dst_ep, ProxyProtocolVersion version)
     : _version(version)
     , _src_addr(src_ep)
@@ -106,6 +108,11 @@ public:
    * @return the destination IP endpoint.
    */
   swoc::IPEndpoint get_dst_ep() const;
+
+  /** Set the IP endpoints representing the source and destination address in
+   * the PROXY header.
+   */
+  void set_endpoints(const swoc::IPEndpoint &src_ep, const swoc::IPEndpoint &dst_ep);
 
 private:
   swoc::Rv<ssize_t> parse_pp_header_v1(swoc::TextView data);

--- a/local/include/core/proxy_protocol_util.h
+++ b/local/include/core/proxy_protocol_util.h
@@ -64,13 +64,12 @@ union ProxyHdr {
   } v2;
 };
 
-// TODO: may need to change the name to ProxyProtocolMsg or ProxyProtocolHdr
-class ProxyProtocolUtil
+class ProxyProtocolMsg
 {
 public:
-  ProxyProtocolUtil() = default;
-  ProxyProtocolUtil(ProxyProtocolVersion version) : _version(version){};
-  ProxyProtocolUtil(swoc::IPEndpoint src_ep, swoc::IPEndpoint dst_ep, ProxyProtocolVersion version)
+  ProxyProtocolMsg() = default;
+  ProxyProtocolMsg(ProxyProtocolVersion version) : _version(version){};
+  ProxyProtocolMsg(swoc::IPEndpoint src_ep, swoc::IPEndpoint dst_ep, ProxyProtocolVersion version)
     : _version(version)
     , _src_addr(src_ep)
     , _dst_addr(dst_ep){};
@@ -111,6 +110,9 @@ public:
 
   /** Set the IP endpoints representing the source and destination address in
    * the PROXY header.
+   *
+   * @param[in] src_ep the source IP endpoint.
+   * @param[in] dst_ep the destination IP endpoint.
    */
   void set_endpoints(const swoc::IPEndpoint &src_ep, const swoc::IPEndpoint &dst_ep);
 
@@ -126,19 +128,19 @@ private:
 };
 
 inline ProxyProtocolVersion
-ProxyProtocolUtil::get_version() const
+ProxyProtocolMsg::get_version() const
 {
   return _version;
 }
 
 inline swoc::IPEndpoint
-ProxyProtocolUtil::get_src_ep() const
+ProxyProtocolMsg::get_src_ep() const
 {
   return _src_addr;
 }
 
 inline swoc::IPEndpoint
-ProxyProtocolUtil::get_dst_ep() const
+ProxyProtocolMsg::get_dst_ep() const
 {
   return _dst_addr;
 }

--- a/local/src/client/verifier-client.cc
+++ b/local/src/client/verifier-client.cc
@@ -288,21 +288,21 @@ ClientReplayFileHandler::ssn_open(YAML::Node const &node)
           (pp_version_node.Scalar() == "1" || pp_version_node.Scalar() == "2"))
       {
         errata.note(S_DIAG, "Enabling PROXY protocol for this session.");
-        // set the PROXY protocol version as specified
+        // Set the PROXY protocol version as specified.
         _ssn->_pp_msg = std::make_unique<ProxyProtocolMsg>(
             (pp_version_node.Scalar() == "1") ? ProxyProtocolVersion::V1 :
                                                 ProxyProtocolVersion::V2);
-        // if the addresses are specified, set them in the PROXY protocol
-        // message
+        // If the addresses are specified, set them in the PROXY protocol
+        // message.
         auto const &pp_src_addr_node = pp_node.result()[YAML_SSN_PP_SRC_ADDR_KEY];
         auto const &pp_dst_addr_node = pp_node.result()[YAML_SSN_PP_DST_ADDR_KEY];
         if (pp_src_addr_node.IsDefined() && pp_dst_addr_node.IsDefined()) {
-          // both are specified
+          // Both are specified.
           swoc::IPEndpoint src_ep{pp_src_addr_node.Scalar()};
           swoc::IPEndpoint dst_ep{pp_dst_addr_node.Scalar()};
           _ssn->_pp_msg->set_endpoints(src_ep, dst_ep);
         } else if (pp_src_addr_node.IsDefined() || pp_dst_addr_node.IsDefined()) {
-          // only one of the source and destination address is specified
+          // Only one of the source and destination address is specified.
           errata.note(
               S_ERROR,
               R"(Invalid PROXY protocol address specification detected in
@@ -313,7 +313,8 @@ ClientReplayFileHandler::ssn_open(YAML::Node const &node)
           return errata;
         }
       } else {
-        // PROXY protocol node exists, but the version is unspecified or invalid
+        // PROXY protocol node exists, but the version is unspecified or
+        // invalid.
         errata.note(
             S_ERROR,
             R"(Invalid PROXY protocol version specified in session at "{}":{}.)",

--- a/local/src/client/verifier-client.cc
+++ b/local/src/client/verifier-client.cc
@@ -294,8 +294,7 @@ ClientReplayFileHandler::ssn_open(YAML::Node const &node)
                                                 ProxyProtocolVersion::V2);
         // if the addresses are specified, set them in the PROXY protocol
         // message
-        auto const &pp_src_addr_node =
-        pp_node.result()[YAML_SSN_PP_SRC_ADDR_KEY];
+        auto const &pp_src_addr_node = pp_node.result()[YAML_SSN_PP_SRC_ADDR_KEY];
         auto const &pp_dst_addr_node = pp_node.result()[YAML_SSN_PP_DST_ADDR_KEY];
         if (pp_src_addr_node.IsDefined() && pp_dst_addr_node.IsDefined()) {
           // both are specified

--- a/local/src/client/verifier-client.cc
+++ b/local/src/client/verifier-client.cc
@@ -289,8 +289,30 @@ ClientReplayFileHandler::ssn_open(YAML::Node const &node)
       {
         errata.note(S_DIAG, "Enabling PROXY protocol for this session.");
         // set proxy protocol header version as specified
-        _ssn->pp_version =
-            (pp_version_node.Scalar() == "1") ? ProxyProtocolVersion::V1 : ProxyProtocolVersion::V2;
+        _ssn->_pp_hdr = std::make_unique<ProxyProtocolUtil>(
+            (pp_version_node.Scalar() == "1") ? ProxyProtocolVersion::V1 :
+                                                ProxyProtocolVersion::V2);
+        // see if the addresses are specified
+        auto const &pp_src_addr_node = pp_node.result()[YAML_SSN_PP_SRC_ADDR_KEY];
+        auto const &pp_dst_addr_node = pp_node.result()[YAML_SSN_PP_DST_ADDR_KEY];
+        if (pp_src_addr_node.IsDefined() && pp_dst_addr_node.IsDefined()) {
+          swoc::IPEndpoint src_ep{pp_src_addr_node.Scalar()};
+          swoc::IPEndpoint dst_ep{pp_dst_addr_node.Scalar()};
+          errata.note(
+              S_DIAG,
+              R"(Setting PROXY protocol source address to "{}" and destination address to "{}" for this session.)",
+              src_ep,
+              dst_ep);
+          _ssn->_pp_hdr->set_endpoints(src_ep, dst_ep);
+        } else if (pp_src_addr_node.IsDefined() || pp_dst_addr_node.IsDefined()) {
+          // only one of the source and destination address is specified
+          errata.note(
+              S_ERROR,
+              R"(Invalid PROXY protocol address specified in session at "{}":{}. Need to specify none or both of the source and destination addresses)",
+              _path,
+              _ssn->_line_no);
+          return errata;
+        }
       } else {
         // unspecified or invalid versions
         errata.note(
@@ -671,7 +693,7 @@ Run_Session(Ssn const &ssn, TargetSelector &target_selector)
 
   // The PROXY protocol needs to be sent when the connection is established.
   // Thus, sending the header in do_connect()
-  errata.note(session->do_connect(specified_interface, real_target, ssn.pp_version));
+  errata.note(session->do_connect(specified_interface, real_target, ssn._pp_hdr.get()));
   if (!errata.is_ok()) {
     Engine::process_exit_code = 1;
     return;

--- a/local/src/client/verifier-client.cc
+++ b/local/src/client/verifier-client.cc
@@ -288,33 +288,33 @@ ClientReplayFileHandler::ssn_open(YAML::Node const &node)
           (pp_version_node.Scalar() == "1" || pp_version_node.Scalar() == "2"))
       {
         errata.note(S_DIAG, "Enabling PROXY protocol for this session.");
-        // set proxy protocol header version as specified
-        _ssn->_pp_hdr = std::make_unique<ProxyProtocolUtil>(
+        // set the PROXY protocol version as specified
+        _ssn->_pp_msg = std::make_unique<ProxyProtocolMsg>(
             (pp_version_node.Scalar() == "1") ? ProxyProtocolVersion::V1 :
                                                 ProxyProtocolVersion::V2);
-        // see if the addresses are specified
-        auto const &pp_src_addr_node = pp_node.result()[YAML_SSN_PP_SRC_ADDR_KEY];
+        // if the addresses are specified, set them in the PROXY protocol
+        // message
+        auto const &pp_src_addr_node =
+        pp_node.result()[YAML_SSN_PP_SRC_ADDR_KEY];
         auto const &pp_dst_addr_node = pp_node.result()[YAML_SSN_PP_DST_ADDR_KEY];
         if (pp_src_addr_node.IsDefined() && pp_dst_addr_node.IsDefined()) {
+          // both are specified
           swoc::IPEndpoint src_ep{pp_src_addr_node.Scalar()};
           swoc::IPEndpoint dst_ep{pp_dst_addr_node.Scalar()};
-          errata.note(
-              S_DIAG,
-              R"(Setting PROXY protocol source address to "{}" and destination address to "{}" for this session.)",
-              src_ep,
-              dst_ep);
-          _ssn->_pp_hdr->set_endpoints(src_ep, dst_ep);
+          _ssn->_pp_msg->set_endpoints(src_ep, dst_ep);
         } else if (pp_src_addr_node.IsDefined() || pp_dst_addr_node.IsDefined()) {
           // only one of the source and destination address is specified
           errata.note(
               S_ERROR,
-              R"(Invalid PROXY protocol address specified in session at "{}":{}. Need to specify none or both of the source and destination addresses)",
+              R"(Invalid PROXY protocol address specification detected in
+              session at "{}":{} - Need to specify none or both of the source
+              and destination addresses)",
               _path,
               _ssn->_line_no);
           return errata;
         }
       } else {
-        // unspecified or invalid versions
+        // PROXY protocol node exists, but the version is unspecified or invalid
         errata.note(
             S_ERROR,
             R"(Invalid PROXY protocol version specified in session at "{}":{}.)",
@@ -693,7 +693,7 @@ Run_Session(Ssn const &ssn, TargetSelector &target_selector)
 
   // The PROXY protocol needs to be sent when the connection is established.
   // Thus, sending the header in do_connect()
-  errata.note(session->do_connect(specified_interface, real_target, ssn._pp_hdr.get()));
+  errata.note(session->do_connect(specified_interface, real_target, ssn._pp_msg.get()));
   if (!errata.is_ok()) {
     Engine::process_exit_code = 1;
     return;

--- a/local/src/core/http.cc
+++ b/local/src/core/http.cc
@@ -920,7 +920,7 @@ Session::send_proxy_msg(ProxyProtocolMsg const &pp_msg)
   // send the data
   errata.note(
       S_DIAG,
-      "Sending PROXY header:\nsource address: {}\ndestination address: {}",
+      "Sending PROXY header: source address: {} - destination address: {}",
       pp_msg.get_src_ep(),
       pp_msg.get_dst_ep());
   // write to socket

--- a/local/src/core/http.cc
+++ b/local/src/core/http.cc
@@ -435,8 +435,7 @@ HttpHeader::verify_headers(swoc::TextView transaction_key, HttpFields const &rul
         }
       } else {
         if (!rule_check
-                 ->test(transaction_key, field_iter->first, swoc::TextView(field_iter->second)))
-        {
+                 ->test(transaction_key, field_iter->first, swoc::TextView(field_iter->second))) {
           issue_exists = true;
         }
       }
@@ -703,8 +702,7 @@ HttpHeader::Binding::operator()(BufferWriter &w, const swoc::bwf::Spec &spec) co
   if (name.starts_with_nocase(FIELD_PREFIX)) {
     name.remove_prefix(FIELD_PREFIX.size());
     if (auto spot{_hdr._fields_rules->_fields.find(name)};
-        spot != _hdr._fields_rules->_fields.end())
-    {
+        spot != _hdr._fields_rules->_fields.end()) {
       bwformat(w, spec, spot->second);
     } else {
       bwformat(w, spec, TRANSACTION_KEY_NOT_SET);

--- a/local/src/core/http3.cc
+++ b/local/src/core/http3.cc
@@ -1541,7 +1541,7 @@ Errata
 H3Session::do_connect(
     swoc::TextView interface,
     swoc::IPEndpoint const *target,
-    ProxyProtocolVersion /*pp_version*/)
+    ProxyProtocolUtil * /*pp_msg*/)
 {
   Errata errata = configure_udp_socket(interface, target);
   if (!errata.is_ok()) {
@@ -1868,14 +1868,16 @@ H3Session::~H3Session()
   }
 }
 
-swoc::Rv<ssize_t> H3Session::read(swoc::MemSpan<char> /* span */)
+swoc::Rv<ssize_t>
+H3Session::read(swoc::MemSpan<char> /* span */)
 {
   swoc::Rv<ssize_t> zret{0};
   zret.note(S_ERROR, "HTTP/3 read() called for the unsupported MemSpan overload.");
   return zret;
 }
 
-swoc::Rv<ssize_t> H3Session::write(TextView /* data */)
+swoc::Rv<ssize_t>
+H3Session::write(TextView /* data */)
 {
   swoc::Rv<ssize_t> zret{0};
   zret.note(S_ERROR, "HTTP/3 write() called for the unsupported TextView overload.");

--- a/local/src/core/http3.cc
+++ b/local/src/core/http3.cc
@@ -1868,16 +1868,14 @@ H3Session::~H3Session()
   }
 }
 
-swoc::Rv<ssize_t>
-H3Session::read(swoc::MemSpan<char> /* span */)
+swoc::Rv<ssize_t> H3Session::read(swoc::MemSpan<char> /* span */)
 {
   swoc::Rv<ssize_t> zret{0};
   zret.note(S_ERROR, "HTTP/3 read() called for the unsupported MemSpan overload.");
   return zret;
 }
 
-swoc::Rv<ssize_t>
-H3Session::write(TextView /* data */)
+swoc::Rv<ssize_t> H3Session::write(TextView /* data */)
 {
   swoc::Rv<ssize_t> zret{0};
   zret.note(S_ERROR, "HTTP/3 write() called for the unsupported TextView overload.");

--- a/local/src/core/http3.cc
+++ b/local/src/core/http3.cc
@@ -1541,7 +1541,7 @@ Errata
 H3Session::do_connect(
     swoc::TextView interface,
     swoc::IPEndpoint const *target,
-    ProxyProtocolUtil * /*pp_msg*/)
+    ProxyProtocolMsg * /*pp_msg*/)
 {
   Errata errata = configure_udp_socket(interface, target);
   if (!errata.is_ok()) {

--- a/local/src/core/proxy_protocol_util.cc
+++ b/local/src/core/proxy_protocol_util.cc
@@ -18,7 +18,7 @@ using swoc::TextView;
 using swoc::IPAddr;
 
 void
-ProxyProtocolUtil::set_endpoints(const swoc::IPEndpoint &src_ep, const swoc::IPEndpoint &dst_ep)
+ProxyProtocolMsg::set_endpoints(const swoc::IPEndpoint &src_ep, const swoc::IPEndpoint &dst_ep)
 {
   // set the source and destination endpoints
   _src_addr = src_ep;
@@ -26,7 +26,7 @@ ProxyProtocolUtil::set_endpoints(const swoc::IPEndpoint &src_ep, const swoc::IPE
 }
 
 swoc::Rv<ssize_t>
-ProxyProtocolUtil::parse_pp_header_v1(swoc::TextView data)
+ProxyProtocolMsg::parse_pp_header_v1(swoc::TextView data)
 {
   // parse the data as a PROXY header v1. The data is expected to contain the v1
   // signature to to enter this function
@@ -94,7 +94,7 @@ ProxyProtocolUtil::parse_pp_header_v1(swoc::TextView data)
 }
 
 swoc::Rv<ssize_t>
-ProxyProtocolUtil::parse_pp_header_v2(swoc::TextView data)
+ProxyProtocolMsg::parse_pp_header_v2(swoc::TextView data)
 {
   // parse the data as a PROXY header v2. The data is expected to contain the v2
   // signature to to enter this function
@@ -152,7 +152,7 @@ ProxyProtocolUtil::parse_pp_header_v2(swoc::TextView data)
 }
 
 swoc::Rv<ssize_t>
-ProxyProtocolUtil::parse_header(swoc::TextView data)
+ProxyProtocolMsg::parse_header(swoc::TextView data)
 {
   swoc::Rv<ssize_t> zret{-1};
   auto receivedBytes = data.size();
@@ -166,7 +166,7 @@ ProxyProtocolUtil::parse_header(swoc::TextView data)
 }
 
 swoc::Errata
-ProxyProtocolUtil::serialize(swoc::BufferWriter &buf) const
+ProxyProtocolMsg::serialize(swoc::BufferWriter &buf) const
 {
   swoc::Errata errata;
   if (_version == ProxyProtocolVersion::V1) {
@@ -179,7 +179,7 @@ ProxyProtocolUtil::serialize(swoc::BufferWriter &buf) const
 };
 
 swoc::Errata
-ProxyProtocolUtil::construct_v1_header(swoc::BufferWriter &buf) const
+ProxyProtocolMsg::construct_v1_header(swoc::BufferWriter &buf) const
 {
   swoc::Errata errata;
   buf.print(
@@ -197,7 +197,7 @@ ProxyProtocolUtil::construct_v1_header(swoc::BufferWriter &buf) const
 }
 
 swoc::Errata
-ProxyProtocolUtil::construct_v2_header(swoc::BufferWriter &buf) const
+ProxyProtocolMsg::construct_v2_header(swoc::BufferWriter &buf) const
 {
   swoc::Errata errata;
   ProxyHdr proxy_hdr;

--- a/local/src/core/proxy_protocol_util.cc
+++ b/local/src/core/proxy_protocol_util.cc
@@ -17,6 +17,14 @@ using swoc::Errata;
 using swoc::TextView;
 using swoc::IPAddr;
 
+void
+ProxyProtocolUtil::set_endpoints(const swoc::IPEndpoint &src_ep, const swoc::IPEndpoint &dst_ep)
+{
+  // set the source and destination endpoints
+  _src_addr = src_ep;
+  _dst_addr = dst_ep;
+}
+
 swoc::Rv<ssize_t>
 ProxyProtocolUtil::parse_pp_header_v1(swoc::TextView data)
 {
@@ -59,7 +67,6 @@ ProxyProtocolUtil::parse_pp_header_v1(swoc::TextView data)
   IPAddr dstIP(dstIPView);
 
   // parse the port
-  zret.note(S_DIAG, "before the source port content: {}", data);
   auto srcPortView = data.split_prefix_at(PP_V1_DELIMITER);
   if (srcPortView.empty()) {
     zret.note(S_ERROR, "Invalid PROXY header: expecting source port");
@@ -67,7 +74,6 @@ ProxyProtocolUtil::parse_pp_header_v1(swoc::TextView data)
   }
   auto srcPort = swoc::svto_radix<10>(srcPortView);
   // parse the dest port
-  zret.note(S_DIAG, "before the dest port content: {:x}", data);
   auto dstPortView = data.split_prefix_at('\r');
   if (dstPortView.empty()) {
     zret.note(S_ERROR, "Invalid PROXY header: expecting destination port");

--- a/test/autests/gold_tests/autest-site/proxy_protocol_context.py
+++ b/test/autests/gold_tests/autest-site/proxy_protocol_context.py
@@ -272,7 +272,11 @@ class ProxyProtocolUtil:
         if ProxyProtocolUtil.pp_version != ProxyProtocolVersion.NONE:
             # send the PROXY protocol header
             ProxyProtocolUtil.send_proxy_header(
-                sock, ProxyProtocolUtil.pp_version, ProxyProtocolUtil.src_addr, ProxyProtocolUtil.dst_addr, ProxyProtocolUtil.addr_family)
+                sock,
+                ProxyProtocolUtil.pp_version,
+                ProxyProtocolUtil.src_addr,
+                ProxyProtocolUtil.dst_addr,
+                ProxyProtocolUtil.addr_family)
         return sock
 
 

--- a/test/autests/gold_tests/proxy-protocol/proxy_protocol.test.py
+++ b/test/autests/gold_tests/proxy-protocol/proxy_protocol.test.py
@@ -58,7 +58,7 @@ class PPTest:
     def setupPPLogsVerification(self):
         # Verify the PROXY protocol related logs
         self.client.Streams.stdout += Testers.ContainsExpression(
-            rf"Sending PROXY header from 127\.0\.0\.1:[0-9]+ to 127\.0\.0\.1:{self.proxyListenPort}",
+            rf"Sending PROXY header",
             "Verify that the PROXY header is sent from the client to the proxy.")
 
         self.proxy.Streams.stdout += Testers.ContainsExpression(
@@ -85,112 +85,158 @@ class PPTest:
 PPTest("http_single_transaction", ppVersion=1, isHTTPS=False,
        testRunDesc="Verify PROXY protocol v1 is sent and received in a HTTP connection").run()
 
-# # Test 2: Verify the PROXY header v2 is sent and received in a HTTP transaction.
-PPTest("http_single_transaction", ppVersion=2, isHTTPS=False,
-       testRunDesc="Verify PROXY protocol v2 is sent and received in a HTTP connection").run()
+# # # Test 2: Verify the PROXY header v2 is sent and received in a HTTP transaction.
+# PPTest("http_single_transaction", ppVersion=2, isHTTPS=False,
+#        testRunDesc="Verify PROXY protocol v2 is sent and received in a HTTP connection").run()
 
-# # Test 3: Verify the PROXY header v1 is sent and received in a HTTPS
-# # transaction.
-PPTest("https_single_transaction", ppVersion=1, isHTTPS=True,
-       testRunDesc="Verify PROXY protocol v1 is sent and received in a HTTPS connection").run()
+# # # Test 3: Verify the PROXY header v1 is sent and received in a HTTPS
+# # # transaction.
+# PPTest("https_single_transaction", ppVersion=1, isHTTPS=True,
+#        testRunDesc="Verify PROXY protocol v1 is sent and received in a HTTPS connection").run()
 
-# # Test 4: Verify the PROXY header v2 is sent and received in a HTTPS
-# # transaction.
-PPTest("https_single_transaction", ppVersion=2, isHTTPS=True,
-       testRunDesc="Verify PROXY protocol v2 is sent and received in a HTTPS connection").run()
+# # # Test 4: Verify the PROXY header v2 is sent and received in a HTTPS
+# # # transaction.
+# PPTest("https_single_transaction", ppVersion=2, isHTTPS=True,
+#        testRunDesc="Verify PROXY protocol v2 is sent and received in a HTTPS connection").run()
 
-# Test 5: Verify the PROXY protocol is not sent when not specified in the replay
-# file
+# # Test 5: Verify the PROXY protocol is not sent when not specified in the replay
+# # file
+# r = Test.AddTestRun(
+#     "Verify the PROXY protocol is not sent when not specified in the replay file")
+
+# # Add configure_https=False to verify ATS client and server work when the https
+# # optional arguments are not provided.
+# client = r.AddClientProcess(
+#     "no-pp-client1",
+#     "replay_files/http_single_transaction_no_pp.replay.yaml",
+#     configure_https=False)
+# server = r.AddServerProcess(
+#     "no-pp-server1",
+#     "replay_files/http_single_transaction_no_pp.replay.yaml",
+#     configure_https=False)
+# proxy = r.AddProxyProcess("no-pp-proxy1", listen_port=client.Variables.http_port,
+#                           server_port=server.Variables.http_port)
+
+# # Verify the http transaction finishes successfully.
+# proxy.Streams.stdout = "gold/http_single_transaction_proxy.gold"
+# client.Streams.stdout = "gold/http_single_transaction_client.gold"
+# server.Streams.stdout = "gold/http_single_transaction_server.gold"
+
+# # Verify the PROXY protocol related logs. Since the replay file does not have
+# # the PROXY protocol related configuration, the client, proxy and server should
+# # not have these logs
+# client.Streams.stdout += Testers.ExcludesExpression(
+#     "Sending PROXY header",
+#     "Client should not send PROXY header if not asked to.")
+# proxy.Streams.stdout += Testers.ExcludesExpression(
+#     "Received .* bytes of Proxy Protocol",
+#     "Proxy should not receive the PROXY header.")
+# server.Streams.stdout += Testers.ExcludesExpression(
+#     "Received PROXY header",
+#     "The server should not receive the PROXY header.")
+
+# #
+# # Test 6: Verify the PROXY v1 message can be sent and received on IPv6
+# # connection.
+# #
+# r = Test.AddTestRun(
+#     "Verify the PROXY message can be sent and received on IPv6 connection")
+# server = r.AddServerProcess(
+#     "ipv6-server1",
+#     "replay_files/single_transaction_ipv6_pp_v1.replay.yaml",
+#     use_ipv6=True)
+# client = r.AddClientProcess(
+#     "ipv6-client1",
+#     "replay_files/single_transaction_ipv6_pp_v1.replay.yaml",
+#     use_ipv6=True,
+#     http_ports=[
+#         server.Variables.http_port],
+#     other_args="--no-proxy")
+
+# # Verify successful transaction despite PROXY protocol processing
+# client.Streams.stdout = "gold/ipv6_client.gold"
+# server.Streams.stdout = "gold/ipv6_server.gold"
+
+# # Verify the PROXY protocol related logs
+# client.Streams.stdout += Testers.ContainsExpression(
+#     rf"Sending PROXY header",
+#     "Verify that the PROXY header is sent from the client to the server.")
+
+# server.Streams.stdout += Testers.ContainsExpression(
+#     f"Received PROXY header v1:.*\nPROXY TCP6 ::.*:.*:.*:0 ::1 [0-9]+ {server.Variables.http_port}",
+#     "Verify that the server receives the PROXY header and parsed sucessfully.", reflags=re.MULTILINE)
+
+# #
+# # Test 7: Verify the PROXY v2 message can be sent and received on IPv6
+# # connection.
+# #
+# r = Test.AddTestRun(
+#     "Verify the PROXY message can be sent and received on IPv6 connection")
+# server = r.AddServerProcess(
+#     "ipv6-server2",
+#     "replay_files/single_transaction_ipv6_pp_v2.replay.yaml",
+#     use_ipv6=True)
+# client = r.AddClientProcess(
+#     "ipv6-client2",
+#     "replay_files/single_transaction_ipv6_pp_v2.replay.yaml",
+#     use_ipv6=True,
+#     http_ports=[
+#         server.Variables.http_port],
+#     other_args="--no-proxy")
+
+# # Verify successful transaction despite PROXY protocol processing
+# client.Streams.stdout = "gold/ipv6_client.gold"
+# server.Streams.stdout = "gold/ipv6_server.gold"
+
+# # Verify the PROXY protocol related logs
+# client.Streams.stdout += Testers.ContainsExpression(
+#     rf"Sending PROXY header",
+#     "Verify that the PROXY header is sent from the client to the server.")
+
+# server.Streams.stdout += Testers.ContainsExpression(
+#     f"Received PROXY header v2:.*\nPROXY TCP6 ::.*:.*:.*:0 ::1 [0-9]+ {server.Variables.http_port}",
+#     "Verify that the server receives the PROXY header and parsed sucessfully.", reflags=re.MULTILINE)
+
+# Test 8: Verify the PROXY protocol is sent with source and
+# destination addresses specified in the replay file
 r = Test.AddTestRun(
-    "Verify the PROXY protocol is not sent when not specified in the replay file")
+    "Verify the PROXY protocol is sent with the source and destination specified addresses in the replay file")
 
+EXPECTED_SRC_ADDRESS = "111.111.111.111"
+EXPECTED_SRC_PORT = "11111"
+EXPECTED_DST_ADDRESS = "222.222.222.222"
+EXPECTED_DST_PORT = "22222"
 # Add configure_https=False to verify ATS client and server work when the https
 # optional arguments are not provided.
 client = r.AddClientProcess(
-    "no-pp-client1",
-    "replay_files/http_single_transaction_no_pp.replay.yaml",
+    "specified-addr-pp-client1",
+    "replay_files/http_pp_v1_with_address.replay.yaml",
     configure_https=False)
 server = r.AddServerProcess(
-    "no-pp-server1",
-    "replay_files/http_single_transaction_no_pp.replay.yaml",
+    "specified-addr-pp-server1",
+    "replay_files/http_pp_v1_with_address.replay.yaml",
     configure_https=False)
-proxy = r.AddProxyProcess("no-pp-proxy1", listen_port=client.Variables.http_port,
-                          server_port=server.Variables.http_port)
+proxy = r.AddProxyProcess("specified-addr-pp-proxy1",
+                          listen_port=client.Variables.http_port, server_port=server.Variables.http_port)
 
 # Verify the http transaction finishes successfully.
 proxy.Streams.stdout = "gold/http_single_transaction_proxy.gold"
 client.Streams.stdout = "gold/http_single_transaction_client.gold"
 server.Streams.stdout = "gold/http_single_transaction_server.gold"
 
-# Verify the PROXY protocol related logs. Since the replay file does not have
-# the PROXY protocol related configuration, the client, proxy and server should
-# not have these logs
-client.Streams.stdout += Testers.ExcludesExpression(
-    "Sending PROXY header from",
-    "Client should not send PROXY header if not asked to.")
-proxy.Streams.stdout += Testers.ExcludesExpression(
-    "Received .* bytes of Proxy Protocol",
-    "Proxy should not receive the PROXY header.")
-server.Streams.stdout += Testers.ExcludesExpression(
-    "Received PROXY header",
-    "The server should not receive the PROXY header.")
-
-#
-# Test 6: Verify the PROXY v1 message can be sent and received on IPv6
-# connection.
-#
-r = Test.AddTestRun("Verify the PROXY message can be sent and received on IPv6 connection")
-server = r.AddServerProcess(
-    "ipv6-server1",
-    "replay_files/single_transaction_ipv6_pp_v1.replay.yaml",
-    use_ipv6=True)
-client = r.AddClientProcess(
-    "ipv6-client1",
-    "replay_files/single_transaction_ipv6_pp_v1.replay.yaml",
-    use_ipv6=True,
-    http_ports=[
-        server.Variables.http_port],
-    other_args="--no-proxy")
-
-# Verify successful transaction despite PROXY protocol processing
-client.Streams.stdout = "gold/ipv6_client.gold"
-server.Streams.stdout = "gold/ipv6_server.gold"
-
-# Verify the PROXY protocol related logs
+# Verify the PROXY protocol related logs. Make sure the source and destination
+# address of the PROXY header matche the ones specified in the replay file
 client.Streams.stdout += Testers.ContainsExpression(
-    rf"Sending PROXY header from \[::a00:.*:0:0\]:[0-9]+ to \[::1\]:{server.Variables.http_port}",
-    "Verify that the PROXY header is sent from the client to the server.")
+    rf"Sending PROXY header",
+    "Verify that the PROXY header is sent from the client to the proxy.")
+
+proxy.Streams.stdout += Testers.ContainsExpression(
+    f"Received .* bytes of Proxy Protocol",
+    "Verify that the PROXY header is received by the proxy.")
+proxy.Streams.stdout += Testers.ContainsExpression(
+    rf"PROXY TCP4 {EXPECTED_SRC_ADDRESS} {EXPECTED_DST_ADDRESS} {EXPECTED_SRC_PORT} {EXPECTED_DST_PORT}",
+    "Verify the client sends a PROXY header with the specified source and destination addresses.")
 
 server.Streams.stdout += Testers.ContainsExpression(
-    f"Received PROXY header v1:.*\nPROXY TCP6 ::a00:.*:0:0 ::1 [0-9]+ {server.Variables.http_port}",
-    "Verify that the server receives the PROXY header and parsed sucessfully.", reflags=re.MULTILINE)
-
-#
-# Test 6: Verify the PROXY v2 message can be sent and received on IPv6
-# connection.
-#
-r = Test.AddTestRun("Verify the PROXY message can be sent and received on IPv6 connection")
-server = r.AddServerProcess(
-    "ipv6-server2",
-    "replay_files/single_transaction_ipv6_pp_v2.replay.yaml",
-    use_ipv6=True)
-client = r.AddClientProcess(
-    "ipv6-client2",
-    "replay_files/single_transaction_ipv6_pp_v2.replay.yaml",
-    use_ipv6=True,
-    http_ports=[
-        server.Variables.http_port],
-    other_args="--no-proxy")
-
-# Verify successful transaction despite PROXY protocol processing
-client.Streams.stdout = "gold/ipv6_client.gold"
-server.Streams.stdout = "gold/ipv6_server.gold"
-
-# Verify the PROXY protocol related logs
-client.Streams.stdout += Testers.ContainsExpression(
-    rf"Sending PROXY header from \[::a00:.*:0:0\]:[0-9]+ to \[::1\]:{server.Variables.http_port}",
-    "Verify that the PROXY header is sent from the client to the server.")
-
-server.Streams.stdout += Testers.ContainsExpression(
-    f"Received PROXY header v2:.*\nPROXY TCP6 ::a00:.*:0:0 ::1 [0-9]+ {server.Variables.http_port}",
+    rf"Received PROXY header v1:.*\nPROXY TCP4 {EXPECTED_SRC_ADDRESS} {EXPECTED_DST_ADDRESS} {EXPECTED_SRC_PORT} {EXPECTED_DST_PORT}",
     "Verify that the server receives the PROXY header and parsed sucessfully.", reflags=re.MULTILINE)

--- a/test/autests/gold_tests/proxy-protocol/proxy_protocol.test.py
+++ b/test/autests/gold_tests/proxy-protocol/proxy_protocol.test.py
@@ -206,6 +206,8 @@ EXPECTED_SRC_ADDRESS = "111.111.111.111"
 EXPECTED_SRC_PORT = "11111"
 EXPECTED_DST_ADDRESS = "222.222.222.222"
 EXPECTED_DST_PORT = "22222"
+EXPECTED_PROXY_HEADER = f"PROXY TCP4 {EXPECTED_SRC_ADDRESS} {EXPECTED_DST_ADDRESS} {EXPECTED_SRC_PORT} {EXPECTED_DST_PORT}"
+
 # Add configure_https=False to verify ATS client and server work when the https
 # optional arguments are not provided.
 client = r.AddClientProcess(
@@ -225,7 +227,7 @@ client.Streams.stdout = "gold/http_single_transaction_client.gold"
 server.Streams.stdout = "gold/http_single_transaction_server.gold"
 
 # Verify the PROXY protocol related logs. Make sure the source and destination
-# address of the PROXY header matche the ones specified in the replay file
+# addresses of the PROXY header match the ones specified in the replay file
 client.Streams.stdout += Testers.ContainsExpression(
     rf"Sending PROXY header",
     "Verify that the PROXY header is sent from the client to the proxy.")
@@ -234,9 +236,9 @@ proxy.Streams.stdout += Testers.ContainsExpression(
     f"Received .* bytes of Proxy Protocol",
     "Verify that the PROXY header is received by the proxy.")
 proxy.Streams.stdout += Testers.ContainsExpression(
-    rf"PROXY TCP4 {EXPECTED_SRC_ADDRESS} {EXPECTED_DST_ADDRESS} {EXPECTED_SRC_PORT} {EXPECTED_DST_PORT}",
+    rf"{EXPECTED_PROXY_HEADER}",
     "Verify the client sends a PROXY header with the specified source and destination addresses.")
 
 server.Streams.stdout += Testers.ContainsExpression(
-    rf"Received PROXY header v1:.*\nPROXY TCP4 {EXPECTED_SRC_ADDRESS} {EXPECTED_DST_ADDRESS} {EXPECTED_SRC_PORT} {EXPECTED_DST_PORT}",
+    rf"Received PROXY header v1:.*\n{EXPECTED_PROXY_HEADER}",
     "Verify that the server receives the PROXY header and parsed sucessfully.", reflags=re.MULTILINE)

--- a/test/autests/gold_tests/proxy-protocol/proxy_protocol.test.py
+++ b/test/autests/gold_tests/proxy-protocol/proxy_protocol.test.py
@@ -69,7 +69,7 @@ class PPTest:
             "Verify the client sends a valid PROXY header.")
 
         self.server.Streams.stdout += Testers.ContainsExpression(
-            rf"Received PROXY header v{self.ppVersion}:.*\nPROXY TCP4 127\.0\.0\.1 127\.0\.0\.1 [0-9]+ {self.serverListenPort}",
+            rf"Received PROXY header v{self.ppVersion}:.*\nPROXY TCP4 127\.0\.0\.1 127\.0\.0\.1 [0-9]+ {self.proxyListenPort}",
             "Verify that the server receives the PROXY header and parsed sucessfully.", reflags=re.MULTILINE)
 
     def run(self):
@@ -81,121 +81,121 @@ class PPTest:
         PPTest.test_id += 1
 
 
-# # Test 1: Verify the PROXY header v1 is sent and received in a HTTP transaction.
+# Test 1: Verify the PROXY header v1 is sent and received in a HTTP transaction.
 PPTest("http_single_transaction", ppVersion=1, isHTTPS=False,
        testRunDesc="Verify PROXY protocol v1 is sent and received in a HTTP connection").run()
 
-# # # Test 2: Verify the PROXY header v2 is sent and received in a HTTP transaction.
-# PPTest("http_single_transaction", ppVersion=2, isHTTPS=False,
-#        testRunDesc="Verify PROXY protocol v2 is sent and received in a HTTP connection").run()
+# Test 2: Verify the PROXY header v2 is sent and received in a HTTP transaction.
+PPTest("http_single_transaction", ppVersion=2, isHTTPS=False,
+       testRunDesc="Verify PROXY protocol v2 is sent and received in a HTTP connection").run()
 
-# # # Test 3: Verify the PROXY header v1 is sent and received in a HTTPS
-# # # transaction.
-# PPTest("https_single_transaction", ppVersion=1, isHTTPS=True,
-#        testRunDesc="Verify PROXY protocol v1 is sent and received in a HTTPS connection").run()
+# Test 3: Verify the PROXY header v1 is sent and received in a HTTPS
+# transaction.
+PPTest("https_single_transaction", ppVersion=1, isHTTPS=True,
+       testRunDesc="Verify PROXY protocol v1 is sent and received in a HTTPS connection").run()
 
-# # # Test 4: Verify the PROXY header v2 is sent and received in a HTTPS
-# # # transaction.
-# PPTest("https_single_transaction", ppVersion=2, isHTTPS=True,
-#        testRunDesc="Verify PROXY protocol v2 is sent and received in a HTTPS connection").run()
+# Test 4: Verify the PROXY header v2 is sent and received in a HTTPS
+# transaction.
+PPTest("https_single_transaction", ppVersion=2, isHTTPS=True,
+       testRunDesc="Verify PROXY protocol v2 is sent and received in a HTTPS connection").run()
 
-# # Test 5: Verify the PROXY protocol is not sent when not specified in the replay
-# # file
-# r = Test.AddTestRun(
-#     "Verify the PROXY protocol is not sent when not specified in the replay file")
+# Test 5: Verify the PROXY protocol is not sent when not specified in the replay
+# file
+r = Test.AddTestRun(
+    "Verify the PROXY protocol is not sent when not specified in the replay file")
 
-# # Add configure_https=False to verify ATS client and server work when the https
-# # optional arguments are not provided.
-# client = r.AddClientProcess(
-#     "no-pp-client1",
-#     "replay_files/http_single_transaction_no_pp.replay.yaml",
-#     configure_https=False)
-# server = r.AddServerProcess(
-#     "no-pp-server1",
-#     "replay_files/http_single_transaction_no_pp.replay.yaml",
-#     configure_https=False)
-# proxy = r.AddProxyProcess("no-pp-proxy1", listen_port=client.Variables.http_port,
-#                           server_port=server.Variables.http_port)
+# Add configure_https=False to verify ATS client and server work when the https
+# optional arguments are not provided.
+client = r.AddClientProcess(
+    "no-pp-client1",
+    "replay_files/http_single_transaction_no_pp.replay.yaml",
+    configure_https=False)
+server = r.AddServerProcess(
+    "no-pp-server1",
+    "replay_files/http_single_transaction_no_pp.replay.yaml",
+    configure_https=False)
+proxy = r.AddProxyProcess("no-pp-proxy1", listen_port=client.Variables.http_port,
+                          server_port=server.Variables.http_port)
 
-# # Verify the http transaction finishes successfully.
-# proxy.Streams.stdout = "gold/http_single_transaction_proxy.gold"
-# client.Streams.stdout = "gold/http_single_transaction_client.gold"
-# server.Streams.stdout = "gold/http_single_transaction_server.gold"
+# Verify the http transaction finishes successfully.
+proxy.Streams.stdout = "gold/http_single_transaction_proxy.gold"
+client.Streams.stdout = "gold/http_single_transaction_client.gold"
+server.Streams.stdout = "gold/http_single_transaction_server.gold"
 
-# # Verify the PROXY protocol related logs. Since the replay file does not have
-# # the PROXY protocol related configuration, the client, proxy and server should
-# # not have these logs
-# client.Streams.stdout += Testers.ExcludesExpression(
-#     "Sending PROXY header",
-#     "Client should not send PROXY header if not asked to.")
-# proxy.Streams.stdout += Testers.ExcludesExpression(
-#     "Received .* bytes of Proxy Protocol",
-#     "Proxy should not receive the PROXY header.")
-# server.Streams.stdout += Testers.ExcludesExpression(
-#     "Received PROXY header",
-#     "The server should not receive the PROXY header.")
+# Verify the PROXY protocol related logs. Since the replay file does not have
+# the PROXY protocol related configuration, the client, proxy and server should
+# not have these logs
+client.Streams.stdout += Testers.ExcludesExpression(
+    "Sending PROXY header",
+    "Client should not send PROXY header if not asked to.")
+proxy.Streams.stdout += Testers.ExcludesExpression(
+    "Received .* bytes of Proxy Protocol",
+    "Proxy should not receive the PROXY header.")
+server.Streams.stdout += Testers.ExcludesExpression(
+    "Received PROXY header",
+    "The server should not receive the PROXY header.")
 
-# #
-# # Test 6: Verify the PROXY v1 message can be sent and received on IPv6
-# # connection.
-# #
-# r = Test.AddTestRun(
-#     "Verify the PROXY message can be sent and received on IPv6 connection")
-# server = r.AddServerProcess(
-#     "ipv6-server1",
-#     "replay_files/single_transaction_ipv6_pp_v1.replay.yaml",
-#     use_ipv6=True)
-# client = r.AddClientProcess(
-#     "ipv6-client1",
-#     "replay_files/single_transaction_ipv6_pp_v1.replay.yaml",
-#     use_ipv6=True,
-#     http_ports=[
-#         server.Variables.http_port],
-#     other_args="--no-proxy")
+#
+# Test 6: Verify the PROXY v1 message can be sent and received on IPv6
+# connection.
+#
+r = Test.AddTestRun(
+    "Verify the PROXY message can be sent and received on IPv6 connection")
+server = r.AddServerProcess(
+    "ipv6-server1",
+    "replay_files/single_transaction_ipv6_pp_v1.replay.yaml",
+    use_ipv6=True)
+client = r.AddClientProcess(
+    "ipv6-client1",
+    "replay_files/single_transaction_ipv6_pp_v1.replay.yaml",
+    use_ipv6=True,
+    http_ports=[
+        server.Variables.http_port],
+    other_args="--no-proxy")
 
-# # Verify successful transaction despite PROXY protocol processing
-# client.Streams.stdout = "gold/ipv6_client.gold"
-# server.Streams.stdout = "gold/ipv6_server.gold"
+# Verify successful transaction despite PROXY protocol processing
+client.Streams.stdout = "gold/ipv6_client.gold"
+server.Streams.stdout = "gold/ipv6_server.gold"
 
-# # Verify the PROXY protocol related logs
-# client.Streams.stdout += Testers.ContainsExpression(
-#     rf"Sending PROXY header",
-#     "Verify that the PROXY header is sent from the client to the server.")
+# Verify the PROXY protocol related logs
+client.Streams.stdout += Testers.ContainsExpression(
+    rf"Sending PROXY header",
+    "Verify that the PROXY header is sent from the client to the server.")
 
-# server.Streams.stdout += Testers.ContainsExpression(
-#     f"Received PROXY header v1:.*\nPROXY TCP6 ::.*:.*:.*:0 ::1 [0-9]+ {server.Variables.http_port}",
-#     "Verify that the server receives the PROXY header and parsed sucessfully.", reflags=re.MULTILINE)
+server.Streams.stdout += Testers.ContainsExpression(
+    f"Received PROXY header v1:.*\nPROXY TCP6 ::.*:.*:.*:0 ::1 [0-9]+ {server.Variables.http_port}",
+    "Verify that the server receives the PROXY header and parsed sucessfully.", reflags=re.MULTILINE)
 
-# #
-# # Test 7: Verify the PROXY v2 message can be sent and received on IPv6
-# # connection.
-# #
-# r = Test.AddTestRun(
-#     "Verify the PROXY message can be sent and received on IPv6 connection")
-# server = r.AddServerProcess(
-#     "ipv6-server2",
-#     "replay_files/single_transaction_ipv6_pp_v2.replay.yaml",
-#     use_ipv6=True)
-# client = r.AddClientProcess(
-#     "ipv6-client2",
-#     "replay_files/single_transaction_ipv6_pp_v2.replay.yaml",
-#     use_ipv6=True,
-#     http_ports=[
-#         server.Variables.http_port],
-#     other_args="--no-proxy")
+#
+# Test 7: Verify the PROXY v2 message can be sent and received on IPv6
+# connection.
+#
+r = Test.AddTestRun(
+    "Verify the PROXY message can be sent and received on IPv6 connection")
+server = r.AddServerProcess(
+    "ipv6-server2",
+    "replay_files/single_transaction_ipv6_pp_v2.replay.yaml",
+    use_ipv6=True)
+client = r.AddClientProcess(
+    "ipv6-client2",
+    "replay_files/single_transaction_ipv6_pp_v2.replay.yaml",
+    use_ipv6=True,
+    http_ports=[
+        server.Variables.http_port],
+    other_args="--no-proxy")
 
-# # Verify successful transaction despite PROXY protocol processing
-# client.Streams.stdout = "gold/ipv6_client.gold"
-# server.Streams.stdout = "gold/ipv6_server.gold"
+# Verify successful transaction despite PROXY protocol processing
+client.Streams.stdout = "gold/ipv6_client.gold"
+server.Streams.stdout = "gold/ipv6_server.gold"
 
-# # Verify the PROXY protocol related logs
-# client.Streams.stdout += Testers.ContainsExpression(
-#     rf"Sending PROXY header",
-#     "Verify that the PROXY header is sent from the client to the server.")
+# Verify the PROXY protocol related logs
+client.Streams.stdout += Testers.ContainsExpression(
+    rf"Sending PROXY header",
+    "Verify that the PROXY header is sent from the client to the server.")
 
-# server.Streams.stdout += Testers.ContainsExpression(
-#     f"Received PROXY header v2:.*\nPROXY TCP6 ::.*:.*:.*:0 ::1 [0-9]+ {server.Variables.http_port}",
-#     "Verify that the server receives the PROXY header and parsed sucessfully.", reflags=re.MULTILINE)
+server.Streams.stdout += Testers.ContainsExpression(
+    f"Received PROXY header v2:.*\nPROXY TCP6 ::.*:.*:.*:0 ::1 [0-9]+ {server.Variables.http_port}",
+    "Verify that the server receives the PROXY header and parsed sucessfully.", reflags=re.MULTILINE)
 
 # Test 8: Verify the PROXY protocol is sent with source and
 # destination addresses specified in the replay file

--- a/test/autests/gold_tests/proxy-protocol/proxy_protocol.test.py
+++ b/test/autests/gold_tests/proxy-protocol/proxy_protocol.test.py
@@ -218,8 +218,10 @@ server = r.AddServerProcess(
     "specified-addr-pp-server1",
     "replay_files/http_pp_v1_with_address.replay.yaml",
     configure_https=False)
-proxy = r.AddProxyProcess("specified-addr-pp-proxy1",
-                          listen_port=client.Variables.http_port, server_port=server.Variables.http_port)
+proxy = r.AddProxyProcess(
+    "specified-addr-pp-proxy1",
+    listen_port=client.Variables.http_port,
+    server_port=server.Variables.http_port)
 
 # Verify the http transaction finishes successfully.
 proxy.Streams.stdout = "gold/http_single_transaction_proxy.gold"
@@ -241,4 +243,5 @@ proxy.Streams.stdout += Testers.ContainsExpression(
 
 server.Streams.stdout += Testers.ContainsExpression(
     rf"Received PROXY header v1:.*\n{EXPECTED_PROXY_HEADER}",
-    "Verify that the server receives the PROXY header and parsed sucessfully.", reflags=re.MULTILINE)
+    "Verify that the server receives the PROXY header and parsed sucessfully.",
+    reflags=re.MULTILINE)

--- a/test/autests/gold_tests/proxy-protocol/replay_files/http_pp_v1_with_address.replay.yaml
+++ b/test/autests/gold_tests/proxy-protocol/replay_files/http_pp_v1_with_address.replay.yaml
@@ -1,0 +1,92 @@
+# @file
+#
+# Copyright 2023, Verizon Media
+# SPDX-License-Identifier: Apache-2.0
+#
+
+meta:
+  version: '1.0'
+
+# This file is taken largely from a sample Traffic Dump file.
+sessions:
+- connection-time: 1552705896896003926
+  # the source and destination addresses are specified and will be used in the
+  # PROXY header
+  protocol: [ { name: tcp }, {name: ip}, {name: proxy-protocol, version: 1,
+  src-addr: 111.111.111.111:11111, dst-addr: 222.222.222.222:22222} ]
+
+  transactions:
+  - start-time: 1552705896896042340
+    uuid: cb9b4e94-5d42-43d4-8545-320033298ba2-226381119
+
+    client-request:
+      method: POST
+      url: http://example.com/client.do
+      version: '1.1'
+      headers:
+        encoding: esc_json
+        fields:
+        - [ Content-Length, '399' ]
+        - [ Content-Type, application/octet-stream ]
+        - [ Host, example.com ]
+        - [ Connection, Keep-Alive ]
+        - [ X-CANDY, cane ]
+        - [ X-SomeID, fda39dfad1 ]
+        - [ uuid, cb9b4e94-5d42-43d4-8545-320033298ba2-226381119 ]
+      content:
+        encoding: plain
+        size: 399
+
+    proxy-request:
+      content:
+        encoding: plain
+        size: 399
+      headers:
+        encoding: esc_json
+        fields:
+        - [ Content-Length, '399' ]
+        - [ Content-Type, application/octet-stream ]
+        - [ Host, example.com ]
+        - [ Client-ip, 10.10.10.1 ]
+        - [ X-Forwarded-For, 10.10.10.2 ]
+        - [ Via, http/1.1 example.data.com (Poland) ]
+        - [ X-SomeId, fda39dfad1 ]
+        - [ uuid, cb9b4e94-5d42-43d4-8545-320033298ba2-226381119 ]
+      method: POST
+      url: /proxy.do
+      version: '1.1'
+
+    proxy-response:
+      content:
+        encoding: plain
+        size: 0
+      headers:
+        encoding: esc_json
+        fields:
+        - [ Date, "Sat, 16 Mar 2019 03:11:36 GMT" ]
+        - [ X-TestHeader, from_proxy_response ]
+        - [ Content-Type, application/octet-stream ]
+        - [ Content-Length, '10' ]
+        - [ Age, '0' ]
+        - [ Server, ATS ]
+        - [ Connection, keep-alive ]
+      reason: OK
+      status: 200
+
+    server-response:
+      content:
+        encoding: plain
+        size: 0
+      headers:
+        encoding: esc_json
+        fields:
+        - [ Date, "Sat, 16 Mar 2019 03:11:36 GMT" ]
+        - [ X-TestHeader, from_server_response ]
+        - [ Content-Type, application/octet-stream ]
+        - [ Content-Length, '10' ]
+        - [ Age, '0' ]
+        - [ Via, "http/1.1 example.data1.com, http/1.1 example.data2.com" ]
+        - [ Server, ATS ]
+        - [ Connection, keep-alive ]
+      reason: OK
+      status: 200


### PR DESCRIPTION
This PR contains the following changes:
* Allow specifying the source and destination address(the PROXY header content) in the replay file
* Updated the test proxy to send PROXY header with the source and destination address matching the PROXY header it received from the client
* Updated the README.md for PROXY protocol support

Note: if user doesn't specify source and destination addresses in the replay file, it will retain the `curl --haproxy-protocol` behavior, aka using the endpoint address of the underlying socket as the source and destination addresses.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
