### PR TITLE
Require the uuid for transactions

### DIFF
--- a/schema/replay_schema.json
+++ b/schema/replay_schema.json
@@ -37,7 +37,7 @@
             "items": {
               "description": "Transaction",
               "type": "object",
-              "required": [ "client-request", "proxy-response" ],
+              "required": [ "client-request", "proxy-response", "uuid" ],
               "properties": {
                 "uuid": {
                   "description": "UUID to identify this specific transaction.",


### PR DESCRIPTION
Simple fix to require the UUID in the replay yaml schema, so its clear that the binaries require it to be present.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
