### PR TITLE
Consolidate polling to a single poll'ing thread

### DIFF
--- a/local/include/core/SocketNotifier.h
+++ b/local/include/core/SocketNotifier.h
@@ -1,0 +1,83 @@
+/** @file
+ * Notifies waiting sessions that their poll has completed.
+ *
+ * Copyright 2024, Verizon Media
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+
+class Session;
+
+/** The information needed to notify a session that its poll is done. */
+struct NotificationInfo
+{
+  NotificationInfo(std::weak_ptr<Session> session, int revent);
+
+  /** The session awaiting a poll result. */
+  std::weak_ptr<Session> session;
+
+  /** The poll output variable for this session's poll. */
+  int revents = 0;
+};
+
+/** Notifies waiting sessions that their sockets are ready.
+ *
+ * Note that this class used as a helper class for SocketPoller. No other
+ * entities should require using this class.
+ */
+class SocketNotifier
+{
+public:
+  /** Notify sessions that their poll events are done.
+   *
+   * @param[in] notification_infos The list of sessions and their poll events.
+   */
+  static void notify_sessions(std::vector<NotificationInfo> const &notification_infos);
+
+  /** No longer notify the indicated session.
+   * @param[in] fd The file descriptor of the session to no longer notify.
+   */
+  static void drop_session_notification(int fd);
+
+  /** Start the thread to notify sessions. */
+  static void start_notifier_thread();
+
+  /** Stop the thread for notification. */
+  static void stop_notifier_thread();
+
+private:
+  SocketNotifier() = default;
+
+  // Delete all other constructors to preserve the singleton.
+  SocketNotifier(const SocketNotifier &) = delete;
+  SocketNotifier &operator=(const SocketNotifier &) = delete;
+  SocketNotifier(SocketNotifier &&) = delete;
+  SocketNotifier &operator=(SocketNotifier &&) = delete;
+
+  /** This is the notification loop run continuously in a thread. It dispatches
+   * notification results from the SocketPoller.
+   */
+  void _start_notifying();
+
+private:
+  /** The notifier singleton. */
+  static SocketNotifier _socket_notifier;
+  static bool _stop_notifier_flag;
+
+  /** The outstanding callbacks that still need to be dispatched. */
+  std::unordered_map<int, NotificationInfo> _notification_infos;
+  std::mutex _notification_infos_mutex;
+
+  /** The Poller is our producer which wakes up the thread via @a notify_sessions. */
+  std::condition_variable _notification_infos_cv;
+
+  static std::thread _notifier_thread;
+};

--- a/local/include/core/SocketPoller.h
+++ b/local/include/core/SocketPoller.h
@@ -1,0 +1,120 @@
+/** @file
+ * Polls on sockets for sessions.
+ *
+ * Copyright 2024, Verizon Media
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <chrono>
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+
+class Session;
+class Notifier;
+
+/** Polls on the various sockets and awakes the waiting sessions as the sockets
+ * become ready.
+ *
+ * This dispatches poll results to SocketNotifier which, on a separate thread,
+ * dispatches notifications to the waiting sessions.
+ *
+ * Thus socket polling happens like so:
+ * 1. Many sessions request polling for their sockets via
+ *    SocketPoller::request_poll(). These sessions wait on their condition variable
+ *    for a poll result.
+ * 2. SocketPoller calls poll(2) on the set of sockets.
+ * 3. As poll(2) returns that sockets are available, SocketPoller dispatches the
+ *    poll results to SocketNotifier.
+ * 4. SocketNotifier awakes the waiting sessions with the poll results.
+ */
+class SocketPoller
+{
+public:
+  /** Start the thread which will call poll(2) on the registered file descriptors.
+   */
+  static void start_polling_thread();
+
+  /** Stop and join any threads related to polling on file descriptors. */
+  static void stop_polling_thread();
+
+  /** Request a polling event for the session.
+   *
+   * @param[in] session The session for which polling should be registered.
+   * @param[in] events The input to poll(2) for the fd. POLLIN, POLLOUT, etc.
+   */
+  static void request_poll(std::weak_ptr<Session> session, short events);
+
+  /** Remove the session as an entity to poll upon.
+   *
+   * @param[in] fd The file descriptor to remove from the list of fds to poll upon.
+   */
+  static void remove_poll_request(int fd);
+
+  /** Remove the specified file descriptors from the list of fds to poll upon.
+   *
+   * This function is more efficient than calling deregister_session for each
+   * session in the vector because it grabs the lock only once.
+   *
+   * @param[in] fds The list of file descriptors to remove from the list of fds
+   * to poll upon.
+   */
+  static void remove_poll_requests(std::vector<int> const &fds);
+
+private:
+  /** The set of information requested for a call to poll(2). */
+  class PollInfo
+  {
+  public:
+    PollInfo(std::weak_ptr<Session> session, short events);
+    std::weak_ptr<Session> session;
+    short events = 0;
+  };
+
+private:
+  SocketPoller() = default;
+
+  // Delete all other constructors to preserve the singleton.
+  SocketPoller(const SocketPoller &) = delete;
+  SocketPoller &operator=(const SocketPoller &) = delete;
+  SocketPoller(SocketPoller &&) = delete;
+  SocketPoller &operator=(SocketPoller &&) = delete;
+
+  /** This is the main logic for SocketPolling.
+   *
+   * This continuously polls on the registered file descriptors and dispatches
+   * notification requests to SocketNotifier as socket events are ready.
+   */
+  void _start_polling();
+
+private:
+  /** The poller singleton. */
+  static SocketPoller _socket_poller;
+
+  /** The timeout to pass to ::poll. This is set very small so that polls for one
+   * set of fds doesn't block for new ones that may come a bit later. */
+  static constexpr std::chrono::milliseconds const _poll_timeout = std::chrono::milliseconds(1);
+
+  /** A flag to tell the polling thread to stop polling. */
+  static bool _stop_polling_flag;
+
+  /** The thread in which socket polling will be performed. */
+  static std::thread _poller_thread;
+
+  /** The socket file descriptors for which to poll.
+   *
+   * This is a map from file descriptor to the session and desired events for
+   * that session.
+   */
+  std::unordered_map<int, PollInfo> _polling_requests;
+  std::mutex _polling_requests_mutex;
+
+  /** Many producers, one consumer. @a register_session awakes the polling
+   * consumer from the set of session threads. */
+  std::condition_variable _polling_requests_cv;
+};

--- a/local/include/core/http.h
+++ b/local/include/core/http.h
@@ -1,7 +1,7 @@
 /** @file
  * Common data structures and definitions for Proxy Verifier tools.
  *
- * Copyright 2022, Verizon Media
+ * Copyright 2024, Verizon Media
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -10,9 +10,12 @@
 #include "case_insensitive_utils.h"
 
 #include <chrono>
+#include <condition_variable>
 #include <list>
 #include <deque>
 #include <map>
+#include <memory>
+#include <mutex>
 #include <unordered_map>
 #include <nghttp2/nghttp2.h>
 #include <nghttp3/nghttp3.h>
@@ -680,11 +683,86 @@ struct Ssn
  * the socket. The goal is to enable a read operation that waits for data but
  * returns as soon as any data is available.
  */
-class Session
+class Session : public std::enable_shared_from_this<Session>
 {
+protected:
+  struct PrivateKey
+  {
+    explicit PrivateKey() = default;
+  };
+
+  // Restrict constructors to prevent any creation of Sessions except via the
+  // factory method.
+  Session() = default;
+
 public:
-  Session();
+  /** Publically accessible constructor.
+   *
+   * This is publicly accessible, so make_shared can call it, but requires
+   * PrivateKey, which only the factories can access.
+   */
+  Session(PrivateKey) : Session() { }
+
+  // Delete copying - all instances must be made via the factory method.
+  Session(Session const &) = delete;
+  Session &operator=(Session const &) = delete;
+
   virtual ~Session();
+
+  std::shared_ptr<Session> get_shared_ptr();
+
+  // -------------------------------------------------------------------
+  // Session Factory Methods Begin.
+  // -------------------------------------------------------------------
+  enum class SessionType {
+    TCP,
+    TLS,
+    HTTP2,
+    QUIC,
+  };
+
+  /** Create an object of the specified session.
+   *
+   * @param[in] type The type of session to create.
+   * @return The created session object.
+   */
+  static std::shared_ptr<Session> create_session(SessionType type);
+
+  /** Creates a TCP session object.
+   *
+   * @return The created Session object.
+   */
+  static std::shared_ptr<Session> create_tcp_session();
+
+  /** Creates a TLS session object.
+   *
+   * @param[in] client_sni The Server Name Indication (SNI) of the client.
+   * @param[in] verify_mode The mode used to verify the TLS session.
+   * @return The created Session object.
+   */
+  static std::shared_ptr<Session> create_tls_session(std::string_view client_sni, int verify_mode);
+
+  /** Creates an HTTP/2 session object.
+   *
+   * @param[in] client_sni The Server Name Indication (SNI) of the client.
+   * @param[in] verify_mode The mode used to verify the TLS session.
+   * @param[in] close_on_goaway Whether to close the session on receiving a GOAWAY frame.
+   * @return The created Session object.
+   */
+  static std::shared_ptr<Session>
+  create_h2_session(std::string_view client_sni, int verify_mode, bool close_on_goaway);
+
+  /** Creates an HTTP/3 session object.
+   *
+   * @param[in] client_sni The Server Name Indication (SNI) of the client.
+   * @param[in] verify_mode The mode used to verify the TLS session.
+   * @return The created Session object.
+   */
+  static std::shared_ptr<Session> create_h3_session(std::string_view client_sni, int verify_mode);
+
+  // -------------------------------------------------------------------
+  // Session Factory Methods End.
+  // -------------------------------------------------------------------
 
   /** Set the the socket to be associated with this stream.
    *
@@ -696,6 +774,12 @@ public:
 
   /** A getter for the socket for this stream. */
   virtual int get_fd() const;
+
+  /** Called by the SocketPoller when this session's poll event is triggered.
+   *
+   * @param[in] revents The poll output variable for this session.
+   */
+  virtual void handle_poll_return(short revents);
 
   /** Wait upon and complete the security layer handshakes.
    *
@@ -850,6 +934,15 @@ private:
 private:
   int _fd = -1; ///< Socket.
   ssize_t _body_offset = 0;
+
+  /** Condition variable for awaiting socket state transitions. */
+  std::condition_variable _poll_cv;
+
+  /// Guard _revent until Poller populates it.
+  std::mutex _revent_mutex;
+
+  /// The return of poll from Poller.
+  int _revents = 0;
 };
 
 inline int

--- a/local/include/core/http2.h
+++ b/local/include/core/http2.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include "core/http.h"
 #include "https.h"
 
 #include <chrono>
@@ -105,13 +106,28 @@ private:
 
 class H2Session : public TLSSession
 {
-public:
-  using super_type = TLSSession;
+protected:
+  /** Only SessionFactory can create Session objects to ensure that they are
+   * always managed via shared_ptrs. */
   H2Session();
   H2Session(
       swoc::TextView const &client_sni,
       int client_verify_mode = SSL_VERIFY_NONE,
       bool close_on_goaway = true);
+
+public:
+  using super_type = TLSSession;
+  // Publicly accessible for std::make_shared, but restricted via protected PrivateKey.
+  H2Session(Session::PrivateKey) : H2Session() { }
+  template <typename... Args>
+  H2Session(Session::PrivateKey, Args &&... args) : H2Session(std::forward<Args>(args)...)
+  {
+  }
+
+  // Delete copying - all instances must be made via the factory method.
+  H2Session(H2Session const &) = delete;
+  H2Session &operator=(H2Session const &) = delete;
+
   ~H2Session();
   swoc::Rv<ssize_t> read(swoc::MemSpan<char> span) override;
   swoc::Rv<ssize_t> write(swoc::TextView data) override;

--- a/local/include/core/http3.h
+++ b/local/include/core/http3.h
@@ -284,8 +284,24 @@ class H3Session : public Session
 {
 public:
   using super_type = Session;
+
+protected:
+  // Only the Session factory methods can create these.
   H3Session();
   H3Session(swoc::TextView const &client_sni, int client_verify_mode = SSL_VERIFY_NONE);
+
+public:
+  // Publicly accessible for std::make_shared, but restricted via protected PrivateKey.
+  H3Session(Session::PrivateKey) : H3Session() { }
+  template <typename... Args>
+  H3Session(Session::PrivateKey, Args &&... args) : H3Session(std::forward<Args>(args)...)
+  {
+  }
+
+  // Delete copying - all instances must be made via the factory method.
+  H3Session(H3Session const &) = delete;
+  H3Session &operator=(H3Session const &) = delete;
+
   ~H3Session();
   swoc::Rv<ssize_t> read(swoc::MemSpan<char> span) override;
   swoc::Rv<ssize_t> write(swoc::TextView data) override;

--- a/local/include/core/https.h
+++ b/local/include/core/https.h
@@ -157,8 +157,23 @@ class TLSSession : public Session
 public:
   using super_type = Session;
 
+protected:
+  // Only the Session factory methods can create these.
   TLSSession() = default;
   TLSSession(swoc::TextView const &client_sni, int client_verify_mode = SSL_VERIFY_NONE);
+
+public:
+  // Publicly accessible for std::make_shared, but restricted via protected PrivateKey.
+  TLSSession(Session::PrivateKey) : TLSSession() { }
+  template <typename... Args>
+  TLSSession(Session::PrivateKey, Args &&... args) : TLSSession(std::forward<Args>(args)...)
+  {
+  }
+
+  // Delete copying - all instances must be made via the factory method.
+  TLSSession(TLSSession const &) = delete;
+  TLSSession &operator=(TLSSession const &) = delete;
+
   ~TLSSession() override;
 
   /** @see Session::read */

--- a/local/src/client/verifier-client.cc
+++ b/local/src/client/verifier-client.cc
@@ -11,6 +11,7 @@
 #include "core/http3.h"
 #include "core/https.h"
 #include "core/ProxyVerifier.h"
+#include "core/SocketPoller.h"
 #include "core/YamlParser.h"
 
 #include <assert.h>
@@ -675,7 +676,7 @@ int Engine::process_exit_code = 0;
 void
 Run_Session(Ssn const &ssn, TargetSelector &target_selector)
 {
-  std::unique_ptr<Session> session;
+  std::shared_ptr<Session> session;
   swoc::IPEndpoint const *real_target = nullptr;
   Errata errata;
   errata.note(
@@ -692,7 +693,7 @@ Run_Session(Ssn const &ssn, TargetSelector &target_selector)
           S_ERROR,
           "Could not replay an HTTP/3 session because no HTTP/3 ports are provided.");
     } else {
-      session = std::make_unique<H3Session>(ssn._client_sni, ssn._client_verify_mode);
+      session = Session::create_h3_session(ssn._client_sni, ssn._client_verify_mode);
       errata.note(S_DIAG, "Connecting via HTTP/3 over QUIC.");
     }
   } else if (ssn.is_h2) {
@@ -702,10 +703,8 @@ Run_Session(Ssn const &ssn, TargetSelector &target_selector)
           S_ERROR,
           "Could not replay an HTTP/2 session because no HTTPS ports are provided.");
     } else {
-      session = std::make_unique<H2Session>(
-          ssn._client_sni,
-          ssn._client_verify_mode,
-          ssn.close_on_goaway);
+      session =
+          Session::create_h2_session(ssn._client_sni, ssn._client_verify_mode, ssn.close_on_goaway);
       errata.note(S_DIAG, "Connecting via HTTP/2 over TLS.");
     }
   } else if (ssn.is_tls) {
@@ -715,7 +714,7 @@ Run_Session(Ssn const &ssn, TargetSelector &target_selector)
           S_ERROR,
           "Could not replay an HTTPS session because no HTTPS ports are provided.");
     } else {
-      session = std::make_unique<TLSSession>(ssn._client_sni, ssn._client_verify_mode);
+      session = Session::create_tls_session(ssn._client_sni, ssn._client_verify_mode);
       errata.note(S_DIAG, "Connecting via TLS.");
     }
   } else {
@@ -723,7 +722,7 @@ Run_Session(Ssn const &ssn, TargetSelector &target_selector)
     if (real_target == nullptr) {
       errata.note(S_ERROR, "Could not replay an HTTP session because no HTTP ports are provided.");
     } else {
-      session = std::make_unique<Session>();
+      session = Session::create_tcp_session();
       errata.note(S_DIAG, "Connecting via HTTP.");
     }
   }
@@ -1090,6 +1089,9 @@ Engine::replay_traffic()
     repeat_count = 1;
   }
 
+  // Parsing is done. Start the various client threads.
+  SocketPoller::start_polling_thread();
+
   auto replay_start_time = ClockType::now();
   unsigned n_ssn = 0;
   unsigned n_txn = 0;
@@ -1129,6 +1131,7 @@ Engine::replay_traffic()
   // Wait until all threads are done
   Shutdown_Flag = true;
   Client_Thread_Pool.join_threads();
+  SocketPoller::stop_polling_thread();
 
   auto replay_duration = duration_cast<milliseconds>(ClockType::now() - replay_start_time);
   errata.note(

--- a/local/src/core/SessionFactory.cc
+++ b/local/src/core/SessionFactory.cc
@@ -1,0 +1,56 @@
+/** @file
+ * Implement a factory to create Session objects.
+ *
+ * Copyright 2024, Verizon Media
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <core/http.h>
+#include <core/http2.h>
+#include <core/https.h>
+#include <core/http3.h>
+
+#include <memory>
+
+std::shared_ptr<Session>
+Session::create_session(SessionType type)
+{
+  switch (type) {
+  case SessionType::TCP:
+    return std::make_shared<Session>(PrivateKey{});
+  case SessionType::TLS:
+    return std::static_pointer_cast<Session>(std::make_shared<TLSSession>(PrivateKey{}));
+  case SessionType::HTTP2:
+    return std::static_pointer_cast<Session>(std::make_shared<H2Session>(PrivateKey{}));
+  case SessionType::QUIC:
+    return std::static_pointer_cast<Session>(std::make_shared<H3Session>(PrivateKey{}));
+  }
+  return nullptr; // Not reached.
+}
+
+std::shared_ptr<Session>
+Session::create_tcp_session()
+{
+  return std::make_shared<Session>(PrivateKey{});
+}
+
+std::shared_ptr<Session>
+Session::create_tls_session(std::string_view client_sni, int verify_mode)
+{
+  return std::static_pointer_cast<Session>(
+      std::make_shared<TLSSession>(PrivateKey{}, client_sni, verify_mode));
+}
+
+std::shared_ptr<Session>
+Session::create_h2_session(std::string_view client_sni, int verify_mode, bool close_on_goaway)
+{
+  return std::static_pointer_cast<Session>(
+      std::make_shared<H2Session>(PrivateKey{}, client_sni, verify_mode, close_on_goaway));
+}
+
+std::shared_ptr<Session>
+Session::create_h3_session(std::string_view client_sni, int verify_mode)
+{
+  return std::static_pointer_cast<Session>(
+      std::make_shared<H3Session>(PrivateKey{}, client_sni, verify_mode));
+}

--- a/local/src/core/SocketNotifier.cc
+++ b/local/src/core/SocketNotifier.cc
@@ -1,0 +1,82 @@
+/** @file
+ * Common implementation for Proxy Verifier
+ *
+ * Copyright 2024, Verizon Media
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "core/SocketNotifier.h"
+#include "core/http.h"
+
+#include <mutex>
+#include <thread>
+
+// Static instantiations.
+SocketNotifier SocketNotifier::_socket_notifier; // Our singleton.
+std::thread SocketNotifier::_notifier_thread;
+bool SocketNotifier::_stop_notifier_flag = false;
+
+NotificationInfo::NotificationInfo(std::weak_ptr<Session> session, int revent)
+  : session(session)
+  , revents(revent)
+{
+}
+
+void
+SocketNotifier::notify_sessions(std::vector<NotificationInfo> const &notification_infos)
+{
+  {
+    std::lock_guard<std::mutex> lock(_socket_notifier._notification_infos_mutex);
+    for (auto const &notification_info : notification_infos) {
+      if (auto session = notification_info.session.lock(); session) {
+        _socket_notifier._notification_infos.emplace(session->get_fd(), notification_info);
+      }
+    }
+  }
+  _socket_notifier._notification_infos_cv.notify_one();
+}
+
+void
+SocketNotifier::drop_session_notification(int fd)
+{
+  std::lock_guard<std::mutex> lock(_socket_notifier._notification_infos_mutex);
+  _socket_notifier._notification_infos.erase(fd);
+}
+
+void
+SocketNotifier::start_notifier_thread()
+{
+  _stop_notifier_flag = false;
+  _notifier_thread = std::thread([]() { SocketNotifier::_socket_notifier._start_notifying(); });
+}
+
+void
+SocketNotifier::stop_notifier_thread()
+{
+  _stop_notifier_flag = true;
+  _socket_notifier._notification_infos_cv.notify_one();
+  _notifier_thread.join();
+}
+
+void
+SocketNotifier::_start_notifying()
+{
+  while (!SocketNotifier::_stop_notifier_flag) {
+    std::unique_lock<std::mutex> lock(_notification_infos_mutex);
+    _notification_infos_cv.wait(lock, [this]() {
+      return !_notification_infos.empty() || SocketNotifier::_stop_notifier_flag;
+    });
+
+    if (SocketNotifier::_stop_notifier_flag) {
+      break;
+    }
+
+    for (auto &[fd, notification_info] : _notification_infos) {
+      auto &[weak_session, revents] = notification_info;
+      if (auto session = weak_session.lock(); session) {
+        session->handle_poll_return(revents);
+      }
+    }
+    _notification_infos.clear();
+  }
+}

--- a/local/src/core/SocketPoller.cc
+++ b/local/src/core/SocketPoller.cc
@@ -1,0 +1,153 @@
+/** @file
+ * Common implementation for Proxy Verifier
+ *
+ * Copyright 2024, Verizon Media
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "core/SocketPoller.h"
+#include "core/http.h"
+#include "core/ProxyVerifier.h"
+#include "core/SocketNotifier.h"
+
+#include "swoc/bwf_ex.h"
+#include "swoc/bwf_ip.h"
+#include "swoc/bwf_std.h"
+#include "swoc/Errata.h"
+
+#include <chrono>
+#include <mutex>
+#include <thread>
+
+using swoc::Errata;
+
+// Static instantiations.
+SocketPoller SocketPoller::_socket_poller; // Our singleton.
+std::thread SocketPoller::_poller_thread;
+bool SocketPoller::_stop_polling_flag = false;
+
+SocketPoller::PollInfo::PollInfo(std::weak_ptr<Session> session, short events)
+  : session(session)
+  , events(events)
+{
+}
+
+void
+SocketPoller::request_poll(std::weak_ptr<Session> session, short events)
+{
+  {
+    std::lock_guard<std::mutex> lock(_socket_poller._polling_requests_mutex);
+    if (auto locked_session = session.lock(); locked_session) {
+      _socket_poller._polling_requests.emplace(locked_session->get_fd(), PollInfo{session, events});
+    }
+  }
+  _socket_poller._polling_requests_cv.notify_one();
+}
+
+void
+SocketPoller::remove_poll_request(int fd)
+{
+  {
+    std::lock_guard<std::mutex> lock(_socket_poller._polling_requests_mutex);
+    _socket_poller._polling_requests.erase(fd);
+  } // Unlock the _polling_requests_mutex.
+  SocketNotifier::drop_session_notification(fd);
+}
+
+void
+SocketPoller::remove_poll_requests(std::vector<int> const &fds)
+{
+  std::lock_guard<std::mutex> lock(_socket_poller._polling_requests_mutex);
+  for (auto const &fd : fds) {
+    _socket_poller._polling_requests.erase(fd);
+  }
+}
+
+void
+SocketPoller::start_polling_thread()
+{
+  SocketPoller::_stop_polling_flag = false;
+  SocketNotifier::start_notifier_thread();
+  _poller_thread = std::thread([]() { SocketPoller::_socket_poller._start_polling(); });
+}
+
+void
+SocketPoller::stop_polling_thread()
+{
+  SocketNotifier::stop_notifier_thread();
+  SocketPoller::_stop_polling_flag = true;
+  _socket_poller._polling_requests_cv.notify_one();
+  SocketPoller::_poller_thread.join();
+}
+
+void
+SocketPoller::_start_polling()
+{
+  Errata errata;
+  while (!SocketPoller::_stop_polling_flag) {
+    // Populate the array of pollfd objects as input to ::poll.
+    std::vector<struct pollfd> poll_fds;
+    {
+      // Wait for the request_poll producer to add sessions to poll upon.
+      std::unique_lock<std::mutex> lock(_polling_requests_mutex);
+      _polling_requests_cv.wait(lock, [this]() {
+        return !_polling_requests.empty() || SocketPoller::_stop_polling_flag;
+      });
+
+      // Either we (1) received poll requests, or (2) we have been asked to stop
+      // polling. Handle both cases.
+      if (SocketPoller::_stop_polling_flag) {
+        break;
+      }
+
+      // We have poll requests to process.
+
+      poll_fds.reserve(_polling_requests.size());
+      for (auto const &[fd, polling_info] : _polling_requests) {
+        poll_fds.push_back({fd, polling_info.events, 0});
+      }
+    } // Unlock the _polling_requests_mutex.
+
+    auto const poll_result =
+        ::poll(poll_fds.data(), poll_fds.size(), SocketPoller::_poll_timeout.count());
+    if (poll_result == 0) {
+      // Timeout. Simply loop backaround and poll again. Maybe other fd's have
+      // been registered.
+      continue;
+    } else if (poll_result < 0) {
+      // Error condition.
+      if (errno == EINTR) {
+        continue;
+      }
+      errata.note(S_ERROR, "poll failed: {}", swoc::bwf::Errno{});
+      return;
+    }
+
+    // Poll succeeded. There are events to process.
+
+    // Call back each session that requested a poll.
+    std::vector<NotificationInfo> notification_infos;
+    std::vector<int> fds_to_deregister;
+    {
+      std::lock_guard<std::mutex> lock(_polling_requests_mutex);
+      for (auto const &poll_fd : poll_fds) {
+        if (poll_fd.revents == 0) {
+          // This fd did not have an event. Move on.
+          continue;
+        }
+        auto sock_fd = poll_fd.fd;
+        // Make sure that, in the meantime, the session didn't time out and
+        // move on and deregister itself.
+        auto spot = _polling_requests.find(sock_fd);
+        if (spot == _polling_requests.end()) {
+          continue;
+        }
+        auto session = spot->second.session;
+        notification_infos.emplace_back(session, poll_fd.revents);
+        fds_to_deregister.push_back(sock_fd);
+      }
+    } // Unlock the _polling_requests_mutex.
+    SocketPoller::remove_poll_requests(fds_to_deregister);
+    SocketNotifier::notify_sessions(notification_infos);
+  }
+}

--- a/local/src/core/core.part
+++ b/local/src/core/core.part
@@ -35,14 +35,17 @@ def build(env):
     env.SdkLib(
         env.StaticLibrary("verifier-core", [
             "ArgParser.cc",
+            "Localizer.cc",
+            "ProxyVerifier.cc",
+            "SessionFactory.cc",
+            "SocketNotifier.cc",
+            "SocketPoller.cc",
+            "YamlParser.cc",
             "http.cc",
             "http2.cc",
             "http3.cc",
             "https.cc",
-            "Localizer.cc",
-            "ProxyVerifier.cc",
-            "verification.cc",
-            "YamlParser.cc",
             "proxy_protocol_util.cc",
+            "verification.cc",
         ])
     )


### PR DESCRIPTION
Rather than have each of the thousands of session polling threads calling their own invocations of poll(2), this consolidates it to a single poll(2) system call for each of the file descriptors. Maybe this will make things more efficient.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
