### PR TITLE
Added HTTP response reason string verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -1068,7 +1068,9 @@ verification.
 Proxy HTTP response status verification is specified in `proxy-response`
 nodes. In this case, the response status that the Verifier client should expect
 from the proxy is specified in the same way that directs the Verifier server
-in what response status should be sent for a given request.
+in what response status should be sent for a given request. Both response code,
+such as "403", and HTTP/1 response reason string, such as "Forbidden", are
+supported for verification.
 
 For example, the following complete `proxy-response` node directs the Proxy
 Verifier client to verify that the proxy replies to the associated HTTP request
@@ -1077,13 +1079,12 @@ with a `404` status:
 ```YAML
   proxy-response:
     status: 404
+    reason: Not Found
 ```
 
 This verification directive applies to HTTP/1 transactions. For HTTP/2, status
 verification is specified via `:status` pseudo header field verification using
 the field verification mechanism described above.
-
-Verification of HTTP response reason strings, such as "Not Found", is also supported.
 
 ### Body Verification
 

--- a/README.md
+++ b/README.md
@@ -1083,8 +1083,7 @@ This verification directive applies to HTTP/1 transactions. For HTTP/2, status
 verification is specified via `:status` pseudo header field verification using
 the field verification mechanism described above.
 
-Verification of HTTP response reason strings, such as "Not Found", is not
-currently supported.
+Verification of HTTP response reason strings, such as "Not Found", is also supported.
 
 ### Body Verification
 

--- a/test/autests/gold_tests/status_verification/replay_files/status_verification.yaml
+++ b/test/autests/gold_tests/status_verification/replay_files/status_verification.yaml
@@ -1,0 +1,104 @@
+# @file
+#
+# Copyright 2023, Verizon Media
+# SPDX-License-Identifier: Apache-2.0
+#
+
+meta:
+  version: "1.0"
+
+# Basic HTTP transactions to verify the correct behavior of response status
+# verification(status code and reason string)
+sessions:
+  - protocol: [{ name: tcp }, { name: ip }]
+    transactions:
+      - client-request:
+          version: "1.1"
+          method: "GET"
+          url: "http://example.one:8080/config/settings.yaml?q=3"
+          headers:
+            fields:
+              - [Host, example.one]
+              - [uuid, 1]
+
+        server-response:
+          status: 200
+          reason: OK
+          content:
+            size: 16
+          headers:
+            fields:
+              - [Content-Length, 16]
+              - [uuid, 1]
+        proxy-response:
+          # expected status code matches the one listed in server-response
+          status: 200
+
+      - client-request:
+          version: "1.1"
+          method: "GET"
+          url: "http://example.one:8080/config/settings.yaml?q=3"
+          headers:
+            fields:
+              - [Host, example.one]
+              - [uuid, 2]
+
+        server-response:
+          status: 200
+          reason: OK
+          content:
+            size: 16
+          headers:
+            fields:
+              - [Content-Length, 16]
+              - [uuid, 2]
+        proxy-response:
+          # expected status code doesn't match the one listed in server-response
+          status: 404
+
+      - client-request:
+          version: "1.1"
+          method: "GET"
+          url: "http://example.one:8080/config/settings.yaml?q=3"
+          headers:
+            fields:
+              - [Host, example.one]
+              - [uuid, 3]
+
+        server-response:
+          status: 200
+          reason: OK
+          content:
+            size: 16
+          headers:
+            fields:
+              - [Content-Length, 16]
+              - [uuid, 3]
+        proxy-response:
+          status: 200
+          # expected reason string matches the one listed in server-response
+          reason: OK
+
+      - client-request:
+          version: "1.1"
+          method: "GET"
+          url: "http://example.one:8080/config/settings.yaml?q=3"
+          headers:
+            fields:
+              - [Host, example.one]
+              - [uuid, 4]
+
+        server-response:
+          status: 200
+          reason: OK
+          content:
+            size: 16
+          headers:
+            fields:
+              - [Content-Length, 16]
+              - [uuid, 4]
+        proxy-response:
+          status: 200
+          # expected reason string doesn't match the one listed in
+          # server-response
+          reason: Not Found

--- a/test/autests/gold_tests/status_verification/status_verification.test.py
+++ b/test/autests/gold_tests/status_verification/status_verification.test.py
@@ -1,0 +1,39 @@
+'''
+Verify correct response status(status code and reason) verification behavior.
+'''
+# @file
+#
+# Copyright 2023, Verizon Media
+# SPDX-License-Identifier: Apache-2.0
+#
+
+Test.Summary = '''
+Verify correct response status(status code and reason) verification behavior.
+'''
+
+#
+# Test 1: Verify status verification in a YAML replay file.
+#
+r = Test.AddTestRun(
+    "Verify status verification works for simple HTTP transactions")
+client = r.AddClientProcess(
+    "client1", "replay_files/status_verification.yaml")
+server = r.AddServerProcess(
+    "server1", "replay_files/status_verification.yaml")
+proxy = r.AddProxyProcess("proxy1", listen_port=client.Variables.http_port,
+                          server_port=server.Variables.http_port)
+
+# Verify status validation logs.
+client.Streams.stdout = Testers.ExcludesExpression(
+    'Violation.*key: 1',
+    'Transaction 1 should not have any violation since the status code matches the expected.')
+client.Streams.stdout += Testers.ContainsExpression(
+    'Status Violation:.*key: 2',
+    'Transaction 2 should have status violation as the status code does not match the expected.')
+client.Streams.stdout += Testers.ExcludesExpression(
+    'Violation.*key: 3',
+    'Transaction 3 should not have violation since the reason string matches the expected.')
+client.Streams.stdout += Testers.ContainsExpression(
+    'Reason String Violation:.*key: 4',
+    'Transaction 4 should have violation as the reason string does not match the expected.')
+client.ReturnCode = 1


### PR DESCRIPTION
This PR adds the HTTP response reason string verification, as proposed in #227 .


I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
