### PR TITLE
Add the interface for adding delay before sending H2 frames

### DIFF
--- a/local/include/core/http.h
+++ b/local/include/core/http.h
@@ -516,17 +516,16 @@ public:
 
   std::deque<H2Frame> _h2_frame_sequence;
 
-  // Note that _client_rst_stream_after will only be set for Verifier clients, and
-  // _server_rst_stream_after will only be set for verifier servers.
-  int _client_rst_stream_after = -1;
+  // Note that _client_rst_stream_error will only be set for Verifier clients, and
+  // _server_rst_stream_error will only be set for verifier servers.
   int _client_rst_stream_error = -1;
-  int _server_rst_stream_after = -1;
   int _server_rst_stream_error = -1;
 
-  int _client_goaway_after = -1;
   int _client_goaway_error = -1;
-  int _server_goaway_after = -1;
   int _server_goaway_error = -1;
+
+  std::map<H2Frame, std::chrono::microseconds> _client_frame_delay;
+  std::map<H2Frame, std::chrono::microseconds> _server_frame_delay;
 
   /// Body is chunked.
   bool _chunked_p = false;

--- a/local/include/core/http2.h
+++ b/local/include/core/http2.h
@@ -81,17 +81,15 @@ public:
   /// The HTTP response headers for this stream.
   std::shared_ptr<HttpHeader> _response_from_server;
 
-  // Note that _client_rst_stream_after will only be set for Verifier clients, and
-  // _server_rst_stream_after will only be set for verifier servers.
-  int _client_rst_stream_after = -1;
+  // Note that _client_rst_stream_error will only be set for Verifier clients, and
+  // _server_rst_stream_error will only be set for verifier servers.
   int _client_rst_stream_error = -1;
-  int _server_rst_stream_after = -1;
   int _server_rst_stream_error = -1;
 
-  int _client_goaway_after = -1;
   int _client_goaway_error = -1;
-  int _server_goaway_after = -1;
   int _server_goaway_error = -1;
+
+  std::deque<H2Frame> _h2_frame_sequence;
 
 private:
   int32_t _stream_id = -1;
@@ -214,6 +212,16 @@ private:
    * @return Whether the transaction is still awaiting upon other configured streams.
    */
   bool request_has_outstanding_stream_dependencies(HttpHeader const &request) const;
+
+  swoc::Errata frame_delay(HttpHeader const &hdr, H2Frame curr_frame);
+  swoc::Errata submit_headers_frame(
+      HttpHeader const &hdr,
+      H2StreamState *stream_state,
+      std::shared_ptr<H2StreamState> new_stream_state,
+      uint8_t flags);
+  swoc::Errata submit_data_frame(HttpHeader const &hdr, H2StreamState *stream_state, uint8_t flags);
+  swoc::Errata submit_rst_stream_frame(H2StreamState *stream_state, H2Frame prev_frame);
+  swoc::Errata submit_goaway_frame(H2StreamState *stream_state, H2Frame prev_frame);
 
 private:
   /// Whether this session is for a listening server.

--- a/local/src/core/http2.cc
+++ b/local/src/core/http2.cc
@@ -325,8 +325,13 @@ H2Session::run_transactions(
       }
     }
 
+    bool print_once = true;
     auto const start_time = ClockType::now();
     while (this->request_has_outstanding_stream_dependencies(txn._req)) {
+      if (print_once) {
+        print_once = false;
+        txn_errata.note(S_DIAG, "Awaiting dependencies for key: {}", key);
+      }
       auto current_time = ClockType::now();
       if (current_time - start_time > 3 * Poll_Timeout) {
         txn_errata.note(S_ERROR, R"(Timed out waiting for dependencies for key: {})", key);
@@ -359,6 +364,7 @@ H2Session::run_transactions(
         next_time = (rate_multiplier * start_offset) + first_time;
         delay_time = next_time - current_time;
       }
+      txn_errata.sink();
       while (delay_time > 0ms) {
         // Make use of our delay time to read any incoming responses.
         auto const ret = receive_nghttp2_data(
@@ -729,76 +735,11 @@ receive_nghttp2_request(
 }
 
 static int
-on_frame_send_cb(nghttp2_session *session, nghttp2_frame const *frame, void *user_data)
+on_frame_send_cb(
+    nghttp2_session * /* session */,
+    nghttp2_frame const * /* frame */,
+    void * /*user_data*/)
 {
-  auto *session_data = reinterpret_cast<H2Session *>(user_data);
-  auto const stream_id = frame->hd.stream_id;
-  auto stream_map_iter = session_data->_stream_map.find(stream_id);
-  if (stream_map_iter == session_data->_stream_map.end()) {
-    // Nothing to do if this is not in our stream map.
-    return 0;
-  }
-  H2StreamState &stream_state = *stream_map_iter->second;
-  Errata errata;
-
-  if (stream_id != 0) {
-    auto const rst_stream_after = stream_state._client_rst_stream_after == -1 ?
-                                      stream_state._server_rst_stream_after :
-                                      stream_state._client_rst_stream_after;
-    auto const rst_stream_error = stream_state._client_rst_stream_error == -1 ?
-                                      stream_state._server_rst_stream_error :
-                                      stream_state._client_rst_stream_error;
-    auto const goaway_after = stream_state._client_goaway_after == -1 ?
-                                  stream_state._server_goaway_after :
-                                  stream_state._client_goaway_after;
-    auto const goaway_error = stream_state._client_goaway_error == -1 ?
-                                  stream_state._server_goaway_error :
-                                  stream_state._client_goaway_error;
-    if (frame->hd.type == rst_stream_after) {
-      errata.note(
-          S_DIAG,
-          "Submitting RST_STREAM frame for key {} after {} frame with error code {}.",
-          stream_state._key,
-          H2FrameNames[static_cast<H2Frame>(rst_stream_after)],
-          H2ErrorCodeNames[static_cast<H2ErrorCode>(rst_stream_error)]);
-      errata.sink();
-      int const submit_status = nghttp2_submit_rst_stream(session, 0, stream_id, rst_stream_error);
-      if (submit_status != 0) {
-        errata.note(
-            S_DIAG,
-            "Failed to submit RST_STREAM frame for key {} after {} frame: {}.",
-            stream_state._key,
-            H2FrameNames[static_cast<H2Frame>(rst_stream_after)],
-            submit_status);
-      } else {
-        errata.note(
-            S_DIAG,
-            "Sent RST_STREAM frame for key {} on stream {}.",
-            stream_state._key,
-            stream_id);
-      }
-    } else if (frame->hd.type == goaway_after) {
-      errata.note(
-          S_DIAG,
-          "Submitting GOAWAY frame for key {} after {} frame with error code {}.",
-          stream_state._key,
-          H2FrameNames[static_cast<H2Frame>(goaway_after)],
-          H2ErrorCodeNames[static_cast<H2ErrorCode>(goaway_error)]);
-      errata.sink();
-      int const submit_status = nghttp2_session_terminate_session2(session, 0, goaway_error);
-      if (submit_status != 0) {
-        errata.note(
-            S_DIAG,
-            "Failed to submit GOAWAY frame for key {} after {} frame: {}.",
-            stream_state._key,
-            H2FrameNames[static_cast<H2Frame>(goaway_after)],
-            submit_status);
-      } else {
-        session_data->sent_goaway_frame = true;
-        errata.note(S_DIAG, "Sent GOAWAY frame for key {}.", stream_state._key);
-      }
-    }
-  }
   return 0;
 }
 
@@ -808,16 +749,18 @@ on_frame_recv_cb(nghttp2_session * /* session */, nghttp2_frame const *frame, vo
   // Note that this is called after the more specific on_begin_headers_callback,
   // on_header_callback, etc. callbacks are called.
   Errata errata;
+  auto const flags = frame->hd.flags;
 
   switch (frame->hd.type) {
-  case NGHTTP2_DATA:
-    break;
-  case NGHTTP2_HEADERS:
-    break;
+  case NGHTTP2_DATA: {
+    errata.note(S_DIAG, "Received DATA frame with stream id {}", frame->hd.stream_id);
+  } break;
+  case NGHTTP2_HEADERS: {
+    errata.note(S_DIAG, "Received HEADERS frame with stream id {}", frame->hd.stream_id);
+  } break;
   case NGHTTP2_PRIORITY:
     break;
   case NGHTTP2_RST_STREAM: {
-    // nghttp2_rst_stream const &rst_stream_frame{frame->rst_stream};
     errata.note(
         S_DIAG,
         "Received RST_STREAM frame with stream id {}, error code {}",
@@ -851,7 +794,6 @@ on_frame_recv_cb(nghttp2_session * /* session */, nghttp2_frame const *frame, vo
         frame->goaway.error_code);
   } break;
   }
-  auto const flags = frame->hd.flags;
   // `flags` have to be processed here. They are not communicated via
   // on_header_callback.
   if (flags & NGHTTP2_FLAG_END_HEADERS || flags & NGHTTP2_FLAG_END_STREAM) {
@@ -928,13 +870,15 @@ on_frame_recv_cb(nghttp2_session * /* session */, nghttp2_frame const *frame, vo
             response_from_wire);
         auto const &key = stream_state._key;
         auto const &specified_response = stream_state._specified_response;
-        if (response_from_wire.verify_headers(key, *specified_response->_fields_rules)) {
+        if (specified_response &&
+            response_from_wire.verify_headers(key, *specified_response->_fields_rules))
+        {
           errata.note(
               S_ERROR,
               R"(HTTP/2 response headers did not match expected response headers.)");
           session_data->set_non_zero_exit_status();
         }
-        if (specified_response->_status != 0 &&
+        if (specified_response && specified_response->_status != 0 &&
             response_from_wire._status != specified_response->_status &&
             (response_from_wire._status != 200 || specified_response->_status != 304) &&
             (response_from_wire._status != 304 || specified_response->_status != 200))
@@ -1183,6 +1127,254 @@ data_read_callback(
   return num_to_copy;
 }
 
+Errata
+H2Session::frame_delay(HttpHeader const &hdr, H2Frame curr_frame)
+{
+  Errata errata;
+
+  std::chrono::microseconds frame_delay{0};
+  if (hdr.is_request()) {
+    auto delay_iter = hdr._client_frame_delay.find(curr_frame);
+    if (delay_iter != hdr._client_frame_delay.end()) {
+      frame_delay = delay_iter->second;
+    }
+  } else if (hdr.is_response()) {
+    auto delay_iter = hdr._server_frame_delay.find(curr_frame);
+    if (delay_iter != hdr._server_frame_delay.end()) {
+      frame_delay = delay_iter->second;
+    }
+  }
+
+  if (frame_delay > 0us) {
+    std::chrono::duration<double, std::micro> delay_time = frame_delay;
+    auto current_time = ClockType::now();
+    auto next_time = current_time + delay_time;
+    errata.note(
+        S_DIAG,
+        "Delaying {} frame per frame delay specification: {}ms",
+        H2FrameNames[curr_frame],
+        duration_cast<milliseconds>(frame_delay).count());
+
+    while (delay_time > 0ms) {
+      // Make use of our delay time to read any incoming responses.
+      auto const ret = receive_nghttp2_data(
+          this->get_session(),
+          nullptr,
+          0,
+          0,
+          this,
+          duration_cast<milliseconds>(delay_time));
+      if (ret < 0) {
+        // There was a problem reading bytes on the socket.
+        errata.note(
+            S_ERROR,
+            "An unexpected error was received reading bytes on a socket while delaying a "
+            "transaction for --rate.");
+      }
+      current_time = ClockType::now();
+      delay_time = next_time - current_time;
+    }
+  }
+
+  return errata;
+}
+
+Errata
+H2Session::submit_headers_frame(
+    HttpHeader const &hdr,
+    H2StreamState *stream_state,
+    std::shared_ptr<H2StreamState> new_stream_state,
+    uint8_t flags)
+{
+  Errata errata;
+  int submit_status = 0;
+  int stream_id = 0;
+
+  // grab header, send to session
+  // pack_headers will convert all the fields in hdr into nghttp2_nv structs
+  int hdr_count = 0;
+  nghttp2_nv *hdrs = nullptr;
+  pack_headers(hdr, hdrs, hdr_count);
+  if (hdr.is_response()) {
+    stream_state->store_nv_response_headers_to_free(hdrs);
+  } else {
+    stream_state->store_nv_request_headers_to_free(hdrs);
+  }
+
+  stream_state->_key = hdr.get_key();
+
+  if (hdr.is_response()) {
+    errata.note(
+        S_DIAG,
+        "Submitting HEADERS frame for key {} on stream {}.",
+        stream_state->_key,
+        stream_state->get_stream_id());
+    submit_status = nghttp2_submit_headers(
+        this->_session,
+        flags,
+        stream_state->get_stream_id(),
+        nullptr,
+        hdrs,
+        hdr_count,
+        stream_state);
+  } else {
+    errata.note(S_DIAG, "Submitting HEADERS frame for key {}.", stream_state->_key);
+    submit_status =
+        nghttp2_submit_headers(this->_session, flags, -1, nullptr, hdrs, hdr_count, stream_state);
+  }
+
+  if (hdr.is_response()) {
+    stream_id = stream_state->get_stream_id();
+    if (submit_status < 0) {
+      errata.note(
+          S_ERROR,
+          "Failed to submit HEADERS frame for key {} on stream {}: {}",
+          stream_state->_key,
+          stream_id,
+          submit_status);
+    }
+  } else { // request
+    if (submit_status < 0) {
+      errata.note(
+          S_ERROR,
+          "Failed to submit HEADERS frame for key {}: {}",
+          stream_state->_key,
+          submit_status);
+    } else {
+      stream_id = submit_status;
+      stream_state->set_stream_id(stream_id);
+      record_stream_state(stream_id, new_stream_state);
+    }
+  }
+  if (errata.is_ok()) {
+    errata.note(
+        S_DIAG,
+        "Submitted the following HTTP/2 {}{} headers for key {} on stream {}:\n{}",
+        swoc::bwf::If(hdr.is_request(), "request"),
+        swoc::bwf::If(hdr.is_response(), "response"),
+        stream_state->_key,
+        stream_id,
+        hdr);
+  }
+
+  return errata;
+}
+
+Errata
+H2Session::submit_data_frame(HttpHeader const &hdr, H2StreamState *stream_state, uint8_t flags)
+{
+  Errata errata;
+  TextView content;
+
+  if (hdr._content_data) {
+    content = TextView{hdr._content_data, hdr._content_size};
+  } else {
+    // If hdr._content_data is null, then there was no explicit description
+    // of the body data via the data node. Instead we'll use our generated
+    // HttpHeader::_content.
+    content = TextView{HttpHeader::_content.data(), hdr._content_size};
+  }
+
+  nghttp2_data_provider data_prd;
+  data_prd.source.fd = 0;
+  data_prd.source.ptr = nullptr;
+  data_prd.read_callback = data_read_callback;
+  stream_state->_body_to_send = content.data();
+  stream_state->_send_body_length = content.size();
+  stream_state->_wait_for_continue = hdr._send_continue;
+
+  errata.note(
+      S_DIAG,
+      "Submitting DATA frame for key {} on stream {}.",
+      stream_state->_key,
+      stream_state->get_stream_id());
+
+  int const submit_status =
+      nghttp2_submit_data(this->_session, flags, stream_state->get_stream_id(), &data_prd);
+
+  if (submit_status < 0) {
+    errata.note(
+        S_ERROR,
+        "Failed to submit DATA frame for key {} on stream {}: {}",
+        stream_state->_key,
+        stream_state->get_stream_id(),
+        submit_status);
+  } else {
+    errata.note(
+        S_DIAG,
+        "Submitted DATA frame for key {} on stream {}.",
+        stream_state->_key,
+        stream_state->get_stream_id());
+  }
+
+  return errata;
+}
+
+swoc::Errata
+H2Session::submit_rst_stream_frame(H2StreamState *stream_state, H2Frame prev_frame)
+{
+  Errata errata;
+
+  stream_state->_h2_frame_sequence.clear();
+  auto const rst_stream_error = stream_state->_client_rst_stream_error == -1 ?
+                                    stream_state->_server_rst_stream_error :
+                                    stream_state->_client_rst_stream_error;
+  errata.note(
+      S_DIAG,
+      "Submitting RST_STREAM frame for key {} after {} frame with error code {}.",
+      stream_state->_key,
+      H2FrameNames[prev_frame],
+      H2ErrorCodeNames[static_cast<H2ErrorCode>(rst_stream_error)]);
+  int const submit_status =
+      nghttp2_submit_rst_stream(this->_session, 0, stream_state->get_stream_id(), rst_stream_error);
+  if (submit_status != 0) {
+    errata.note(
+        S_DIAG,
+        "Failed to submit RST_STREAM frame for key {} on stream {}: {}.",
+        stream_state->_key,
+        stream_state->get_stream_id(),
+        submit_status);
+  } else {
+    errata.note(
+        S_DIAG,
+        "Submitted RST_STREAM frame for key {} on stream {}.",
+        stream_state->_key,
+        stream_state->get_stream_id());
+  }
+
+  return errata;
+}
+
+swoc::Errata
+H2Session::submit_goaway_frame(H2StreamState *stream_state, H2Frame prev_frame)
+{
+  Errata errata;
+
+  stream_state->_h2_frame_sequence.clear();
+  auto const goaway_error = stream_state->_client_goaway_error == -1 ?
+                                stream_state->_server_goaway_error :
+                                stream_state->_client_goaway_error;
+  errata.note(
+      S_DIAG,
+      "Submitting GOAWAY frame for key {} after {} frame with error code {}.",
+      stream_state->_key,
+      H2FrameNames[static_cast<H2Frame>(prev_frame)],
+      H2ErrorCodeNames[static_cast<H2ErrorCode>(goaway_error)]);
+  int const submit_status = nghttp2_session_terminate_session2(this->_session, 0, goaway_error);
+  if (submit_status != 0) {
+    errata.note(
+        S_DIAG,
+        "Failed to submit GOAWAY frame for key {}: {}.",
+        stream_state->_key,
+        submit_status);
+  } else {
+    this->sent_goaway_frame = true;
+    errata.note(S_DIAG, "Submitted GOAWAY frame for key {}.", stream_state->_key);
+  }
+
+  return errata;
+}
+
 swoc::Rv<ssize_t>
 H2Session::write(HttpHeader const &hdr)
 {
@@ -1209,104 +1401,165 @@ H2Session::write(HttpHeader const &hdr)
   }
 
   if (hdr.is_request()) {
-    stream_state->_client_rst_stream_after = hdr._client_rst_stream_after;
     stream_state->_client_rst_stream_error = hdr._client_rst_stream_error;
-    stream_state->_client_goaway_after = hdr._client_goaway_after;
     stream_state->_client_goaway_error = hdr._client_goaway_error;
   } else if (hdr.is_response()) {
-    stream_state->_server_rst_stream_after = hdr._server_rst_stream_after;
     stream_state->_server_rst_stream_error = hdr._server_rst_stream_error;
-    stream_state->_server_goaway_after = hdr._server_goaway_after;
     stream_state->_server_goaway_error = hdr._server_goaway_error;
   }
 
-  // grab header, send to session
-  // pack_headers will convert all the fields in hdr into nghttp2_nv structs
-  int hdr_count = 0;
-  nghttp2_nv *hdrs = nullptr;
-  pack_headers(hdr, hdrs, hdr_count);
-  if (hdr.is_response()) {
-    stream_state->store_nv_response_headers_to_free(hdrs);
+  if (!hdr._h2_frame_sequence.empty()) {
+    stream_state->_h2_frame_sequence = hdr._h2_frame_sequence;
+    H2Frame prev_frame = H2Frame::INVALID;
+
+    auto first_frame = stream_state->_h2_frame_sequence.front();
+    if ((first_frame == H2Frame::RST_STREAM || first_frame == H2Frame::GOAWAY) && hdr.is_request())
+    {
+      stream_state->_h2_frame_sequence.pop_front();
+      zret.note(S_WARN, "The first frame of a request cannot be RST_STREAM.");
+    }
+
+    while (!stream_state->_h2_frame_sequence.empty()) {
+      auto curr_frame = stream_state->_h2_frame_sequence.front();
+      stream_state->_h2_frame_sequence.pop_front();
+      auto next_frame = stream_state->_h2_frame_sequence.front();
+
+      uint8_t flags = 0;
+
+      // We need to consider sending the END_STREAM as if RST_STREAM or GOAWAY isn't present in the
+      // sequence. So in the following two situations we need to send the END_STREAM flag:
+      //   - If the next frame is RST_STREAM or GOAWAY, and it is the only frame left in the
+      //   sequence.
+      //   - If there are no more frames to send.
+      if (stream_state->_h2_frame_sequence.empty() ||
+          ((next_frame == H2Frame::RST_STREAM || next_frame == H2Frame::GOAWAY) &&
+           stream_state->_h2_frame_sequence.size() == 1))
+      {
+        flags = NGHTTP2_FLAG_END_STREAM;
+      }
+
+      zret.note(frame_delay(hdr, curr_frame));
+
+      switch (curr_frame) {
+      case H2Frame::HEADERS: {
+        zret.note(submit_headers_frame(hdr, stream_state, new_stream_state, flags));
+      } break;
+      case H2Frame::DATA: {
+        zret.note(submit_data_frame(hdr, stream_state, flags));
+      } break;
+      case H2Frame::RST_STREAM: {
+        zret.note(submit_rst_stream_frame(stream_state, prev_frame));
+      } break;
+      case H2Frame::GOAWAY: {
+        zret.note(submit_goaway_frame(stream_state, prev_frame));
+      } break;
+      default: {
+        zret.note(S_ERROR, "Invalid frame type.");
+      } break;
+      }
+      zret.errata().sink();
+
+      // Kick off the send logic to put the data on the wire
+      zret.note(S_DIAG, "Writing {} frame to the wire.", H2FrameNames[curr_frame]);
+      zret.result() = send_nghttp2_data(_session, nullptr, 0, 0, this);
+      zret.errata().sink();
+      prev_frame = curr_frame;
+    }
   } else {
-    stream_state->store_nv_request_headers_to_free(hdrs);
-  }
-
-  stream_state->_key = hdr.get_key();
-  if (hdr._content_size > 0 && (hdr.is_request() || !HttpHeader::STATUS_NO_CONTENT[hdr._status])) {
-    TextView content;
-    if (hdr._content_data) {
-      content = TextView{hdr._content_data, hdr._content_size};
-    } else {
-      // If hdr._content_data is null, then there was no explicit description
-      // of the body data via the data node. Instead we'll use our generated
-      // HttpHeader::_content.
-      content = TextView{HttpHeader::_content.data(), hdr._content_size};
-    }
-    nghttp2_data_provider data_prd;
-    data_prd.source.fd = 0;
-    data_prd.source.ptr = nullptr;
-    data_prd.read_callback = data_read_callback;
-    stream_state->_body_to_send = content.data();
-    stream_state->_send_body_length = content.size();
-    stream_state->_wait_for_continue = hdr._send_continue;
+    // grab header, send to session
+    // pack_headers will convert all the fields in hdr into nghttp2_nv structs
+    int hdr_count = 0;
+    nghttp2_nv *hdrs = nullptr;
+    pack_headers(hdr, hdrs, hdr_count);
     if (hdr.is_response()) {
-      submit_result = nghttp2_submit_response(
-          this->_session,
-          stream_state->get_stream_id(),
-          hdrs,
-          hdr_count,
-          &data_prd);
+      stream_state->store_nv_response_headers_to_free(hdrs);
     } else {
-      submit_result =
-          nghttp2_submit_request(this->_session, nullptr, hdrs, hdr_count, &data_prd, stream_state);
+      stream_state->store_nv_request_headers_to_free(hdrs);
     }
-  } else { // Empty body.
-    if (hdr.is_response()) {
-      submit_result = nghttp2_submit_response(
-          this->_session,
-          stream_state->get_stream_id(),
-          hdrs,
-          hdr_count,
-          nullptr);
-    } else {
-      submit_result =
-          nghttp2_submit_request(this->_session, nullptr, hdrs, hdr_count, nullptr, stream_state);
-    }
-  }
 
-  if (hdr.is_response()) {
-    stream_id = stream_state->get_stream_id();
-    if (submit_result < 0) {
+    stream_state->_key = hdr.get_key();
+    if (hdr._content_size > 0 && (hdr.is_request() || !HttpHeader::STATUS_NO_CONTENT[hdr._status]))
+    {
+      TextView content;
+      if (hdr._content_data) {
+        content = TextView{hdr._content_data, hdr._content_size};
+      } else {
+        // If hdr._content_data is null, then there was no explicit description
+        // of the body data via the data node. Instead we'll use our generated
+        // HttpHeader::_content.
+        content = TextView{HttpHeader::_content.data(), hdr._content_size};
+      }
+      nghttp2_data_provider data_prd;
+      data_prd.source.fd = 0;
+      data_prd.source.ptr = nullptr;
+      data_prd.read_callback = data_read_callback;
+      stream_state->_body_to_send = content.data();
+      stream_state->_send_body_length = content.size();
+      stream_state->_wait_for_continue = hdr._send_continue;
+      if (hdr.is_response()) {
+        submit_result = nghttp2_submit_response(
+            this->_session,
+            stream_state->get_stream_id(),
+            hdrs,
+            hdr_count,
+            &data_prd);
+      } else {
+        submit_result = nghttp2_submit_request(
+            this->_session,
+            nullptr,
+            hdrs,
+            hdr_count,
+            &data_prd,
+            stream_state);
+      }
+    } else { // Empty body.
+      if (hdr.is_response()) {
+        submit_result = nghttp2_submit_response(
+            this->_session,
+            stream_state->get_stream_id(),
+            hdrs,
+            hdr_count,
+            nullptr);
+      } else {
+        submit_result =
+            nghttp2_submit_request(this->_session, nullptr, hdrs, hdr_count, nullptr, stream_state);
+      }
+    }
+
+    if (hdr.is_response()) {
+      stream_id = stream_state->get_stream_id();
+      if (submit_result < 0) {
+        zret.note(
+            S_ERROR,
+            "Submitting an HTTP/2 response with stream id {} failed: {}",
+            stream_id,
+            submit_result);
+      }
+    } else { // request
+      if (submit_result < 0) {
+        zret.note(S_ERROR, "Submitting an HTTP/2 request failed: {}", submit_result);
+      } else {
+        stream_id = submit_result;
+        stream_state->set_stream_id(stream_id);
+        record_stream_state(stream_id, new_stream_state);
+      }
+    }
+    if (zret.is_ok()) {
       zret.note(
-          S_ERROR,
-          "Submitting an HTTP/2 response with stream id {} failed: {}",
+          S_DIAG,
+          "Sent the following HTTP/2 {}{} headers for key {} with stream id {}:\n{}",
+          swoc::bwf::If(hdr.is_request(), "request"),
+          swoc::bwf::If(hdr.is_response(), "response"),
+          stream_state->_key,
           stream_id,
-          submit_result);
+          hdr);
+      // Make sure the logging of the headers are emitted before the body.
+      zret.errata().sink();
     }
-  } else { // request
-    if (submit_result < 0) {
-      zret.note(S_ERROR, "Submitting an HTTP/2 request failed: {}", submit_result);
-    } else {
-      stream_id = submit_result;
-      stream_state->set_stream_id(stream_id);
-      record_stream_state(stream_id, new_stream_state);
-    }
-  }
-  if (zret.is_ok()) {
-    zret.note(
-        S_DIAG,
-        "Sent the following HTTP/2 {}{} headers for key {} with stream id {}:\n{}",
-        swoc::bwf::If(hdr.is_request(), "request"),
-        swoc::bwf::If(hdr.is_response(), "response"),
-        stream_state->_key,
-        stream_id,
-        hdr);
-    // Make sure the logging of the headers are emitted before the body.
-    zret.errata().sink();
-  }
 
-  // Kick off the send logic to put the data on the wire
-  zret.result() = send_nghttp2_data(_session, nullptr, 0, 0, this);
+    // Kick off the send logic to put the data on the wire
+    zret.result() = send_nghttp2_data(_session, nullptr, 0, 0, this);
+  }
 
   return zret;
 }

--- a/test/autests/gold_tests/autest-site/proxy_http2.py
+++ b/test/autests/gold_tests/autest-site/proxy_http2.py
@@ -165,14 +165,20 @@ class Http2ConnectionManager(object):
                         err = H2ErrorCodes(event.error_code).name
                         print(
                             f'Received RST_STREAM frame with error code {err} on stream {event.stream_id}.')
+                        if stream_id not in resp_from_server.keys():
+                            ret_vals = self.request_received(
+                                request_info._headers, request_info._body_bytes, stream_id)
+                            if ret_vals is not None:
+                                resp_from_server[stream_id] = ret_vals
 
                     if isinstance(event, StreamEnded):
                         print('StreamEnded')
                         stream_id_list.add(stream_id)
-                        ret_vals = self.request_received(
-                            request_info._headers, request_info._body_bytes, stream_id)
-                        if ret_vals is not None:
-                            resp_from_server[stream_id] = ret_vals
+                        if stream_id not in resp_from_server.keys():
+                            ret_vals = self.request_received(
+                                request_info._headers, request_info._body_bytes, stream_id)
+                            if ret_vals is not None:
+                                resp_from_server[stream_id] = ret_vals
 
                 else:
                     if isinstance(event, ConnectionTerminated):

--- a/test/autests/gold_tests/http2_abort/http2_abort.test.py
+++ b/test/autests/gold_tests/http2_abort/http2_abort.test.py
@@ -26,8 +26,12 @@ client.Streams.stdout += Testers.ContainsExpression(
     'Detect client abort flag.')
 
 client.Streams.stdout += Testers.ContainsExpression(
-    'Sent RST_STREAM frame for key 1 on stream 1.',
-    'Sent RST_STREAM frame.')
+    'Submitted RST_STREAM frame for key 1 on stream 1.',
+    'Submitted RST_STREAM frame.')
+
+server.Streams.stdout += Testers.ContainsExpression(
+    'Received an HTTP/2 request for key 1 with stream id 1',
+    'Server is functional.')
 
 server.Streams.stdout += Testers.ExcludesExpression(
     'RST_STREAM',
@@ -56,8 +60,16 @@ client.Streams.stdout += Testers.ContainsExpression(
     'Detect client abort flag.')
 
 client.Streams.stdout += Testers.ContainsExpression(
-    'Sent RST_STREAM frame for key 1 on stream 1.',
-    'Sent RST_STREAM frame.')
+    'Submitted RST_STREAM frame for key 1 on stream 1.',
+    'Submitted RST_STREAM frame.')
+
+client.Streams.stdout += Testers.ExcludesExpression(
+    'Timed out waiting for frame: HEADERS',
+    'Await HEADERS')
+
+server.Streams.stdout += Testers.ContainsExpression(
+    'Received an HTTP/2 request for key 1 with stream id 1',
+    'Server is functional.')
 
 server.Streams.stdout += Testers.ExcludesExpression(
     'RST_STREAM',
@@ -90,8 +102,8 @@ server.Streams.stdout += Testers.ContainsExpression(
     'Detect client abort flag.')
 
 server.Streams.stdout += Testers.ContainsExpression(
-    'Sent RST_STREAM frame for key 1 on stream 1.',
-    'Sent RST_STREAM frame.')
+    'Submitted RST_STREAM frame for key 1 on stream 1.',
+    'Submitted RST_STREAM frame.')
 
 proxy.Streams.stdout += Testers.ContainsExpression(
     'httpcore.RemoteProtocolError:',
@@ -116,8 +128,8 @@ client.Streams.stdout += Testers.ContainsExpression(
     'Detect client abort flag.')
 
 client.Streams.stdout += Testers.ContainsExpression(
-    'Sent GOAWAY frame for key 1.',
-    'Sent GOAWAY frame.')
+    'Submitted GOAWAY frame for key 1.',
+    'Submitted GOAWAY frame.')
 
 client.Streams.stdout += Testers.ExcludesExpression(
     'should_not_send',
@@ -162,8 +174,8 @@ server.Streams.stdout += Testers.ContainsExpression(
     'Detect server abort flag.')
 
 server.Streams.stdout += Testers.ContainsExpression(
-    'Sent GOAWAY frame for key 1.',
-    'Sent GOAWAY frame.')
+    'Submitted GOAWAY frame for key 1.',
+    'Submitted GOAWAY frame.')
 
 server.Streams.stdout += Testers.ExcludesExpression(
     'should_not_send',

--- a/test/autests/gold_tests/http2_frames/gold/client.gold
+++ b/test/autests/gold_tests/http2_frames/gold/client.gold
@@ -1,5 +1,7 @@
 ``
-``Sent the following HTTP/2 request headers for key 1 with stream id 1:
+``Delaying HEADERS frame per frame delay specification: 500ms
+``Submitting HEADERS frame for key 1.
+``Submitted the following HTTP/2 request headers for key 1 on stream 1:
 :method: POST
 :scheme: https
 :authority: example.data.com
@@ -7,7 +9,10 @@
 content-type: text/html
 content-length: 11
 uuid: 1
-
+``
+``Delaying DATA frame per frame delay specification: 1000ms
+``Submitting DATA frame for key 1 on stream 1.
+``Submitted DATA frame for key 1 on stream 1.
 ``Sent an HTTP/2 body of 11 bytes for key 1 of stream id 1:
 client_test
 ``

--- a/test/autests/gold_tests/http2_frames/gold/server.gold
+++ b/test/autests/gold_tests/http2_frames/gold/server.gold
@@ -1,9 +1,12 @@
 ``
-``Sent the following HTTP/2 response headers for key 1 with stream id 1:
+``Submitting HEADERS frame for key 1 on stream 1.
+``Submitted the following HTTP/2 response headers for key 1 on stream 1:
 :status: 200
 content-type: text/html
 content-length: 11
-
+``
+``Submitting DATA frame for key 1 on stream 1.
+``Submitted DATA frame for key 1 on stream 1.
 ``Sent an HTTP/2 body of 11 bytes for key 1 of stream id 1:
 server_test
 ``

--- a/test/autests/gold_tests/http2_frames/http2_frames.test.py
+++ b/test/autests/gold_tests/http2_frames/http2_frames.test.py
@@ -24,3 +24,19 @@ proxy = r.AddProxyProcess("proxy1", listen_port=client.Variables.https_port,
 client.Streams.stdout = "gold/client.gold"
 server.Streams.stdout = "gold/server.gold"
 proxy.Streams.stdout = "gold/proxy.gold"
+
+#
+# Test 2: Verify that the timing data indicates that the delays took place.
+#
+r = Test.AddTestRun("Verify the client-side delay replay took an expected amount of time to run.")
+verifier_script = 'verify_duration.py'
+client_output = client.Streams.stdout.AbsTestPath
+expected_min_delay_ms = "1500"
+r.Processes.Default.Setup.Copy(verifier_script)
+
+r.Processes.Default.Command = \
+    f'python3 {verifier_script} {client_output} {expected_min_delay_ms}'
+r.ReturnCode = 0
+r.Streams.stdout += Testers.ContainsExpression(
+    'Good',
+    'The verifier script should report success.')

--- a/test/autests/gold_tests/http2_frames/http2_frames.yaml
+++ b/test/autests/gold_tests/http2_frames/http2_frames.yaml
@@ -13,6 +13,7 @@ sessions:
   - client-request:
       frames:
       - HEADERS:
+          delay: 500ms
           headers:
             fields:
             - [:method, POST]
@@ -23,6 +24,7 @@ sessions:
             - [Content-Length, '11']
             - [uuid, 1]
       - DATA:
+          delay: 1s
           content:
             encoding: plain
             data: client_test

--- a/test/autests/gold_tests/http2_frames/verify_duration.py
+++ b/test/autests/gold_tests/http2_frames/verify_duration.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+'''
+Verify client output recorded an expected replay duration.
+'''
+# @file
+#
+# Copyright 2021, Verizon Media
+# SPDX-License-Identifier: Apache-2.0
+#
+
+
+import argparse
+import sys
+import re
+
+
+def line_has_timing_data(line):
+    """
+    Determine whether the line has Verifier client timing data in it.
+
+    >>> line_has_timing_data('   [0]: h2 is negotiated.')
+    False
+    >>> line_has_timing_data(' [1]: 2 transactions in 2 sessions (reuse 1) in 1790 milliseconds (0.1 / millisecond).')
+    True
+    >>> line_has_timing_data(r' [1]: 2 transactions in 2 sessions (reuse 1) in 1790 milliseconds (0.1 / millisecond).\\n')
+    True
+    """
+    line_matcher = re.compile('.*transaction[s]* in .* session[s]* .* in .* milliseconds.*')
+    return line_matcher.match(line) is not None
+
+
+def get_replay_duration(line):
+    """
+    Retrieve the number of milliseconds the replay took.
+
+    >>> get_replay_duration(' [1]: 2 transactions in 2 sessions (reuse 1) in 1790 milliseconds (0.1 / millisecond).')
+    1790
+    >>> get_replay_duration(r' [1]: 2 transactions in 2 sessions (reuse 1) in 1790 milliseconds (0.1 / millisecond).\\n')
+    1790
+
+    >>> get_replay_duration('   [0]: h2 is negotiated.')
+    Traceback (most recent call last):
+        ...
+    ValueError: The line does not have timing data:
+       [0]: h2 is negotiated.
+    """
+    if not line_has_timing_data(line):
+        raise ValueError(f'The line does not have timing data:\n{line}')
+
+    duration_getter = re.compile(r'in (\d+) milliseconds')
+    return int(duration_getter.findall(line)[0])
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description='Verify client output recorded an expected replay duration.')
+
+    parser.add_argument('client_output', type=argparse.FileType('r'),
+                        help='The Verifier client output file.')
+
+    parser.add_argument('min_milliseconds', type=int,
+                        help='The minimum number of milliseconds the '
+                        'replay should have taken.')
+
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    min_milliseconds = args.min_milliseconds
+    for line in args.client_output:
+        if not line_has_timing_data(line):
+            continue
+
+        duration_in_ms = get_replay_duration(line)
+
+        if duration_in_ms >= min_milliseconds:
+            print(f'Good: replay took {duration_in_ms} ms which is more '
+                  f'than required {min_milliseconds} ms')
+            return 0
+        else:
+            print(f'Bad: replay took {duration_in_ms} ms which is less than '
+                  f'than required {min_milliseconds} ms')
+            return 1
+
+
+if __name__ == '__main__':
+    import doctest
+    doctest.testmod()
+    sys.exit(main())


### PR DESCRIPTION
Add the interface for adding delay before sending H2 frames, and add support to send h2 request and response frame by frame.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
