### PR TITLE
Updated HTTP/2 pseudo-headers enforcement logic

### DIFF
--- a/local/src/core/YamlParser.cc
+++ b/local/src/core/YamlParser.cc
@@ -95,14 +95,15 @@ validate_psuedo_headers(const HttpHeader &hdr, int number_of_pseudo_headers)
   if (hdr.is_response()) {
     if (number_of_pseudo_headers != 1 || hdr._status == 0) {
       // The response should contain and only contain the :status pseudo-header
-      // field.
+      // field per RFC9113 section 8.3.2.
       errata.note(S_ERROR, "The response must include only the :status pseudo-header field.");
     }
     return errata;
   }
   // This is a request header.
   if (hdr._method == "CONNECT") {
-    // CONNECT requests have some special rules for pseudo-headers.
+    // CONNECT requests have some special rules for pseudo-headers. Refer to
+    // RFC9113 section 8.5 for more details.
     if (!hdr._scheme.empty() || !hdr._path.empty()) {
       errata.note(
           S_ERROR,
@@ -114,7 +115,8 @@ validate_psuedo_headers(const HttpHeader &hdr, int number_of_pseudo_headers)
           "The :authority pseudo-header field must be included in a CONNECT request.");
     }
   } else if (hdr._method.empty() || hdr._scheme.empty() || hdr._path.empty()) {
-    // Missing required pseudo-header fields for non-CONNECT requests.
+    // Missing required pseudo-header fields for non-CONNECT requests. See
+    // RFC9113 section 8.3.1.
     errata.note(
         S_ERROR,
         "Did not find all the required pseudo-header fields "

--- a/local/src/core/YamlParser.cc
+++ b/local/src/core/YamlParser.cc
@@ -89,6 +89,41 @@ get_delay_time(YAML::Node const &node)
 }
 
 Errata
+validate_psuedo_headers(const HttpHeader &hdr, int number_of_pseudo_headers)
+{
+  Errata errata;
+  if (hdr.is_response()) {
+    if (number_of_pseudo_headers != 1 || hdr._status == 0) {
+      // The response should contain and only contain the :status pseudo-header
+      // field.
+      errata.note(S_ERROR, "The response must include only the :status pseudo-header field.");
+    }
+    return errata;
+  }
+  // This is a request header.
+  if (hdr._method == "CONNECT") {
+    // CONNECT requests have some special rules for pseudo-headers.
+    if (!hdr._scheme.empty() || !hdr._path.empty()) {
+      errata.note(
+          S_ERROR,
+          "The :scheme and :path pseudo-header fields must be omitted in a CONNECT request.");
+    }
+    if (hdr._authority.empty()) {
+      errata.note(
+          S_ERROR,
+          "The :authority pseudo-header field must be included in a CONNECT request.");
+    }
+  } else if (hdr._method.empty() || hdr._scheme.empty() || hdr._path.empty()) {
+    // Missing required pseudo-header fields for non-CONNECT requests.
+    errata.note(
+        S_ERROR,
+        "Did not find all the required pseudo-header fields "
+        "(:method, :scheme, :path)");
+  }
+  return errata;
+}
+
+Errata
 YamlParser::populate_http_message(YAML::Node const &node, HttpHeader &message)
 {
   Errata errata;
@@ -1064,18 +1099,11 @@ YamlParser::process_pseudo_headers(YAML::Node const &node, HttpHeader &message)
   }
   if (number_of_pseudo_headers > 0) {
     // Do some sanity checking on the user's pseudo headers, if provided.
-    if (message.is_response() && number_of_pseudo_headers != 1) {
-      errata.note(
-          S_ERROR,
-          "Found a mixture of request and response pseudo header fields: {}",
-          node.Mark());
-    }
-    if (message.is_request() && number_of_pseudo_headers != 4) {
-      errata.note(
-          S_ERROR,
-          "Did not find all four required pseudo header fields "
-          "(:method, :scheme, :authority, :path): {}",
-          node.Mark());
+    auto psuedo_header_validation_errata =
+        validate_psuedo_headers(message, number_of_pseudo_headers);
+    if (!psuedo_header_validation_errata.is_ok()) {
+      errata.note(S_ERROR, "Invalid pseudo-headers detected at {}.", node.Mark());
+      errata.note(std::move(psuedo_header_validation_errata));
     }
     // Pseudo header fields currently implies HTTP/2.
     message._http_version = "2";

--- a/local/src/core/http2.cc
+++ b/local/src/core/http2.cc
@@ -1594,15 +1594,21 @@ H2Session::pack_headers(HttpHeader const &hdr, nghttp2_nv *&nv_hdr, int &hdr_cou
   // nghttp2 requires pseudo header fields to be at the start of the
   // nv array. Thus we add them here before calling add_fields_to_ngnva
   // which then skips the pseueo headers if they are in there.
-  if (hdr.is_response()) {
+  if (hdr.is_response() && !hdr._status_string.empty()) {
     nv_hdr[offset++] = tv_to_nv(":status", hdr._status_string);
   } else if (hdr.is_request()) {
-    // TODO: add error checking and refactor and tolerance for non-required
-    // pseudo-headers
-    nv_hdr[offset++] = tv_to_nv(":method", hdr._method);
-    nv_hdr[offset++] = tv_to_nv(":scheme", hdr._scheme);
-    nv_hdr[offset++] = tv_to_nv(":path", hdr._path);
-    nv_hdr[offset++] = tv_to_nv(":authority", hdr._authority);
+    if (!hdr._method.empty()) {
+      nv_hdr[offset++] = tv_to_nv(":method", hdr._method);
+    }
+    if (!hdr._scheme.empty()) {
+      nv_hdr[offset++] = tv_to_nv(":scheme", hdr._scheme);
+    }
+    if (!hdr._path.empty()) {
+      nv_hdr[offset++] = tv_to_nv(":path", hdr._path);
+    }
+    if (!hdr._authority.empty()) {
+      nv_hdr[offset++] = tv_to_nv(":authority", hdr._authority);
+    }
   }
 
   hdr._fields_rules->add_fields_to_ngnva(nv_hdr + offset);


### PR DESCRIPTION
The pseudo-header validation logic is updated to enforce the following specified by the RFC:

#### Request
##### non-CONNECT request

should at least include the `:method` , `:scheme` and `:path` pseudo-header fields. `:authority` is not strictly requried.

##### CONNECT request
* must omit the `:scheme` and `:path` pseudo-header fields.
* must include the `:authority` pseudo-header field.
#### Response

should include and only include the `:status` pseudo-header field.

This resolves #252.



<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
