### PR TITLE
If there are no trailer headers, do not pack them

### DIFF
--- a/local/src/core/http2.cc
+++ b/local/src/core/http2.cc
@@ -1627,6 +1627,11 @@ H2Session::pack_headers(HttpHeader const &hdr, bool is_trailer, nghttp2_nv *&nv_
     fields_rules = hdr._trailer_fields_rules;
   }
   hdr_count = fields_rules->_fields.size();
+  if (is_trailer && hdr_count == 0) {
+    nv_hdr = nullptr;
+    // There's nothing left to do for the trailers.
+    return errata;
+  }
 
   if (!is_trailer && !hdr._contains_pseudo_headers_in_fields_array) {
     if (hdr.is_response()) {


### PR DESCRIPTION
pack_headers would always malloc trailers even if there were none. This caused issues with some HTTP/2 traffic that didn't have trailers. This patch short-circuits the pack in these cases.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
