### PR TITLE
H3Session::receive_responses: detect closed connection

### DIFF
--- a/local/src/core/http3.cc
+++ b/local/src/core/http3.cc
@@ -2297,6 +2297,10 @@ H3Session::receive_responses()
 {
   Errata errata;
   while (!stream_map.empty()) {
+    if (is_closed()) {
+      errata.note(S_ERROR, "The connection was closed while awaiting HTTP/3 responses.");
+      break;
+    }
     errata.note(nghttp3_receive_and_send_data(*this, Poll_Timeout));
     if (!errata.is_ok()) {
       errata.note(S_ERROR, "Encountered a problem while receiving responses.");


### PR DESCRIPTION
This fixes an infinite loop while waiting for incoming responses when a connection has been closed.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
