### PR TITLE
Update http2 test proxy to use the h2 lib

### DIFF
--- a/test/autests/Pipfile
+++ b/test/autests/Pipfile
@@ -15,7 +15,7 @@ pyflakes = "*"
 
 [packages]
 autest = "*"
-"httpx[http2]" = "*"
+"h2" = "*"
 pyOpenSSL = "*"
 eventlet = "*"
 ruamel_yaml = "*"

--- a/test/autests/gold_tests/autest-site/proxy_protocol_context.py
+++ b/test/autests/gold_tests/autest-site/proxy_protocol_context.py
@@ -258,8 +258,8 @@ class ProxyProtocolUtil:
         return pp_length
 
     @staticmethod
-    def create_connection_and_send_pp(address, timeout,
-                                      source_address):
+    def create_connection_and_send_pp(address, timeout=5,
+                                      source_address=None):
         """ This is a wraper of the socket.create_connection method, which in
         addition sends a PROXY protocol header as the connection is established.
         :param address: the address to connect to

--- a/test/autests/gold_tests/doctest/gold/doctest_server.gold
+++ b/test/autests/gold_tests/doctest/gold/doctest_server.gold
@@ -18,14 +18,10 @@ connection: keep-alive
 ``
 :method: POST
 :scheme: https
-:authority: 127.0.0.1:``
+:authority: www.example.com
 :path: /pictures/flower.jpeg
-accept: ``
-accept-encoding: ``
-user-agent: ``
 content-type: image/jpeg
 uuid: second-request
-content-length: ``
 
 ``
 :status: 200

--- a/test/autests/gold_tests/http2/gold/http2_to_http2_server.gold
+++ b/test/autests/gold_tests/http2/gold/http2_to_http2_server.gold
@@ -5,10 +5,10 @@
 :scheme: https
 :authority: example.data.com
 :path: /a/path?q=3
-user-agent: ``
 accept: */*
 accept-language: en-us
 accept-encoding: gzip
+host: example.data.com
 x-test-duplicate-combined: first
 x-test-duplicate-combined: second
 x-test-duplicate-separate: first
@@ -32,21 +32,18 @@ uuid: 1
 ``
 :method: POST
 :scheme: https
-:authority: ``
+:authority: example.data.com
 :path: /a/path
-accept: ``
-accept-encoding: ``
-user-agent: ``
 x-request-header: request
 uuid: 2
 x-added-header: 1
-content-length: 10
 
 ``Received an HTTP/2 body of 10 bytes for key 2 with stream id 3:
 0123456789
-`` Contains Success: Key: "2", Field Name: ":authority", Required Value: "127.0.0.1", Value: "127.0.0.1:``"
+``Equals Success: Key: "2", Field Name: ":authority", Value: "example.data.com"
 ``Equals Success: Key: "2", Field Name: ":method", Value: "POST"
 ``Equals Success: Key: "2", Field Name: ":scheme", Value: "https"
+``Absence Success: Key: "2", Field Name: "content-length"
 ``Presence Success: Key: "2", Field Name: "x-added-header", Value: "1"
 ``Absence Success: Key: "2", Field Name: "x-deleted-header"
 ``Presence Success: Key: "2", Field Name: "x-request-header", Value: "request"
@@ -61,11 +58,8 @@ uuid: 2
 ``
 :method: GET
 :scheme: https
-:authority: 127.0.0.1:``
+:authority: example.data.com
 :path: /b/path
-accept: ``
-accept-encoding: ``
-user-agent: ``
 x-request-header: test_request
 uuid: 3
 
@@ -78,11 +72,8 @@ uuid: 3
 ``Received an HTTP/2 request for key 4 with stream id 7:
 :method: GET
 :scheme: https
-:authority: 127.0.0.1:``
+:authority: example.data.com
 :path: /b/path
-accept: ``
-accept-encoding: ``
-user-agent: ``
 x-request-header: test_request
 uuid: 4
 

--- a/test/autests/gold_tests/http2/http2.test.py
+++ b/test/autests/gold_tests/http2/http2.test.py
@@ -36,7 +36,8 @@ server.Streams.stdout += Testers.ExcludesExpression(
 #
 # Test 2: Verify field verification: all success.
 #
-r = Test.AddTestRun("Verify HTTP/2 behavior on both the client and server sides")
+r = Test.AddTestRun(
+    "Verify HTTP/2 behavior on both the client and server sides")
 client = r.AddClientProcess("client2", "replay_files/http2_to_http2.yaml")
 server = r.AddServerProcess("server2", "replay_files/http2_to_http2.yaml")
 proxy = r.AddProxyProcess("proxy2", listen_port=client.Variables.https_port,
@@ -59,8 +60,10 @@ server.Streams.stdout += Testers.ExcludesExpression(
 # Test 3: Verify field verification: failures.
 #
 r = Test.AddTestRun("Verify HTTP/2 field verification")
-client = r.AddClientProcess("client3", "replay_files/http2_to_http2_verification_failures.yaml")
-server = r.AddServerProcess("server3", "replay_files/http2_to_http2_verification_failures.yaml")
+client = r.AddClientProcess(
+    "client3", "replay_files/http2_to_http2_verification_failures.yaml")
+server = r.AddServerProcess(
+    "server3", "replay_files/http2_to_http2_verification_failures.yaml")
 proxy = r.AddProxyProcess("proxy3", listen_port=client.Variables.https_port,
                           server_port=server.Variables.https_port,
                           use_ssl=True, use_http2_to_2=True)
@@ -86,7 +89,8 @@ server.Streams.stdout += Testers.ContainsExpression(
 #
 # Test 4: Verify the ability to control server protocol negotiation via ALPN.
 #
-r = Test.AddTestRun("Verify HTTP/2 behavior on both the client and server sides")
+r = Test.AddTestRun(
+    "Verify HTTP/2 behavior on both the client and server sides")
 client = r.AddClientProcess("client4", "replay_files/set_alpn.yaml")
 server = r.AddServerProcess("server4", "replay_files/set_alpn.yaml")
 proxy = r.AddProxyProcess("proxy4", listen_port=client.Variables.https_port,

--- a/test/autests/gold_tests/http2/replay_files/http2_to_http2.yaml
+++ b/test/autests/gold_tests/http2/replay_files/http2_to_http2.yaml
@@ -58,7 +58,7 @@ sessions:
       - [ scheme, { value: https, as: equal } ]
       - [ host, { value: example.data.com, as: equal } ]
       - [ path, { value: /a/path, as: equal } ]
-      - [ authority, { value: 127.0.0.1, as: contains } ]
+      - [ authority, { value: example.data.com, as: equal } ]
       - [ net-loc, { value: example.data.com, as: equal } ]
       - [ query, { value: q=3, as: present } ]
       - [ query, { value: 3, as: contains } ]
@@ -73,8 +73,7 @@ sessions:
         - [ :scheme, { value: https, as: equal } ]
         - [ :authority, { value: example.data.com, as: equal } ]
         - [ :path, { value: '/a/path?q=3', as: equal } ]
-        # The Python httpx test proxy doesn't send the Host header.
-        - [ Host, { as: absent } ]
+        - [ Host, { value: example.data.com, as: equal } ]
         - [ Content-Length, { value: "0", as: equal } ]
         - [ x-test-duplicate-combined, { value: [ first, second ], as: equal } ]
         - [ x-test-duplicate-separate, { value: [ first, second ], as: equal } ]
@@ -146,16 +145,12 @@ sessions:
         fields:
         - [ :method, { value: POST, as: equal } ]
         - [ :scheme, { value: https, as: equal } ]
-        # Our Python httpx proxy changes the `:authority` header to:
-        # 127.0.0.1:<some_port>
-        - [ :authority, { value: 127.0.0.1, as: contains } ]
+        - [ :authority, { value: example.data.com, as: equal } ]
         - [ :path, /a/path ]
         - [ X-Request-Header, { as: present } ]
         - [ X-Added-Header, { as: present } ]
         - [ X-Deleted-Header, { as: absent } ]
-        # Annoyingly, the Python httpx HTTP/2 client we use as a test proxy
-        # inserts a Content-Length header.
-        #- [ Content-Length, { as: absent } ]
+        - [ Content-Length, { as: absent } ]
 
     server-response:
       headers:
@@ -216,7 +211,7 @@ sessions:
         fields:
         - [ :method, { value: GET, as: equal } ]
         - [ :scheme, { value: https, as: equal } ]
-        - [ :authority, { value: 127.0.0.1, as: contains } ]
+        - [ :authority, { value: example.data.com, as: equal } ]
         - [ :path, { value: /b/path, as: equal } ]
         - [ X-Request-Header, { value: test_request, as: equal } ]
 
@@ -268,7 +263,7 @@ sessions:
         fields:
         - [ :method, { value: GET, as: equal } ]
         - [ :scheme, { value: https, as: equal } ]
-        - [ :authority, { value: 127.0.0.1, as: contains } ]
+        - [ :authority, { value: example.data.com, as: equal } ]
         - [ :path, { value: /b/path, as: equal } ]
         - [ X-Request-Header, { value: test_request, as: equal } ]
 

--- a/test/autests/gold_tests/http2/replay_files/set_alpn.yaml
+++ b/test/autests/gold_tests/http2/replay_files/set_alpn.yaml
@@ -49,8 +49,7 @@ sessions:
 
       headers:
         fields:
-        # Our Python httpx test proxy does not send a Host header.
-        #- [ Host, { value: example.data.com, as: equal } ]
+        - [ Host, { value: example.data.com, as: equal } ]
         - [ Content-Length, { value: "0", as: equal } ]
 
     server-response:

--- a/test/autests/gold_tests/http2_abort/http2_abort.test.py
+++ b/test/autests/gold_tests/http2_abort/http2_abort.test.py
@@ -15,8 +15,10 @@ Abort HTTP/2 connection.
 # Test 1: Client sends RST_STREAM after DATA frame
 #
 r = Test.AddTestRun('Client sends RST_STREAM after DATA frame')
-client = r.AddClientProcess('client1', 'replay_files/client_rst_stream_after_data.yaml')
-server = r.AddServerProcess('server1', 'replay_files/client_rst_stream_after_data.yaml')
+client = r.AddClientProcess(
+    'client1', 'replay_files/client_rst_stream_after_data.yaml')
+server = r.AddServerProcess(
+    'server1', 'replay_files/client_rst_stream_after_data.yaml')
 proxy = r.AddProxyProcess('proxy1', listen_port=client.Variables.https_port,
                           server_port=server.Variables.https_port,
                           use_ssl=True, use_http2_to_2=True)
@@ -49,8 +51,10 @@ proxy.Streams.stdout += Testers.ContainsExpression(
 # Test 2: Client sends RST_STREAM after HEADERS frame
 #
 r = Test.AddTestRun('Client sends RST_STREAM after HEADERS frame')
-client = r.AddClientProcess('client2', 'replay_files/client_rst_stream_after_headers.yaml')
-server = r.AddServerProcess('server2', 'replay_files/client_rst_stream_after_headers.yaml')
+client = r.AddClientProcess(
+    'client2', 'replay_files/client_rst_stream_after_headers.yaml')
+server = r.AddServerProcess(
+    'server2', 'replay_files/client_rst_stream_after_headers.yaml')
 proxy = r.AddProxyProcess('proxy2', listen_port=client.Variables.https_port,
                           server_port=server.Variables.https_port,
                           use_ssl=True, use_http2_to_2=True)
@@ -83,12 +87,15 @@ proxy.Streams.stdout += Testers.ContainsExpression(
     'Frame sequence from client: HEADERS, RST_STREAM',
     'Frame sequence.')
 
+
 #
 # Test 3: Server sends RST_STREAM after HEADERS frame
 #
 r = Test.AddTestRun('Server sends RST_STREAM after HEADERS frame')
-client = r.AddClientProcess('client3', 'replay_files/server_rst_stream_after_headers.yaml')
-server = r.AddServerProcess('server3', 'replay_files/server_rst_stream_after_headers.yaml')
+client = r.AddClientProcess(
+    'client3', 'replay_files/server_rst_stream_after_headers.yaml')
+server = r.AddServerProcess(
+    'server3', 'replay_files/server_rst_stream_after_headers.yaml')
 proxy = r.AddProxyProcess('proxy3', listen_port=client.Variables.https_port,
                           server_port=server.Variables.https_port,
                           use_ssl=True, use_http2_to_2=True)
@@ -106,10 +113,6 @@ server.Streams.stdout += Testers.ContainsExpression(
     'Submitted RST_STREAM frame.')
 
 proxy.Streams.stdout += Testers.ContainsExpression(
-    'httpcore.RemoteProtocolError:',
-    'Received RST_STREAM frame.')
-
-proxy.Streams.stdout += Testers.ContainsExpression(
     'StreamReset stream_id:1, error_code:(11|ErrorCodes.ENHANCE_YOUR_CALM), remote_reset:True',
     'Received RST_STREAM frame.')
 
@@ -117,8 +120,10 @@ proxy.Streams.stdout += Testers.ContainsExpression(
 # Test 4: Client sends GOAWAY after HEADERS frame
 #
 r = Test.AddTestRun('Client sends GOAWAY after HEADERS frame')
-client = r.AddClientProcess('client4', 'replay_files/client_goaway_after_headers.yaml')
-server = r.AddServerProcess('server4', 'replay_files/client_goaway_after_headers.yaml')
+client = r.AddClientProcess(
+    'client4', 'replay_files/client_goaway_after_headers.yaml')
+server = r.AddServerProcess(
+    'server4', 'replay_files/client_goaway_after_headers.yaml')
 proxy = r.AddProxyProcess('proxy4', listen_port=client.Variables.https_port,
                           server_port=server.Variables.https_port,
                           use_ssl=True, use_http2_to_2=True)
@@ -155,8 +160,10 @@ proxy.Streams.stdout += Testers.ContainsExpression(
 # Test 5: Server sends GOAWAY after HEADERS frame
 #
 r = Test.AddTestRun('Server sends GOAWAY after HEADERS frame')
-client = r.AddClientProcess('client5', 'replay_files/server_goaway_after_headers.yaml')
-server = r.AddServerProcess('server5', 'replay_files/server_goaway_after_headers.yaml')
+client = r.AddClientProcess(
+    'client5', 'replay_files/server_goaway_after_headers.yaml')
+server = r.AddServerProcess(
+    'server5', 'replay_files/server_goaway_after_headers.yaml')
 proxy = r.AddProxyProcess('proxy5', listen_port=client.Variables.https_port,
                           server_port=server.Variables.https_port,
                           use_ssl=True, use_http2_to_2=True)


### PR DESCRIPTION
Currently the http2 test proxy uses the httpx library, which works great in general. However it doesn't support trailer header. As we are working on adding trailer header support in Proxy Verifier,  it would be good to have the test proxy support trailer header, so that we can verify the proper functionality of the feature.

This PR updates the http2 test proxy, replacing the usage of  `httpx` with the `python-hyper/h2` library.  The `h2` is a lower-level library that supports trailer header and is used in the client-facing logic already. Verified that after these changes(with adjusted expectations), all existing tests pass.

Note that while this PR updates the test proxy to use a library that can support trailer header, the actual trailer header handling logic in the proxy would be added in another PR(on top of this one) for clarity and convenience of testing. The changes in this PR makes it quite trivial to add that.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
