### PR TITLE
HTTP/2 trailer header support

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,9 +371,11 @@ therefore, would look like the following:
       size: 3432
 ```
 
-Trailer response headers are useful for transmitting additional fields after the message body, providing dynamically generated metadata such as integrity checks or post-processing status. Proxy Verifier supports sending and verifying trailer headers, as demonstrated below:
+Trailer response headers are useful for transmitting additional fields after the
+message body, providing dynamically generated metadata such as integrity checks
+or post-processing status. Proxy Verifier supports sending and receiving trailer
+headers, as demonstrated below:
 ```YAML
-
   server-response:
     status: 200
     headers:
@@ -386,13 +388,6 @@ Trailer response headers are useful for transmitting additional fields after the
       fields:
       - [ x-test-trailer-1, one ]
       - [ x-test-trailer-2, two ]
-  proxy-response:
-    # Other verifications...
-    trailers:
-      fields:
-      # Verify the client receives the response trailers.
-      - [ x-test-trailer-1, { value: one, as: equal } ]
-      - [ x-test-trailer-2, { value: two, as: equal } ]
 ```
 
 It is also possible to specify everything as a sequence of frames. The available
@@ -1028,6 +1023,17 @@ The `not` and `case: ignore` directives can both be applied on the same rule. Th
 
 ```YAML
   - [ X-Forwarded-For, { value: a, not: prefix, case: ignore } ]
+```
+
+In addition to HTTP/2 trailer header replay discussed above, Proxy Verifier also supports trailer header verification, as demonstrated below:
+```YAML
+proxy-response:
+  # Other verifications...
+  trailers:
+    fields:
+    # Verify the client receives the response trailers.
+    - [ x-test-trailer-1, { value: one, as: equal } ]
+    - [ x-test-trailer-2, { value: two, as: equal } ]
 ```
 
 #### meta headers

--- a/README.md
+++ b/README.md
@@ -375,6 +375,7 @@ Trailer response headers are useful for transmitting additional fields after the
 message body, providing dynamically generated metadata such as integrity checks
 or post-processing status. Proxy Verifier supports sending and receiving trailer
 headers, as demonstrated below:
+
 ```YAML
   server-response:
     status: 200
@@ -1026,6 +1027,7 @@ The `not` and `case: ignore` directives can both be applied on the same rule. Th
 ```
 
 In addition to HTTP/2 trailer header replay discussed above, Proxy Verifier also supports trailer header verification, as demonstrated below:
+
 ```YAML
 proxy-response:
   # Other verifications...
@@ -1039,9 +1041,10 @@ proxy-response:
 #### meta headers
 In addition to the directives that check the actual content of individual
 fields, Proxy Verifier supports meta-fields denoted by an `@` prefix that serve
-as directives for the tool to perform custom operations. The following
-demonstrates the usage of the `@hasfields` meta-field to verify that the
-`header` node has at least one field:
+as directives for the tool to perform custom operations. Currently, the only
+meta header that is supported is `@hasfields`, which can verify that there are
+or are not header fields with a proxy-request or proxy-response. The following
+demonstrates the usage of this meta header:
 
 ```YAML
 proxy-response:

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Table of Contents
          * [Session and Transaction Delay Specification](#session-and-transaction-delay-specification)
       * [Traffic Verification Specification](#traffic-verification-specification)
          * [Field Verification](#field-verification)
+            * [meta headers](#meta-headers)
          * [URL Verification](#url-verification)
          * [Status Verification](#status-verification)
          * [Body Verification](#body-verification)
@@ -368,6 +369,30 @@ therefore, would look like the following:
       - [ Content-Type, image/jpeg ]
     content:
       size: 3432
+```
+
+Trailer response headers are useful for transmitting additional fields after the message body, providing dynamically generated metadata such as integrity checks or post-processing status. Proxy Verifier supports sending and verifying trailer headers, as demonstrated below:
+```YAML
+
+  server-response:
+    status: 200
+    headers:
+      fields:
+      # Some fields...
+    content:
+      # Some data...
+    trailers:
+      encoding: esc_json
+      fields:
+      - [ x-test-trailer-1, one ]
+      - [ x-test-trailer-2, two ]
+  proxy-response:
+    # Other verifications...
+    trailers:
+      fields:
+      # Verify the client receives the response trailers.
+      - [ x-test-trailer-1, { value: one, as: equal } ]
+      - [ x-test-trailer-2, { value: two, as: equal } ]
 ```
 
 It is also possible to specify everything as a sequence of frames. The available
@@ -1003,6 +1028,23 @@ The `not` and `case: ignore` directives can both be applied on the same rule. Th
 
 ```YAML
   - [ X-Forwarded-For, { value: a, not: prefix, case: ignore } ]
+```
+
+#### meta headers
+In addition to the directives that check the actual content of individual
+fields, Proxy Verifier supports meta-fields denoted by an `@` prefix that serve
+as directives for the tool to perform custom operations. The following
+demonstrates the usage of the `@hasfields` meta-field to verify that the
+`header` node has at least one field:
+
+```YAML
+proxy-response:
+  headers:
+    fields:
+    - [ :status, { value: 200, as: equal } ]
+    - [ Cache-Control, private ]
+    - [ Content-Length, { value: '16', as: equal } ]
+    - [ "@hasfields", { value: true, as: equal } ]
 ```
 
 ### URL Verification

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ Table of Contents
          * [Session and Transaction Delay Specification](#session-and-transaction-delay-specification)
       * [Traffic Verification Specification](#traffic-verification-specification)
          * [Field Verification](#field-verification)
-            * [meta headers](#meta-headers)
          * [URL Verification](#url-verification)
          * [Status Verification](#status-verification)
          * [Body Verification](#body-verification)
@@ -1036,24 +1035,6 @@ proxy-response:
     # Verify the client receives the response trailers.
     - [ x-test-trailer-1, { value: one, as: equal } ]
     - [ x-test-trailer-2, { value: two, as: equal } ]
-```
-
-#### meta headers
-In addition to the directives that check the actual content of individual
-fields, Proxy Verifier supports meta-fields denoted by an `@` prefix that serve
-as directives for the tool to perform custom operations. Currently, the only
-meta header that is supported is `@hasfields`, which can verify that there are
-or are not header fields with a proxy-request or proxy-response. The following
-demonstrates the usage of this meta header:
-
-```YAML
-proxy-response:
-  headers:
-    fields:
-    - [ :status, { value: 200, as: equal } ]
-    - [ Cache-Control, private ]
-    - [ Content-Length, { value: '16', as: equal } ]
-    - [ "@hasfields", { value: true, as: equal } ]
 ```
 
 ### URL Verification

--- a/local/include/core/YamlParser.h
+++ b/local/include/core/YamlParser.h
@@ -61,6 +61,7 @@ static const std::string YAML_ALL_MESSAGES_KEY{"all"};
 static const std::string YAML_FRAMES_KEY{"frames"};
 static const std::string YAML_ERROR_CODE_KEY{"error-code"};
 static const std::string YAML_HDR_KEY{"headers"};
+static const std::string YAML_TRAILER_KEY{"trailers"};
 static const std::string YAML_FIELDS_KEY{"fields"};
 static const std::string YAML_HTTP_STATUS_KEY{"status"};
 static const std::string YAML_HTTP_REASON_KEY{"reason"};

--- a/local/include/core/http.h
+++ b/local/include/core/http.h
@@ -396,6 +396,7 @@ public:
 
   /** Verify that the (header) fields in 'this' correspond to the provided rules.
    *
+   * @param key The key for this transaction.
    * @param rules_ HeaderRules to iterate over, contains RuleCheck objects
    * @return Whether any rules were violated
    */
@@ -403,6 +404,7 @@ public:
 
   /** Verify that the (trailer) fields in 'this' correspond to the provided rules.
    *
+   * @param key The key for this transaction.
    * @param rules_ HeaderRules to iterate over, contains RuleCheck objects
    * @return Whether any rules were violated
    */
@@ -618,10 +620,9 @@ struct Txn
 
   /// How long the user said to delay for this transaction.
   std::chrono::microseconds _user_specified_delay_duration{0};
-  HttpHeader _req; ///< Request to send.
-  HttpHeader _rsp; ///< Rules for response to expect.
-  // TODO: zli11: understand the following naming and comment. May need modify.
-  HttpHeader _rsp_trailer; ///< Rules for response to expect.
+  HttpHeader _req;         ///< Request to send.
+  HttpHeader _rsp;         ///< Rules for response to expect.
+  HttpHeader _rsp_trailer; ///< Rules for response trailer to expect.
 };
 
 struct Ssn

--- a/local/include/core/http.h
+++ b/local/include/core/http.h
@@ -309,6 +309,8 @@ public:
    */
   void add_fields_to_ngnva(nghttp3_nv *l) const;
 
+  bool verify(swoc::TextView transaction_key, HttpFields const &rules_) const;
+
   friend class HttpHeader;
 };
 
@@ -392,12 +394,19 @@ public:
    */
   std::string get_key() const;
 
-  /** Verify that the fields in 'this' correspond to the provided rules.
+  /** Verify that the (header) fields in 'this' correspond to the provided rules.
    *
    * @param rules_ HeaderRules to iterate over, contains RuleCheck objects
    * @return Whether any rules were violated
    */
   bool verify_headers(swoc::TextView key, HttpFields const &rules_) const;
+
+  /** Verify that the (trailer) fields in 'this' correspond to the provided rules.
+   *
+   * @param rules_ HeaderRules to iterate over, contains RuleCheck objects
+   * @return Whether any rules were violated
+   */
+  bool verify_trailers(swoc::TextView key, HttpFields const &rules_) const;
 
   /** Add the fields and rules from other into self's _fields_rules.
    *
@@ -519,6 +528,7 @@ public:
 
   /// Maps field names to functors (rules) and field names to values (fields)
   std::shared_ptr<HttpFields> _fields_rules = nullptr;
+  std::shared_ptr<HttpFields> _trailer_fields_rules = nullptr;
 
   std::deque<H2Frame> _h2_frame_sequence;
 
@@ -610,6 +620,8 @@ struct Txn
   std::chrono::microseconds _user_specified_delay_duration{0};
   HttpHeader _req; ///< Request to send.
   HttpHeader _rsp; ///< Rules for response to expect.
+  // TODO: zli11: understand the following naming and comment. May need modify.
+  HttpHeader _rsp_trailer; ///< Rules for response to expect.
 };
 
 struct Ssn

--- a/local/include/core/http2.h
+++ b/local/include/core/http2.h
@@ -65,6 +65,9 @@ public:
   size_t _send_body_offset = 0;
   bool _wait_for_continue = false;
   std::string _key;
+
+  nghttp2_nv *_trailer_to_send = nullptr;
+  int _trailer_length{0};
   /** The composed URL parts from :method, :authority, and :path pseudo headers
    * from the request.
    *
@@ -194,6 +197,7 @@ protected:
   static void terminate(SSL_CTX *&client_context);
 
 private:
+  // TODO: update doxygen param for the following.
   /** Populate an nghttp2 vector from the information in an HttpHeader instance.
    *
    * @param[in] hdr The instance from which to pack headers.
@@ -202,7 +206,8 @@ private:
    *
    * @return Any errata information from the packing operation.
    */
-  swoc::Errata pack_headers(HttpHeader const &hdr, nghttp2_nv *&nv_hdr, int &hdr_count);
+  swoc::Errata
+  pack_headers(HttpHeader const &hdr, bool trailer, nghttp2_nv *&nv_hdr, int &hdr_count);
   nghttp2_nv tv_to_nv(char const *name, swoc::TextView v);
   void set_expected_response_for_last_request(HttpHeader const &response);
 

--- a/local/include/core/http2.h
+++ b/local/include/core/http2.h
@@ -197,17 +197,17 @@ protected:
   static void terminate(SSL_CTX *&client_context);
 
 private:
-  // TODO: update doxygen param for the following.
   /** Populate an nghttp2 vector from the information in an HttpHeader instance.
    *
    * @param[in] hdr The instance from which to pack headers.
+   * @param[in] is_trailer Whether the headers are trailers.
    * @param[out] nv_hdr The packed headers.
    * @param[out] hdr_count The size of the nv_hdr vector.
    *
    * @return Any errata information from the packing operation.
    */
   swoc::Errata
-  pack_headers(HttpHeader const &hdr, bool trailer, nghttp2_nv *&nv_hdr, int &hdr_count);
+  pack_headers(HttpHeader const &hdr, bool is_trailer, nghttp2_nv *&nv_hdr, int &hdr_count);
   nghttp2_nv tv_to_nv(char const *name, swoc::TextView v);
   void set_expected_response_for_last_request(HttpHeader const &response);
 

--- a/local/src/core/YamlParser.cc
+++ b/local/src/core/YamlParser.cc
@@ -370,6 +370,20 @@ YamlParser::populate_http_message(YAML::Node const &node, HttpHeader &message)
     }
   }
 
+  if (node[YAML_TRAILER_KEY]) {
+    auto hdr_node{node[YAML_TRAILER_KEY]};
+    if (hdr_node[YAML_FIELDS_KEY]) {
+      auto field_list_node{hdr_node[YAML_FIELDS_KEY]};
+      Errata result = parse_fields_and_rules(
+          field_list_node,
+          *message._trailer_fields_rules,
+          message._verify_strictly);
+      if (!result.is_ok()) {
+        errata.note(S_ERROR, "Failed to parse trailer at {}", node.Mark());
+        errata.note(std::move(result));
+      }
+    }
+  }
   errata.note(process_pseudo_headers(headers_frame, message));
 
   if (!rst_stream_frame.IsNull()) {
@@ -1225,10 +1239,7 @@ public:
   {
     errata.note(_handler.file_open(path));
   }
-  ~HandlerOpener()
-  {
-    errata.note(_handler.file_close());
-  }
+  ~HandlerOpener() { errata.note(_handler.file_close()); }
 
 private:
   ReplayFileHandler &_handler;

--- a/local/src/core/YamlParser.cc
+++ b/local/src/core/YamlParser.cc
@@ -369,7 +369,7 @@ YamlParser::populate_http_message(YAML::Node const &node, HttpHeader &message)
       }
     }
   }
-
+  // Parse the trailer.
   if (node[YAML_TRAILER_KEY]) {
     auto hdr_node{node[YAML_TRAILER_KEY]};
     if (hdr_node[YAML_FIELDS_KEY]) {
@@ -1239,7 +1239,10 @@ public:
   {
     errata.note(_handler.file_open(path));
   }
-  ~HandlerOpener() { errata.note(_handler.file_close()); }
+  ~HandlerOpener()
+  {
+    errata.note(_handler.file_close());
+  }
 
 private:
   ReplayFileHandler &_handler;

--- a/local/src/core/http.cc
+++ b/local/src/core/http.cc
@@ -259,6 +259,90 @@ HttpFields::add_fields_to_ngnva(nghttp3_nv *l) const
   }
 }
 
+bool
+HttpFields::verify(swoc::TextView transaction_key, HttpFields const &rules_) const
+{
+  // Remains false if no issue is observed
+  // Setting true does not break loop because test() calls errata.diag()
+  bool issue_exists = false;
+  auto const &rules = rules_._rules;
+  auto const *url_rules = rules_._url_rules;
+  auto const &fields = this->_fields;
+  auto const *url_parts = this->_url_parts;
+  for (auto const &[name, rule_check] : rules) {
+    // meta headers
+    if (*name == '@') {
+      if (name == "@hasfields") {
+        const char *true_string = "true";
+        const char *false_string = "false";
+        if (!rule_check->test(
+                transaction_key,
+                name,
+                swoc::TextView(_fields.size() > 0 ? true_string : false_string)))
+        {
+          issue_exists = true;
+        }
+      }
+    } else {
+      auto name_range = fields.equal_range(name);
+      auto field_iter = name_range.first;
+      if (rule_check->expects_duplicate_fields()) {
+        if (field_iter == name_range.second) {
+          if (!rule_check->test(transaction_key, swoc::TextView(), std::vector<TextView>{})) {
+            // We supply the empty name and value for the absence check which
+            // expects this to indicate an absent field.
+            issue_exists = true;
+          }
+        } else {
+          std::vector<TextView> values;
+          while (field_iter != name_range.second) {
+            values.emplace_back(field_iter->second);
+            ++field_iter;
+          }
+          if (!rule_check->test(transaction_key, name, values)) {
+            issue_exists = true;
+          }
+        }
+      } else {
+        if (field_iter == name_range.second) {
+          if (!rule_check->test(transaction_key, swoc::TextView(), swoc::TextView())) {
+            // We supply the empty name and value for the absence check which
+            // expects this to indicate an absent field.
+            issue_exists = true;
+          }
+        } else {
+          if (!rule_check
+                   ->test(transaction_key, field_iter->first, swoc::TextView(field_iter->second))) {
+            issue_exists = true;
+          }
+        }
+      }
+    }
+  }
+  for (std::size_t i = 0; i < URL_PART_NAMES.count(); ++i) {
+    const std::vector<std::shared_ptr<RuleCheck>> &v = url_rules[i];
+    for (size_t j = 0; j < v.size(); ++j) {
+      const std::shared_ptr<RuleCheck> rule_check = v[j];
+      swoc::TextView value = url_parts[i];
+      if (rule_check == nullptr) {
+        continue;
+      }
+      if (value.empty()) {
+        if (!rule_check->test(transaction_key, swoc::TextView(), swoc::TextView())) {
+          // We supply the empty name and value for the absence check which
+          // expects this to indicate an absent field.
+          issue_exists = true;
+        }
+      } else {
+        if (!rule_check->test(transaction_key, URL_PART_NAMES[static_cast<UrlPart>(i)], value)) {
+          issue_exists = true;
+        }
+      }
+    }
+  }
+  return issue_exists;
+}
+
 swoc::Errata
 HttpHeader::parse_url(TextView url)
 {
@@ -395,74 +479,18 @@ HttpHeader::derive_key()
   swoc::FixedBufferWriter{_key.data(), _key.size()}.print_n(binding, _key_format);
 }
 
-// Verify that the fields in 'this' correspond to the provided rules.
+// Verify that the headers in 'this' correspond to the provided rules.
 bool
 HttpHeader::verify_headers(swoc::TextView transaction_key, HttpFields const &rules_) const
 {
-  // Remains false if no issue is observed
-  // Setting true does not break loop because test() calls errata.note(S_DIAG, )
-  bool issue_exists = false;
-  auto const &rules = rules_._rules;
-  auto const *url_rules = rules_._url_rules;
-  auto const &fields = _fields_rules->_fields;
-  auto const *url_parts = _fields_rules->_url_parts;
-  for (auto const &[name, rule_check] : rules) {
-    auto name_range = fields.equal_range(name);
-    auto field_iter = name_range.first;
-    if (rule_check->expects_duplicate_fields()) {
-      if (field_iter == name_range.second) {
-        if (!rule_check->test(transaction_key, swoc::TextView(), std::vector<TextView>{})) {
-          // We supply the empty name and value for the absence check which
-          // expects this to indicate an absent field.
-          issue_exists = true;
-        }
-      } else {
-        std::vector<TextView> values;
-        while (field_iter != name_range.second) {
-          values.emplace_back(field_iter->second);
-          ++field_iter;
-        }
-        if (!rule_check->test(transaction_key, name, values)) {
-          issue_exists = true;
-        }
-      }
-    } else {
-      if (field_iter == name_range.second) {
-        if (!rule_check->test(transaction_key, swoc::TextView(), swoc::TextView())) {
-          // We supply the empty name and value for the absence check which
-          // expects this to indicate an absent field.
-          issue_exists = true;
-        }
-      } else {
-        if (!rule_check
-                 ->test(transaction_key, field_iter->first, swoc::TextView(field_iter->second))) {
-          issue_exists = true;
-        }
-      }
-    }
-  }
-  for (std::size_t i = 0; i < URL_PART_NAMES.count(); ++i) {
-    const std::vector<std::shared_ptr<RuleCheck>> &v = url_rules[i];
-    for (size_t j = 0; j < v.size(); ++j) {
-      const std::shared_ptr<RuleCheck> rule_check = v[j];
-      swoc::TextView value = url_parts[i];
-      if (rule_check == nullptr) {
-        continue;
-      }
-      if (value.empty()) {
-        if (!rule_check->test(transaction_key, swoc::TextView(), swoc::TextView())) {
-          // We supply the empty name and value for the absence check which
-          // expects this to indicate an absent field.
-          issue_exists = true;
-        }
-      } else {
-        if (!rule_check->test(transaction_key, URL_PART_NAMES[static_cast<UrlPart>(i)], value)) {
-          issue_exists = true;
-        }
-      }
-    }
-  }
-  return issue_exists;
+  return _fields_rules->verify(transaction_key, rules_);
+}
+
+// Verify that the trailers in 'this' correspond to the provided rules.
+bool
+HttpHeader::verify_trailers(swoc::TextView transaction_key, HttpFields const &rules_) const
+{
+  return _trailer_fields_rules->verify(transaction_key, rules_);
 }
 
 void
@@ -474,6 +502,7 @@ HttpHeader::merge(HttpFields const &other)
 
 HttpHeader::HttpHeader(bool verify_strictly)
   : _fields_rules{std::make_shared<HttpFields>()}
+  , _trailer_fields_rules{std::make_shared<HttpFields>()}
   , _verify_strictly{verify_strictly}
   , _key{TRANSACTION_KEY_NOT_SET}
 {

--- a/local/src/server/verifier-server.cc
+++ b/local/src/server/verifier-server.cc
@@ -83,10 +83,7 @@ public:
 ServerThreadPool Server_Thread_Pool;
 
 HttpHeader
-get_continue_response(
-    int64_t stream_id,
-    HTTP_PROTOCOL_TYPE protocol,
-    std::string_view key)
+get_continue_response(int64_t stream_id, HTTP_PROTOCOL_TYPE protocol, std::string_view key)
 {
   HttpHeader response;
   response.set_key(key);
@@ -104,10 +101,7 @@ get_continue_response(
 }
 
 HttpHeader
-get_not_found_response(
-    int64_t stream_id,
-    HTTP_PROTOCOL_TYPE protocol,
-    std::string_view key)
+get_not_found_response(int64_t stream_id, HTTP_PROTOCOL_TYPE protocol, std::string_view key)
 {
   HttpHeader response;
   response.set_key(key);

--- a/test/autests/gold_tests/http2/gold/http2_to_http2_client.gold
+++ b/test/autests/gold_tests/http2/gold/http2_to_http2_client.gold
@@ -43,6 +43,18 @@ uuid: 3
 x-request-header: test_request
 uuid: 4
 
+``Sent the following HTTP/2 request headers for key 5 with stream id 9:
+:method: GET
+:scheme: https
+:authority: example.data.com
+:path: /a/path?q=3
+accept: */*
+accept-language: en-us
+accept-encoding: gzip
+host: example.data.com
+content-length: 0
+uuid: 5
+
 ``Equals Success: Key: "1", Field Name: ":status", Value: "200"
 ``Equals Success: Key: "1", Field Name: "content-length", Value: "16"
 ``Equals Success: Key: "1", Field Name: "x-test-duplicate-combined", Values: "one" "two"
@@ -96,4 +108,24 @@ x-response-header: response
 content-length: 0
 uuid: 4
 
+``
+``Equals Success: Key: "5", Field Name: ":status", Value: "200"
+``Equals Success: Key: "5", Field Name: "content-length", Value: "16"
+``Received an HTTP/2 response for key 5 with stream id 9:
+:status: 200
+cache-control: private
+content-type: application/json;charset=utf-8
+content-length: 16
+date: Sat, 16 Mar 2019 01:13:21 GMT
+age: 0
+uuid: 5
+``
+``Received an HTTP/2 body of 16 bytes for key 5 with stream id 9:
+0123456789abcdef
+``
+``Received an HTTP/2 trailer for stream id 9:
+
+``Equals Success: Key: "5", Field Name: "@hasfields", Value: "true"
+``Equals Success: Key: "5", Field Name: "x-test-trailer-1", Value: "one"
+``Equals Success: Key: "5", Field Name: "x-test-trailer-2", Value: "two"
 ``

--- a/test/autests/gold_tests/http2/gold/http2_to_http2_client.gold
+++ b/test/autests/gold_tests/http2/gold/http2_to_http2_client.gold
@@ -125,7 +125,6 @@ uuid: 5
 ``
 ``Received an HTTP/2 trailer for stream id 9:
 
-``Equals Success: Key: "5", Field Name: "@hasfields", Value: "true"
 ``Equals Success: Key: "5", Field Name: "x-test-trailer-1", Value: "one"
 ``Equals Success: Key: "5", Field Name: "x-test-trailer-2", Value: "two"
 ``

--- a/test/autests/gold_tests/http2/gold/http2_to_http2_proxy.gold
+++ b/test/autests/gold_tests/http2/gold/http2_to_http2_proxy.gold
@@ -100,4 +100,32 @@ uuid: 4
 
 ==== RESPONSE BODY ====
 b''
+
+StreamEnded
+==== REQUEST HEADERS ====
+:method: GET
+:scheme: https
+:path: /a/path?q=3
+:authority: example.data.com
+accept: */*
+accept-language: en-us
+accept-encoding: gzip
+host: example.data.com
+content-length: 0
+uuid: 5
+
+==== RESPONSE ====
+200
+
+==== RESPONSE HEADERS ====
+:status: 200
+cache-control: private
+content-type: application/json;charset=utf-8
+content-length: 16
+date: Sat, 16 Mar 2019 01:13:21 GMT
+age: 0
+uuid: 5
+
+==== RESPONSE BODY ====
+b'0123456789abcdef'
 ``

--- a/test/autests/gold_tests/http2/gold/http2_to_http2_server.gold
+++ b/test/autests/gold_tests/http2/gold/http2_to_http2_server.gold
@@ -1,5 +1,5 @@
 ``
-``Ready with 4 transactions.
+``Ready with 5 transactions.
 ``
 :method: GET
 :scheme: https
@@ -84,4 +84,6 @@ x-response-header: response
 content-length: 0
 uuid: 4
 
+``
+``Received an HTTP/2 request for key 5 with stream id 9:
 ``

--- a/test/autests/gold_tests/http2/replay_files/http2_to_http2.yaml
+++ b/test/autests/gold_tests/http2/replay_files/http2_to_http2.yaml
@@ -285,10 +285,13 @@ sessions:
         - [ X-Response-Header, { value: response, as: equal } ]
         - [ Content-Length, { value: 0, as: equal } ]
 
+  #
+  # Verify the sending/receiving and verification of trailer headers.
+  #
   - all:
       headers:
         fields:
-        - [ uuid, 500 ]
+        - [ uuid, 5 ]
 
     client-request:
       method: GET
@@ -301,12 +304,9 @@ sessions:
         - [ Accept-Language, en-us ]
         - [ Accept-Encoding, gzip ]
         # Generally HTTP/2 does not use the Host header field, instead relying
-        # upon the :authority pseudo header field. But Proxy Verifier should do both if
-        # requested.
+        # upon the :authority pseudo header field. But Proxy Verifier should do
+        # both if requested.
         - [ Host, example.data.com ]
-        - [ x-test-duplicate-combined, [ first, second ] ]
-        - [ x-test-duplicate-separate, first ]
-        - [ x-test-duplicate-separate, second ]
         - [ Content-Length, "0" ]
       content:
         encoding: plain
@@ -328,13 +328,6 @@ sessions:
       - [ host, { value: example.data.com, as: equal } ]
       - [ path, { value: /a/path, as: equal } ]
       - [ authority, { value: example.data.com, as: equal } ]
-      - [ net-loc, { value: example.data.com, as: equal } ]
-      - [ query, { value: q=3, as: present } ]
-      - [ query, { value: 3, as: contains } ]
-      - [ fragment, { as: absent } ]
-      - [ host, { as: present } ]
-      - [ path, { value: /, as: prefix } ]
-      - [ port, { as: absent } ]
       headers:
         encoding: esc_json
         fields:
@@ -343,9 +336,6 @@ sessions:
         - [ :authority, { value: example.data.com, as: equal } ]
         - [ :path, { value: '/a/path?q=3', as: equal } ]
         - [ Host, { value: example.data.com, as: equal } ]
-        - [ Content-Length, { value: "0", as: equal } ]
-        - [ x-test-duplicate-combined, { value: [ first, second ], as: equal } ]
-        - [ x-test-duplicate-separate, { value: [ first, second ], as: equal } ]
 
     server-response:
       status: 200
@@ -357,13 +347,11 @@ sessions:
         - [ Content-Length, '16' ]
         - [ Date, "Sat, 16 Mar 2019 01:13:21 GMT" ]
         - [ Age, '0' ]
-        - [ x-test-duplicate-combined, [ one, two ] ]
-        - [ x-test-duplicate-separate, one ]
-        - [ x-test-duplicate-separate, two ]
       content:
         encoding: plain
         data: "0123456789abcdef"
       trailers:
+        # The server sends some trailers after the body data.
         encoding: esc_json
         fields:
         - [ x-test-trailer-1, one ]
@@ -375,10 +363,11 @@ sessions:
         - [ :status, { value: 200, as: equal } ]
         - [ Cache-Control, private ]
         - [ Content-Length, { value: '16', as: equal } ]
-        - [ x-test-duplicate-combined, { value: [ one, two ], as: equal } ]
-        - [ x-test-duplicate-separate, { value: [ one, two ], as: equal } ]
       trailers:
         fields:
+        # Verify the client receives the response trailers.
         - [ x-test-trailer-1, { value: one, as: equal } ]
         - [ x-test-trailer-2, { value: two, as: equal } ]
+        # The @hasfields meta header verifies there is at least one field under
+        # the current node.
         - [ "@hasfields", { value: true, as: equal } ]

--- a/test/autests/gold_tests/http2/replay_files/http2_to_http2.yaml
+++ b/test/autests/gold_tests/http2/replay_files/http2_to_http2.yaml
@@ -368,6 +368,3 @@ sessions:
         # Verify the client receives the response trailers.
         - [ x-test-trailer-1, { value: one, as: equal } ]
         - [ x-test-trailer-2, { value: two, as: equal } ]
-        # The @hasfields meta header verifies there is at least one field under
-        # the current node.
-        - [ "@hasfields", { value: true, as: equal } ]

--- a/test/autests/gold_tests/http2/replay_files/http2_to_http2.yaml
+++ b/test/autests/gold_tests/http2/replay_files/http2_to_http2.yaml
@@ -284,3 +284,101 @@ sessions:
         - [ :status, { value: 200, as: equal } ]
         - [ X-Response-Header, { value: response, as: equal } ]
         - [ Content-Length, { value: 0, as: equal } ]
+
+  - all:
+      headers:
+        fields:
+        - [ uuid, 500 ]
+
+    client-request:
+      method: GET
+      scheme: https
+      url: https://example.data.com/a/path?q=3
+      headers:
+        encoding: esc_json
+        fields:
+        - [ Accept, '*/*' ]
+        - [ Accept-Language, en-us ]
+        - [ Accept-Encoding, gzip ]
+        # Generally HTTP/2 does not use the Host header field, instead relying
+        # upon the :authority pseudo header field. But Proxy Verifier should do both if
+        # requested.
+        - [ Host, example.data.com ]
+        - [ x-test-duplicate-combined, [ first, second ] ]
+        - [ x-test-duplicate-separate, first ]
+        - [ x-test-duplicate-separate, second ]
+        - [ Content-Length, "0" ]
+      content:
+        encoding: plain
+        size: 0
+
+    proxy-request:
+      # HTTP/2 on the server-side.
+      protocol:
+      - name: http
+        version: 2
+      - name: tls
+        sni: test_sni
+      - name: tcp
+      - name: ip
+
+      # URL verification is supported for HTTP/2, with the appropriate fields
+      # from :scheme, :authority, and :path used.
+      - [ scheme, { value: https, as: equal } ]
+      - [ host, { value: example.data.com, as: equal } ]
+      - [ path, { value: /a/path, as: equal } ]
+      - [ authority, { value: example.data.com, as: equal } ]
+      - [ net-loc, { value: example.data.com, as: equal } ]
+      - [ query, { value: q=3, as: present } ]
+      - [ query, { value: 3, as: contains } ]
+      - [ fragment, { as: absent } ]
+      - [ host, { as: present } ]
+      - [ path, { value: /, as: prefix } ]
+      - [ port, { as: absent } ]
+      headers:
+        encoding: esc_json
+        fields:
+        - [ :method, { value: GET, as: equal } ]
+        - [ :scheme, { value: https, as: equal } ]
+        - [ :authority, { value: example.data.com, as: equal } ]
+        - [ :path, { value: '/a/path?q=3', as: equal } ]
+        - [ Host, { value: example.data.com, as: equal } ]
+        - [ Content-Length, { value: "0", as: equal } ]
+        - [ x-test-duplicate-combined, { value: [ first, second ], as: equal } ]
+        - [ x-test-duplicate-separate, { value: [ first, second ], as: equal } ]
+
+    server-response:
+      status: 200
+      headers:
+        encoding: esc_json
+        fields:
+        - [ Cache-Control, private ]
+        - [ Content-Type, application/json;charset=utf-8 ]
+        - [ Content-Length, '16' ]
+        - [ Date, "Sat, 16 Mar 2019 01:13:21 GMT" ]
+        - [ Age, '0' ]
+        - [ x-test-duplicate-combined, [ one, two ] ]
+        - [ x-test-duplicate-separate, one ]
+        - [ x-test-duplicate-separate, two ]
+      content:
+        encoding: plain
+        data: "0123456789abcdef"
+      trailers:
+        encoding: esc_json
+        fields:
+        - [ x-test-trailer-1, one ]
+        - [ x-test-trailer-2, two ]
+
+    proxy-response:
+      headers:
+        fields:
+        - [ :status, { value: 200, as: equal } ]
+        - [ Cache-Control, private ]
+        - [ Content-Length, { value: '16', as: equal } ]
+        - [ x-test-duplicate-combined, { value: [ one, two ], as: equal } ]
+        - [ x-test-duplicate-separate, { value: [ one, two ], as: equal } ]
+      trailers:
+        fields:
+        - [ x-test-trailer-1, { value: one, as: equal } ]
+        - [ x-test-trailer-2, { value: two, as: equal } ]
+        - [ "@hasfields", { value: true, as: equal } ]


### PR DESCRIPTION
This PR adds HTTP/2 trailer header support in Proxy Verifier. The changes in this PR was originally implemented by @keesspoelstra as in https://github.com/yahoo/proxy-verifier/pull/172 back in 2021.

I cherry-picked the changes into current master and made the following changes:
    * Updated test proxy to forward trailer header.
    * Updated test gold files
    * Minor code refractoring.
    * Updated README.

Note: To update the test proxy to support proxying trailer header, I put up a prerequisite PR https://github.com/yahoo/proxy-verifier/pull/265 that changes the library the test proxy uses for HTTP2. This PR is based on top of that.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
