### PR TITLE
Address STATUS_NO_CONTENT overrun

### DIFF
--- a/local/include/core/http.h
+++ b/local/include/core/http.h
@@ -409,6 +409,12 @@ public:
    */
   std::string get_key() const;
 
+  /** Indicate whether the current status represents a no content response.
+   *
+   * @return Whether the status represents a no content response.
+   */
+  bool status_is_no_content() const;
+
   /** Verify that the (header) fields in 'this' correspond to the provided rules.
    *
    * @param key The key for this transaction.


### PR DESCRIPTION
Ensure that indexing into STATUS_NO_CONTENT does not overrun the buffer.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
