### PR TITLE
Fix ATS regressions for v3.1.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ cmake_minimum_required(VERSION 4.2.3)
 
 project(
   ProxyVerifier
-  VERSION 3.1.1
+  VERSION 3.1.2
   LANGUAGES C CXX)
 
 include(CTest)

--- a/src/core/ProxyVerifier.h
+++ b/src/core/ProxyVerifier.h
@@ -49,17 +49,31 @@ swoc::Rv<int> block_sigpipe();
  * This is useful for keeping large temporary buffers off pthread stacks on
  * platforms such as musl, while also avoiding per-call heap allocation.
  *
+ * Each unique combination of @a N and @a Tag produces an independent
+ * thread-local buffer. Use distinct tag types when two callers on the same
+ * thread must not alias each other's storage (e.g. reading request headers
+ * vs. serializing an outgoing response).
+ *
  * @tparam N The size of the backing buffer.
+ * @tparam Tag Disambiguation tag so that callers needing independent buffers
+ *   of the same size can each get their own thread-local storage.
  *
  * @return A writer bound to thread-local storage for the current thread.
  */
-template <size_t N>
+template <size_t N, typename Tag = void>
 swoc::FixedBufferWriter
 make_thread_local_buffer_writer()
 {
   thread_local std::array<char, N> storage;
   return swoc::FixedBufferWriter{storage.data(), storage.size()};
 }
+
+/// Tag for the thread-local buffer used by Session::write() to serialize
+/// outgoing headers, kept separate from the read-side buffer so that
+/// writing a response does not clobber in-flight request header views.
+struct WriteBufferTag
+{
+};
 
 /** Configure logging.
  *

--- a/src/core/http.cc
+++ b/src/core/http.cc
@@ -1347,11 +1347,7 @@ Session::send_proxy_msg(ProxyProtocolMsg const &pp_msg)
 swoc::Rv<ssize_t>
 Session::write(HttpHeader const &hdr)
 {
-  // 1. header.serialize, write it out
-  // 2. transmit the body
-  // Keep the large header buffer off the worker-thread stack without
-  // allocating on every call.
-  auto w = make_thread_local_buffer_writer<MAX_HDR_SIZE>();
+  auto w = make_thread_local_buffer_writer<MAX_HDR_SIZE, WriteBufferTag>();
   swoc::Rv<ssize_t> zret{-1};
 
   zret.errata() = hdr.serialize(w);
@@ -2031,6 +2027,7 @@ Session::set_fd(int fd)
 {
   Errata errata;
   _fd = fd;
+  m_close_reason = CloseReason::UNSPECIFIED;
   return errata;
 }
 
@@ -2231,9 +2228,19 @@ void
 Session::close()
 {
   if (!this->is_closed()) {
+    if (m_close_reason == CloseReason::UNSPECIFIED) {
+      m_close_reason = CloseReason::LOCAL;
+    }
     ::close(_fd);
     _fd = -1;
   }
+}
+
+void
+Session::close_with_reason(CloseReason reason)
+{
+  m_close_reason = reason;
+  close();
 }
 
 Errata

--- a/src/core/http.h
+++ b/src/core/http.h
@@ -1025,8 +1025,34 @@ public:
    */
   virtual swoc::Rv<ssize_t> write_body(HttpHeader const &hdr);
 
+  /** The reason the connection was last closed. */
+  enum class CloseReason {
+    UNSPECIFIED, ///< No close reason has been recorded.
+    LOCAL,       ///< Proxy Verifier closed the connection itself.
+    PEER_CLOSE,  ///< The peer cleanly closed the connection.
+    PEER_ERROR   ///< The connection became unusable because of a peer-side error.
+  };
+
   /** Whether the connection is currently closed. */
   bool is_closed() const;
+
+  /** Close the connection and record why it closed.
+   *
+   * @param[in] reason The reason to retain for later inspection.
+   */
+  void close_with_reason(CloseReason reason);
+
+  /** Retrieve the last recorded reason for closing the connection.
+   *
+   * @return The last recorded close reason.
+   */
+  CloseReason get_close_reason() const;
+
+  /** Whether the peer cleanly closed the connection.
+   *
+   * @return True if the peer cleanly closed the connection, false otherwise.
+   */
+  bool is_closed_cleanly_by_peer() const;
 
   /** Close the connection. */
   virtual void close();
@@ -1079,6 +1105,7 @@ private:
 private:
   int _fd = -1; ///< Socket.
   ssize_t _body_offset = 0;
+  CloseReason m_close_reason = CloseReason::UNSPECIFIED;
 };
 
 inline int
@@ -1091,6 +1118,18 @@ inline bool
 Session::is_closed() const
 {
   return _fd < 0;
+}
+
+inline Session::CloseReason
+Session::get_close_reason() const
+{
+  return m_close_reason;
+}
+
+inline bool
+Session::is_closed_cleanly_by_peer() const
+{
+  return m_close_reason == CloseReason::PEER_CLOSE;
 }
 
 inline void

--- a/src/core/http2.cc
+++ b/src/core/http2.cc
@@ -556,7 +556,10 @@ H2Session::run_transactions(
           drain_h2_receive_window(*this, Poll_Timeout, "dependency wait");
       txn_errata.note(std::move(progress_errata));
       if (!txn_errata.is_ok()) {
-        // There was a problem reading bytes on the socket.
+        if (this->is_closed_cleanly_by_peer()) {
+          txn_errata.sink();
+          break;
+        }
         txn_errata.note(
             S_ERROR,
             "An unexpected error was received reading bytes on a socket while delaying a "
@@ -569,6 +572,11 @@ H2Session::run_transactions(
     if (!txn_errata.is_ok()) {
       errata.note(std::move(txn_errata));
       log_h2_replay_metrics(0ms);
+      break;
+    }
+    if (this->is_closed_cleanly_by_peer()) {
+      errata.note(S_DIAG, "HTTP/2 session closed by peer during dependency wait.");
+      errata.sink();
       break;
     }
     if (rate_multiplier != 0 || txn._user_specified_delay_duration > 0us) {
@@ -590,12 +598,16 @@ H2Session::run_transactions(
       }
       txn_errata.sink();
       while (delay_time > 0ms) {
-        // Make use of our delay time to read any incoming responses.
         auto &&[progress, progress_errata] =
             drain_h2_receive_window(*this, duration_cast<milliseconds>(delay_time), "delay window");
         txn_errata.note(std::move(progress_errata));
         if (!txn_errata.is_ok()) {
-          // There was a problem reading bytes on the socket.
+          if (this->is_closed_cleanly_by_peer()) {
+            // The peer closed the connection during the delay window (e.g.
+            // server inactivity timeout). This is not a client-side error.
+            txn_errata.sink();
+            break;
+          }
           txn_errata.note(
               S_ERROR,
               "An unexpected error was received reading bytes on a socket while delaying a "
@@ -607,6 +619,11 @@ H2Session::run_transactions(
         current_time = ClockType::now();
         delay_time = next_time - current_time;
       }
+    }
+    if (this->is_closed_cleanly_by_peer()) {
+      errata.note(S_DIAG, "HTTP/2 session closed by peer during delay window.");
+      errata.sink();
+      break;
     }
     if (this->close_on_goaway && this->received_goaway_frame) {
       errata.note(S_DIAG, "Closing HTTP/2 session due to receiving a GOAWAY frame.");
@@ -941,10 +958,11 @@ receive_nghttp2_data(
   if (n <= 0) {
     auto const ssl_error = SSL_get_error(session_data->get_ssl(), n);
     if (ssl_error == SSL_ERROR_WANT_READ || ssl_error == SSL_ERROR_WANT_WRITE) {
-      // SSL just wants more data. Not a problem.
       return 0;
     } else {
-      // Assume there was an issue.
+      if (ssl_error == SSL_ERROR_ZERO_RETURN || ssl_error == SSL_ERROR_SYSCALL) {
+        session_data->close_with_reason(TLSSession::classify_ssl_close_reason(ssl_error));
+      }
       errata.note(
           S_ERROR,
           "SSL_read error in receive_nghttp2_data: {}",

--- a/src/core/https.cc
+++ b/src/core/https.cc
@@ -8,6 +8,7 @@
 #include "core/https.h"
 #include "core/ProxyVerifier.h"
 
+#include <cerrno>
 #include <cstring>
 #include <fcntl.h>
 #include <netdb.h>
@@ -27,6 +28,22 @@ using namespace std::literals;
 
 namespace chrono = std::chrono;
 using chrono::milliseconds;
+
+Session::CloseReason
+TLSSession::classify_ssl_close_reason(int ssl_error)
+{
+  if (ssl_error == SSL_ERROR_ZERO_RETURN) {
+    return Session::CloseReason::PEER_CLOSE;
+  }
+  if (ssl_error == SSL_ERROR_SYSCALL) {
+    // OpenSSL reports a peer EOF as SSL_ERROR_SYSCALL with no queued TLS
+    // error and errno cleared.
+    if (ERR_peek_last_error() == 0 && errno == 0) {
+      return Session::CloseReason::PEER_CLOSE;
+    }
+  }
+  return Session::CloseReason::PEER_ERROR;
+}
 
 std::unordered_map<std::string, TLSHandshakeBehavior> TLSSession::_handshake_behavior_per_sni;
 std::mutex TLSSession::_handshake_behavior_mutex;
@@ -316,10 +333,12 @@ TLSSession::poll_for_data_on_ssl_socket(chrono::milliseconds timeout, int ssl_er
   if (ssl_error == SSL_ERROR_ZERO_RETURN || ssl_error == SSL_ERROR_SYSCALL ||
       ssl_error == SSL_ERROR_SSL)
   {
-    // Either of these indicates that the peer has closed the connection for
-    // writing and no more data can be read.
-    zret.note(S_DIAG, "Poll called on a TLS session closed by the peer.");
-    this->close();
+    auto const close_reason = classify_ssl_close_reason(ssl_error);
+    zret.note(
+        S_DIAG,
+        "Poll called on a TLS session that can no longer be read: {}.",
+        swoc::bwf::SSLError{ssl_error});
+    this->close_with_reason(close_reason);
     return zret;
   }
 

--- a/src/core/https.h
+++ b/src/core/https.h
@@ -191,6 +191,13 @@ public:
       std::chrono::milliseconds timeout,
       int ssl_error);
 
+  /** Classify a terminal SSL read/write state into a session close reason.
+   *
+   * @param[in] ssl_error The value returned by SSL_get_error.
+   * @return The close reason implied by the SSL state.
+   */
+  static Session::CloseReason classify_ssl_close_reason(int ssl_error);
+
   /** @see Session::close */
   void close() override;
   /** @see Session::accept */

--- a/tests/unit_tests/test_https.cc
+++ b/tests/unit_tests/test_https.cc
@@ -1,12 +1,15 @@
 /** @file
  * Unit tests for HttpReplay.h.
  *
- * Copyright 2021, Verizon Media
+ * Copyright 2026, Verizon Media
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include "catch.hpp"
 #include "core/https.h"
+
+#include <cerrno>
+#include <unistd.h>
 
 TEST_CASE("ALPN string formatting", "[alpn]")
 {
@@ -26,5 +29,71 @@ TEST_CASE("ALPN string formatting", "[alpn]")
     CHECK(
         std::string("h2,http1.1") ==
         get_printable_alpn_string({(char *)two_protos, sizeof(two_protos)}));
+  }
+}
+
+TEST_CASE("TLS close reasons are tracked", "[tls]")
+{
+  SECTION("SSL zero return is treated as a clean peer close")
+  {
+    int fd_pair[2];
+    REQUIRE(::pipe(fd_pair) == 0);
+
+    TLSSession session;
+    REQUIRE(session.set_fd(fd_pair[0]).is_ok());
+    ::close(fd_pair[1]);
+
+    auto const poll_result =
+        session.poll_for_data_on_ssl_socket(std::chrono::milliseconds{1}, SSL_ERROR_ZERO_RETURN);
+
+    CHECK(poll_result.result() < 0);
+    CHECK(session.is_closed());
+    CHECK(session.is_closed_cleanly_by_peer());
+    CHECK(session.get_close_reason() == Session::CloseReason::PEER_CLOSE);
+
+    int reconnect_fd_pair[2];
+    REQUIRE(::pipe(reconnect_fd_pair) == 0);
+    REQUIRE(session.set_fd(reconnect_fd_pair[0]).is_ok());
+    ::close(reconnect_fd_pair[1]);
+
+    CHECK(session.get_close_reason() == Session::CloseReason::UNSPECIFIED);
+    session.close();
+  }
+
+  SECTION("SSL protocol errors stay fatal")
+  {
+    int fd_pair[2];
+    REQUIRE(::pipe(fd_pair) == 0);
+
+    TLSSession session;
+    REQUIRE(session.set_fd(fd_pair[0]).is_ok());
+    ::close(fd_pair[1]);
+
+    auto const poll_result =
+        session.poll_for_data_on_ssl_socket(std::chrono::milliseconds{1}, SSL_ERROR_SSL);
+
+    CHECK(poll_result.result() < 0);
+    CHECK(session.is_closed());
+    CHECK_FALSE(session.is_closed_cleanly_by_peer());
+    CHECK(session.get_close_reason() == Session::CloseReason::PEER_ERROR);
+  }
+
+  SECTION("EOF-style SSL_ERROR_SYSCALL is treated as a clean peer close")
+  {
+    ERR_clear_error();
+    errno = 0;
+    CHECK(
+        TLSSession::classify_ssl_close_reason(SSL_ERROR_SYSCALL) ==
+        Session::CloseReason::PEER_CLOSE);
+  }
+
+  SECTION("SSL_ERROR_SYSCALL with errno set is treated as an error")
+  {
+    ERR_clear_error();
+    errno = EIO;
+    CHECK(
+        TLSSession::classify_ssl_close_reason(SSL_ERROR_SYSCALL) ==
+        Session::CloseReason::PEER_ERROR);
+    errno = 0;
   }
 }


### PR DESCRIPTION
The 3.1.1 replay changes introduced ATS regressions in HTTP/1
100 Continue handling and HTTP/2 delay-window shutdown handling.
These failures showed up in both Proxy Verifier coverage and ATS
integration tests.

Split the thread-local header buffers by use site, record why TLS
sessions close so HTTP/2 only suppresses clean peer shutdowns, and
bump the project version to 3.1.2 for the bugfix release.