### PR TITLE
nghttp2 v.1.54.0 -> v1.54.0

### DIFF
--- a/tools/build_library_dependencies.sh
+++ b/tools/build_library_dependencies.sh
@@ -15,6 +15,9 @@ fail()
   exit 1
 }
 
+set -x
+set -e
+
 os=$(uname)
 [ "${os}" = "Linux" -o "${os}" = "Darwin" ] || fail "Unrecognized OS: ${os}"
 
@@ -89,7 +92,7 @@ sudo chmod -R ugo+rX ${install_dir}/ngtcp2
 cd ${repo_dir}
 git clone https://github.com/tatsuhiro-t/nghttp2.git
 cd nghttp2
-git checkout v.1.54.0
+git checkout v1.54.0
 autoreconf -if
 ./configure \
   PKG_CONFIG_PATH=${install_dir}/openssl/lib/pkgconfig:${install_dir}/ngtcp2/lib/pkgconfig:${install_dir}/nghttp3/lib/pkgconfig \


### PR DESCRIPTION
Fix the checkout of nghttp2 in build_library_dependencies.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
