### PR TITLE
Update Expect: 100-continue header support.

### DIFF
--- a/local/include/core/YamlParser.h
+++ b/local/include/core/YamlParser.h
@@ -93,6 +93,7 @@ static const std::string YAML_RULE_TYPE_MAP_KEY_NOT{"not"};
 static const std::string YAML_RULE_CASE_MAP_KEY{"case"};
 
 static constexpr swoc::TextView FIELD_HOST{"host"};
+static constexpr swoc::TextView FIELD_EXPECT{"expect"};
 
 static constexpr bool ASSUME_EQUALITY_RULE = true;
 

--- a/local/include/core/http.h
+++ b/local/include/core/http.h
@@ -452,6 +452,12 @@ public:
   /// Return whether this is an HTTP response.
   bool is_response() const;
 
+  /// Set this to be an HTTP request with an Expect: 100-continue header.
+  void set_is_request_with_expect_100_continue();
+
+  /// Return whether this is a request with an Expect: 100-continue header.
+  bool is_request_with_expect_100_continue() const;
+
   /// Whether the _fields array contains pseudo header fields.
   bool _contains_pseudo_headers_in_fields_array = false;
   int32_t _stream_id = -1; ///< For protocols with streams, this is the stream identifier.
@@ -589,6 +595,9 @@ private:
 
   /// Whether this is an HTTP request.
   bool _is_request = false;
+
+  /// Whether this contains an Expect: 100-continue header.
+  bool _contains_expect_100_continue = false;
 };
 
 struct Txn

--- a/local/src/core/YamlParser.cc
+++ b/local/src/core/YamlParser.cc
@@ -458,6 +458,13 @@ YamlParser::populate_http_message(YAML::Node const &node, HttpHeader &message)
       }
     }
   }
+  auto const it = message._fields_rules->_fields.find(FIELD_EXPECT);
+  if (it != message._fields_rules->_fields.end()) {
+    TextView value{it->second};
+    if (0 == strcasecmp("100-continue"_tv, value)) {
+      message.set_is_request_with_expect_100_continue();
+    }
+  }
 
   if (!message._method.empty() && message._authority.empty()) {
     // The URL didn't have the authority. Get it from the Host header if it

--- a/local/src/core/http2.cc
+++ b/local/src/core/http2.cc
@@ -1281,7 +1281,7 @@ H2Session::submit_data_frame(HttpHeader const &hdr, H2StreamState *stream_state,
   data_prd.read_callback = data_read_callback;
   stream_state->_body_to_send = content.data();
   stream_state->_send_body_length = content.size();
-  stream_state->_wait_for_continue = hdr._send_continue;
+  stream_state->_wait_for_continue = hdr.is_request_with_expect_100_continue();
 
   errata.note(
       S_DIAG,
@@ -1495,7 +1495,7 @@ H2Session::write(HttpHeader const &hdr)
       data_prd.read_callback = data_read_callback;
       stream_state->_body_to_send = content.data();
       stream_state->_send_body_length = content.size();
-      stream_state->_wait_for_continue = hdr._send_continue;
+      stream_state->_wait_for_continue = hdr.is_request_with_expect_100_continue();
       if (hdr.is_response()) {
         submit_result = nghttp2_submit_response(
             this->_session,

--- a/local/src/core/http3.cc
+++ b/local/src/core/http3.cc
@@ -1936,7 +1936,7 @@ H3Session::write(HttpHeader const &hdr)
     nghttp3_data_reader data_reader;
     data_reader.read_data = cb_h3_readfunction;
     stream_state->body_to_send = TextView{content.data(), content.size()};
-    stream_state->wait_for_continue = hdr._send_continue;
+    stream_state->wait_for_continue = hdr.is_request_with_expect_100_continue();
     if (hdr.is_response()) {
       submit_result = nghttp3_conn_submit_response(
           quic_socket.h3conn,


### PR DESCRIPTION
Mostly, this updates HTTP/1 Expect: 100-continue handling to not send the body until a 100 Continue response is received.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
