### PR TITLE
pin aioquic to 1.1.0

### DIFF
--- a/test/autests/Pipfile
+++ b/test/autests/Pipfile
@@ -21,7 +21,12 @@ eventlet = "*"
 ruamel_yaml = "*"
 
 asyncio = "*"
-aioquic = "*"
+
+# The latest aioquic, 1.2.0, causes http3 tests to fail. For now, I'm pinning
+# to last week's 1.1.0 release because tests work with this. When we have time,
+# we should investigate why this is failing with 1.2.0 and either fix the test
+# or file an issue with aioquic.
+aioquic = "==1.1.0"
 wsproto = "*"
 
 [requires]


### PR DESCRIPTION
The latest release, 1.2.0, causes the http3 tests to fail. For now, pinning to 1.1.0 from last week.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
