### PR TITLE
Python 3.11 http2_abort updates

### DIFF
--- a/test/autests/gold_tests/http2_abort/http2_abort.test.py
+++ b/test/autests/gold_tests/http2_abort/http2_abort.test.py
@@ -110,7 +110,7 @@ proxy.Streams.stdout += Testers.ContainsExpression(
     'Received RST_STREAM frame.')
 
 proxy.Streams.stdout += Testers.ContainsExpression(
-    'StreamReset stream_id:1, error_code:ErrorCodes.ENHANCE_YOUR_CALM, remote_reset:True',
+    'StreamReset stream_id:1, error_code:(11|ErrorCodes.ENHANCE_YOUR_CALM), remote_reset:True',
     'Received RST_STREAM frame.')
 
 #
@@ -182,5 +182,5 @@ server.Streams.stdout += Testers.ExcludesExpression(
     'Server connection should terminate.')
 
 proxy.Streams.stdout += Testers.ContainsExpression(
-    'ConnectionTerminated error_code:ErrorCodes.STREAM_CLOSED, last_stream_id:0, additional_data:None',
+    'ConnectionTerminated error_code:(5|ErrorCodes.STREAM_CLOSED), last_stream_id:0, additional_data:None',
     'Received GOAWAY frame.')


### PR DESCRIPTION
The formatting of exception strings changed in httpx for Python 3.11. This patch adjusts test expectations for this.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
