### PR TITLE
Better memory management in _start_polling.

### DIFF
--- a/local/src/core/SocketPoller.cc
+++ b/local/src/core/SocketPoller.cc
@@ -18,6 +18,7 @@
 #include <chrono>
 #include <mutex>
 #include <thread>
+#include <unordered_set>
 
 using swoc::Errata;
 
@@ -80,13 +81,98 @@ SocketPoller::stop_polling_thread()
   SocketPoller::_poller_thread.join();
 }
 
+/** Help maintain the memory of the "struct pollfd" array for ::poll. */
+class PollFdManager
+{
+public:
+  /** Reserve space in our containers in the constructor. */
+  PollFdManager()
+  {
+    // default_max_threads is a reasonable approximation since we don't have
+    // access to the ThreadPool instance to call get_max_threads. If the user
+    // configured more, future emplace_backs will expand the size for us as
+    // needed.
+    _poll_fds.reserve(ThreadPool::default_max_threads);
+    _contained_fds.reserve(ThreadPool::default_max_threads);
+  }
+
+  /** Add fd to our set, if it isn't in there already.
+   * @param[in] fd The file descriptor to add.
+   * @param[in] events The events to poll for on the file descriptor.
+   */
+  void
+  add_fd(int fd, short events)
+  {
+    auto spot = _contained_fds.find(fd);
+    if (spot != _contained_fds.end() && spot->second == events) {
+      return;
+    }
+    _contained_fds.emplace(fd, events);
+    _poll_fds.push_back(pollfd{fd, events, 0});
+  }
+
+  /** Remove the set of file descriptors from the polling set.
+   *@param[in] fds_to_erase The file descriptors to remove.
+   */
+  void
+  remove_fds(std::vector<int> const &fds_to_erase)
+  {
+    for (auto const &fd_to_erase : fds_to_erase) {
+      _contained_fds.erase(fd_to_erase);
+    }
+    _poll_fds.erase(
+        std::remove_if(
+            _poll_fds.begin(),
+            _poll_fds.end(),
+            [this](struct pollfd const &poll_fd) {
+              return _contained_fds.find(poll_fd.fd) == _contained_fds.end();
+            }),
+        _poll_fds.end());
+  }
+
+  /** Used as a parameter to ::poll. */
+  struct pollfd *
+  data()
+  {
+    return _poll_fds.data();
+  }
+
+  /** Used as a parameter to ::poll. */
+  size_t
+  size() const
+  {
+    return _poll_fds.size();
+  }
+
+  std::vector<struct pollfd> const &
+  get_poll_fds() const
+  {
+    return _poll_fds;
+  }
+
+private:
+  /// Manage the memory to use for ::poll.
+  std::vector<struct pollfd> _poll_fds;
+
+  /// fd -> poll events value.
+  std::unordered_map<int, short> _contained_fds;
+};
+
 void
 SocketPoller::_start_polling()
 {
   Errata errata;
+
+  // Declare these out here so there memory isn't reallocated on each iteration.
+  PollFdManager poll_fd_manager;
+  std::vector<NotificationInfo> notification_infos;
+  std::vector<int> fds_to_deregister;
+  // default_max_threads is a reasonable approximation. If the user configured
+  // more, future emplace_backs will expand the size for us as needed.
   while (!SocketPoller::_stop_polling_flag) {
-    // Populate the array of pollfd objects as input to ::poll.
-    std::vector<struct pollfd> poll_fds;
+    // Clear maintains capacity.
+    notification_infos.clear();
+    fds_to_deregister.clear();
     {
       // Wait for the request_poll producer to add sessions to poll upon.
       std::unique_lock<std::mutex> lock(_polling_requests_mutex);
@@ -100,16 +186,15 @@ SocketPoller::_start_polling()
         break;
       }
 
-      // We have poll requests to process.
-
-      poll_fds.reserve(_polling_requests.size());
+      // We have poll requests to process. Now populate the array of pollfd
+      // objects as input to ::poll.
       for (auto const &[fd, polling_info] : _polling_requests) {
-        poll_fds.push_back({fd, polling_info.events, 0});
+        poll_fd_manager.add_fd(fd, polling_info.events);
       }
     } // Unlock the _polling_requests_mutex.
 
     auto const poll_result =
-        ::poll(poll_fds.data(), poll_fds.size(), SocketPoller::_poll_timeout.count());
+        ::poll(poll_fd_manager.data(), poll_fd_manager.size(), SocketPoller::_poll_timeout.count());
     if (poll_result == 0) {
       // Timeout. Simply loop backaround and poll again. Maybe other fd's have
       // been registered.
@@ -126,11 +211,9 @@ SocketPoller::_start_polling()
     // Poll succeeded. There are events to process.
 
     // Call back each session that requested a poll.
-    std::vector<NotificationInfo> notification_infos;
-    std::vector<int> fds_to_deregister;
     {
       std::lock_guard<std::mutex> lock(_polling_requests_mutex);
-      for (auto const &poll_fd : poll_fds) {
+      for (auto const &poll_fd : poll_fd_manager.get_poll_fds()) {
         if (poll_fd.revents == 0) {
           // This fd did not have an event. Move on.
           continue;
@@ -148,6 +231,7 @@ SocketPoller::_start_polling()
       }
     } // Unlock the _polling_requests_mutex.
     SocketPoller::remove_poll_requests(fds_to_deregister);
+    poll_fd_manager.remove_fds(fds_to_deregister);
     SocketNotifier::notify_sessions(notification_infos);
   }
 }


### PR DESCRIPTION
perf mem highlighted _stop_polling as being a hot spot of memory allocations and frees. This should alleviate that.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
