### PR TITLE
server: set SO_REUSEPORT on the listen socket to avoid spurious EADDRINUSE on rapid restart

### DIFF
--- a/src/server/verifier-server.cc
+++ b/src/server/verifier-server.cc
@@ -893,6 +893,19 @@ do_listen(swoc::IPEndpoint &server_addr, bool do_https, bool do_http3)
           R"(Could not set reuseaddr on socket {}: {}.)",
           socket_fd,
           swoc::bwf::Errno{});
+    } else if (setsockopt(socket_fd, SOL_SOCKET, SO_REUSEPORT, &ONE, sizeof(int)) < 0) {
+      // SO_REUSEADDR alone permits binding a port left in TIME_WAIT, but not one
+      // still actively bound by a live listening socket. When the server is run
+      // back-to-back on the same port (e.g. an autest harness recycling ports
+      // across tests, where a prior server instance has not fully exited), the
+      // bind() below can fail with EADDRINUSE and the server exits without ever
+      // listening. SO_REUSEPORT lets the new listener bind alongside the
+      // departing one, eliminating that spurious startup failure.
+      errata.note(
+          S_ERROR,
+          R"(Could not set reuseport on socket {}: {}.)",
+          socket_fd,
+          swoc::bwf::Errno{});
     } else if (
         Send_Buffer_size > 0 &&
         setsockopt(socket_fd, SOL_SOCKET, SO_SNDBUF, &Send_Buffer_size, sizeof(Send_Buffer_size)) <


### PR DESCRIPTION
## Problem

When the server is started on a port that a **previous server instance has not fully released**, `bind()` fails with `EADDRINUSE` and the process exits (`process_exit_code = 1`) **without ever calling `listen()`** — there is no bind retry.

`SO_REUSEADDR` is already set, but it only permits rebinding a port in `TIME_WAIT`; it does **not** allow binding a port still held by a live listening socket. So a rapidly-restarted server (or two server instances briefly overlapping during teardown/startup) races on the port and the new one dies on startup.

This shows up in test harnesses that recycle a pool of ports across many back-to-back tests (e.g. ATS autest under `--network=host`): intermittently a verifier server is handed a port whose prior owner is still finishing its exit, `bind()` returns `EADDRINUSE`, and the server exits before listening. The harness, which only polls "is the port open?", reports a generic *"process failed to become ready in time"* — masking the real cause.

## Fix

Set `SO_REUSEPORT` alongside the existing `SO_REUSEADDR` on the server listen socket. This lets the new listener bind even while the departing instance still holds the port, eliminating the spurious startup failure. The kernel routes new connections to the live listener once the old one closes.

One line (plus a comment) in `do_listen()`. Scoped to the **server TCP listen** socket only — the client `do_connect()` path and the QUIC UDP socket are intentionally left unchanged.

## Verification

- `SO_REUSEPORT` compiles on Linux/Fedora and macOS (the supported build platforms); `verifier-server.cc` already includes `<sys/socket.h>`.
- Full build + test will run in this PR's CI.
