### PR TITLE
Gracefully handle non-sequence transactions

### DIFF
--- a/local/src/core/YamlParser.cc
+++ b/local/src/core/YamlParser.cc
@@ -1365,6 +1365,7 @@ YamlParser::load_replay_file(swoc::file::path const &path, ReplayFileHandler &ha
           txn_list_node.Mark(),
           ssn_node.Mark(),
           path);
+      continue;
     }
     if (txn_list_node.size() == 0) {
       session_errata.note(


### PR DESCRIPTION
We should stop processing a transaction list if the element is not a sequence. This will propagate an error rather than aborting with an uncaught exception later.

Fixes #289


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
