### PR TITLE
Support Ctrl-C for parsing YAML

### DIFF
--- a/local/include/core/ProxyVerifier.h
+++ b/local/include/core/ProxyVerifier.h
@@ -94,6 +94,7 @@ public:
   void join_threads();
   static constexpr size_t default_max_threads = 2'000;
   void set_max_threads(size_t new_max);
+  size_t get_max_threads() const;
 
 protected:
   std::list<std::thread> _allThreads;

--- a/local/include/core/YamlParser.h
+++ b/local/include/core/YamlParser.h
@@ -8,8 +8,10 @@
 #pragma once
 
 #include <chrono>
+#include <condition_variable>
 #include <functional>
 #include <memory>
+#include <queue>
 #include <string>
 #include <unordered_set>
 
@@ -265,14 +267,19 @@ public:
    *
    * @param[in] path The path to the YAML file to parse.
    *
+   * @param[in] content The file's content to parse.
+   *
    * @param[in] handler Conceptually, this contains the set of callbacks to
    *   dispatch into as the YAML file is parsed.
    *
    * @return Any errata from parsing the file.
    */
-  static swoc::Errata load_replay_file(swoc::file::path const &path, ReplayFileHandler &handler);
+  static swoc::Errata load_replay_file(
+      swoc::file::path const &path,
+      std::string const &content,
+      ReplayFileHandler &handler);
 
-  using loader_t = std::function<swoc::Errata(swoc::file::path const &)>;
+  using loader_t = std::function<swoc::Errata(swoc::file::path const &, std::string const &)>;
 
   /** Parse the specified YAML file(s).
    *
@@ -281,13 +288,20 @@ public:
    *
    * @param[in] loader The function to use for each file in path.
    *
-   * @param[in] n_threads The number of threads to use to parse the files in
-   *   path.
+   * @param[in] shutdown_flag A flag to indicate that the parsing should stop.
+   *
+   * @param[in] n_reader_threads The number of threads to use for reading files.
+   *
+   * @param[in] n_parser_threads The number of threads to use for parsing YAML file content.
    *
    * @return Any errata from parsing the file.
    */
-  static swoc::Errata
-  load_replay_files(swoc::file::path const &path, loader_t loader, int n_threads = 10);
+  static swoc::Errata load_replay_files(
+      swoc::file::path const &path,
+      loader_t loader,
+      bool &shutdown_flag,
+      int n_reader_threads = 4,
+      int n_parser_threads = 10);
 
   /** Populate an HTTP message from a YAML node.
    *

--- a/local/src/client/verifier-client.cc
+++ b/local/src/client/verifier-client.cc
@@ -891,10 +891,12 @@ Engine::parse_replay_files()
   errata.note(S_INFO, R"(Loading replay data from "{}".)", _replay_location);
   errata.note(YamlParser::load_replay_files(
       swoc::file::path{_replay_location},
-      [](swoc::file::path const &file) -> Errata {
+      [](swoc::file::path const &file, std::string const &content) -> Errata {
         ClientReplayFileHandler handler;
-        return YamlParser::load_replay_file(file, handler);
+        return YamlParser::load_replay_file(file, content, handler);
       },
+      Shutdown_Flag,
+      3,
       10));
   if (!errata.is_ok()) {
     process_exit_code = 1;

--- a/local/src/core/ProxyVerifier.cc
+++ b/local/src/core/ProxyVerifier.cc
@@ -12,6 +12,7 @@
 #include <array>
 #include <cassert>
 #include <csignal>
+#include <cstddef>
 #include <dirent.h>
 #include <fcntl.h>
 #include <iostream>
@@ -280,4 +281,10 @@ void
 ThreadPool::set_max_threads(size_t new_max)
 {
   max_threads = new_max;
+}
+
+size_t
+ThreadPool::get_max_threads() const
+{
+  return max_threads;
 }

--- a/local/src/server/verifier-server.cc
+++ b/local/src/server/verifier-server.cc
@@ -1001,12 +1001,15 @@ Engine::command_run()
       }
     }
 
+    // Typically, between reading and parsing, parsing is the bottleneck.
     errata.note(YamlParser::load_replay_files(
         swoc::file::path{args[0]},
-        [](swoc::file::path const &file) -> swoc::Errata {
+        [](swoc::file::path const &file, std::string const &content) -> swoc::Errata {
           ServerReplayFileHandler handler;
-          return YamlParser::load_replay_file(file, handler);
+          return YamlParser::load_replay_file(file, content, handler);
         },
+        Shutdown_Flag,
+        3,
         10));
 
     if (!errata.is_ok()) {


### PR DESCRIPTION
Separates reader and parser threads, in case that's helpful someday. It looks like the majority of the time is taken up in YAML parsing, shifting memory.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
