### PR TITLE
library build: cleanup the build directory on succcess

### DIFF
--- a/tools/build_library_dependencies.sh
+++ b/tools/build_library_dependencies.sh
@@ -98,3 +98,6 @@ autoreconf -if
 make -j ${num_threads}
 ${SUDO} make install
 sudo chmod -R ugo+rX ${install_dir}/nghttp2
+
+# Everything worked. Cleanup the build directory.
+rm -rf ${repo_dir}


### PR DESCRIPTION
Modify build_library_dependencies.sh to cleanup the build directory on success.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
