### PR TITLE
Use OpenSSL 3.5 for HTTP/3 QUIC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,17 +75,17 @@ set(PV_DEPS_ROOT
     ""
     CACHE
       PATH
-      "Common dependency root containing openssl/nghttp2/ngtcp2/nghttp3 subdirectories."
+      "Optional dependency root containing openssl/nghttp2/nghttp3 subdirectories."
 )
 set(PV_OPENSSL_ROOT
     ""
-    CACHE PATH "Explicit OpenSSL root.")
+    CACHE PATH "Explicit OpenSSL 3.5 or newer root.")
 set(PV_NGHTTP2_ROOT
     ""
     CACHE PATH "Explicit nghttp2 root.")
 set(PV_NGTCP2_ROOT
     ""
-    CACHE PATH "Explicit ngtcp2 root.")
+    CACHE PATH "Deprecated compatibility variable; ngtcp2 is no longer used.")
 set(PV_NGHTTP3_ROOT
     ""
     CACHE PATH "Explicit nghttp3 root.")

--- a/README.md
+++ b/README.md
@@ -1836,12 +1836,16 @@ presets. The build requires:
 * autoconf
 * automake
 * libtool
+* Perl with the `Time::Piece` module
 * pkg-config
 
-CMake fetches pinned `libswoc` and `yaml-cpp` sources during configure. The
-remaining QUIC and TLS dependencies can either be bootstrapped as part of the
-CMake build or provided from an existing install tree such as `/opt/pv_libs`
-(see [Using Prebuilt Libraries](#using-prebuilt-libraries) below).
+CMake fetches pinned `libswoc` and `yaml-cpp` sources during configure. HTTP/3
+uses OpenSSL 3.5 or newer for the native QUIC transport and nghttp3 for HTTP/3
+framing and QPACK. HTTP/2 uses nghttp2. These dependencies can be bootstrapped
+as part of the CMake build, discovered through the system package manager, or
+provided from an install tree such as `/opt/pv_libs` (see
+[Using Prebuilt Libraries](#using-prebuilt-libraries) below).
+ngtcp2 is not required because OpenSSL provides the QUIC transport.
 
 For Mac builds, the following brew command can be helpful:
 
@@ -1850,9 +1854,11 @@ brew install \
   git \
   cmake \
   ninja \
-  libtool \
   automake \
   libtool \
+  nghttp2 \
+  nghttp3 \
+  openssl@3 \
   pkg-config \
   python@3.14
 ```
@@ -1872,8 +1878,8 @@ This places the build-tree binaries under `build/dev-external/bin`.
 
 #### Bootstrapping Dependencies Under CMake
 
-If you want CMake to fetch and build OpenSSL, nghttp3, ngtcp2, and nghttp2 as
-part of the build, use the `dev-bootstrap` preset:
+If you want CMake to fetch and build OpenSSL 3.5, nghttp3, and nghttp2 as part
+of the build, use the `dev-bootstrap` preset:
 
 ```
 cmake --preset dev-bootstrap
@@ -1884,18 +1890,23 @@ This populates the dependency prefix under `build/dev-bootstrap/pv-deps/`.
 
 #### Using Prebuilt Libraries
 
-If you prefer to manage the external QUIC/TLS libraries separately, use the
+If you prefer to manage the external HTTP and QUIC libraries separately, use the
 [build-library-dependencies.sh](https://github.com/yahoo/proxy-verifier/blob/master/tools/build-library-dependencies.sh)
 script:
 
 ```bash
 http3_libs_dir=${HOME}/src/http3_libs
 
-# The following takes a while as it builds openssl and various ng* libraries.
+# The following builds OpenSSL 3.5, nghttp2, and nghttp3.
 bash ./tools/build-library-dependencies.sh ${http3_libs_dir}
 cmake --preset dev-external -DPV_DEPS_ROOT=${http3_libs_dir}
 cmake --build --preset dev-external --parallel
 ```
+
+The external build uses the `openssl`, `nghttp2`, and `nghttp3` subdirectories
+under `PV_DEPS_ROOT` when present. A missing subdirectory is resolved from the
+system instead. The corresponding `PV_OPENSSL_ROOT`, `PV_NGHTTP2_ROOT`, and
+`PV_NGHTTP3_ROOT` variables can override individual dependencies.
 
 The checked-in `dev-external` preset assumes `/opt/pv_libs`, which matches the
 provided Dockerfiles under `docker/alpine_3.20`, `docker/rockylinux_8`,
@@ -1904,7 +1915,7 @@ provided Dockerfiles under `docker/alpine_3.20`, `docker/rockylinux_8`,
 ```bash
 http3_libs_dir=/opt/pv_libs
 
-# The following takes a while as it builds openssl and various ng* libraries.
+# The following builds OpenSSL 3.5, nghttp2, and nghttp3.
 bash ./tools/build-library-dependencies.sh ${http3_libs_dir}
 cmake --preset dev-external
 cmake --build --preset dev-external --parallel
@@ -1918,29 +1929,33 @@ for development workflows, not deployment images. For deployment, using the
 statically linked binaries associated with the GitHub releases is the easiest
 path for most people.
 
-Each image build has two stages:
+Each Dockerfile provides these targets:
 
-* `pv-libs-builder-base` installs the shared toolchain and creates the
-  `/opt/pv-venv` virtual environment with `cmake`, `ninja`, and `uv`.
-* `dev` compiles OpenSSL, nghttp3, ngtcp2, and nghttp2 into `/opt/pv_libs` and
-  is also the final development image.
+* `dev-base` installs the Proxy Verifier build and AuTest toolchain and creates
+  the `/opt/pv-venv` virtual environment with `cmake`, `ninja`, and `uv`.
+* `deps-builder` adds the Autotools and Perl tooling needed to compile OpenSSL
+  3.5, nghttp3, and nghttp2 into `/opt/pv_libs`.
+* `dev-external` copies `/opt/pv_libs` from `deps-builder` onto `dev-base`. This
+  smaller target supports the external-dependency presets without retaining
+  the dependency-build-only tooling.
+* `dev` extends `deps-builder` and is the default final image. It retains the
+  full toolchain for CMake bootstrap builds and the Alpine portable workflow.
 
 Tooling for the dev image lives in the `/opt/pv-venv` virtual environment and
 is added to the `PATH` by the Dockerfile `ENV` configuration.
 
-The Dockerfiles are self-contained, so you can build them from within each
-image directory. By default the builder stage clones
-`https://github.com/yahoo/proxy-verifier.git` at `master` to run
-`tools/build-library-dependencies.sh`; override that with `--build-arg
-PV_REPO_URL=... --build-arg PV_REPO_REF=...` if you need a different fork or
-branch.
+Build the images from the repository root. The dependency stage copies the
+checked-out `tools/build-library-dependencies.sh` into the image, so Docker
+invalidates the layer whenever its dependency pins or build logic change.
 
-Here's an example of building the rockylinux:9 based image:
+Here's an example of building the smaller rockylinux:9 external-dependency
+image:
 
 ```bash
-cd docker/rockylinux_9
-docker build -t pv-dev:rocky9 .
-docker run --rm -it -v "$(git rev-parse --show-toplevel)":/workspace pv-dev:rocky9
+docker build -f docker/rockylinux_9/Dockerfile --target dev-external \
+  -t pv-dev:rocky9-external .
+docker run --rm -it -v "$(git rev-parse --show-toplevel)":/workspace \
+  pv-dev:rocky9-external
 
 # Now, within the container.
 cd /workspace
@@ -1949,6 +1964,9 @@ cmake --build --preset dev-external --parallel
 ctest --preset dev-external
 ./build/dev-external/autest.sh --sandbox /tmp/pv-autest --clean=none
 ```
+
+Omit `--target dev-external` and use a `pv-dev:rocky9` tag to build the default
+full `dev` image instead.
 
 #### Install
 
@@ -2401,10 +2419,10 @@ to be replayed in serial.
 
 #### --qlog-dir \<directory\>
 
-Proxy Verifier supports logging of replayed QUIC traffic information conformant
-to the qlog format. If the `--qlog-dir` option is provided, then qlog files for all
-replayed QUIC traffic will be written into the specified directory.  qlog
-diagnostic logging is disabled by default.
+The `--qlog-dir` option remains accepted and Proxy Verifier creates the
+specified directory. OpenSSL's native QUIC API does not currently expose qlog
+events, however, so the OpenSSL 3.5 implementation reports a diagnostic and
+does not write qlog files. qlog diagnostic logging remains disabled by default.
 
 #### --tls-secrets-log-file \<secrets_log_file_name\>
 

--- a/cmake/HttpDependencies.cmake
+++ b/cmake/HttpDependencies.cmake
@@ -8,22 +8,23 @@ include_guard(GLOBAL)
 include(ExternalProject)
 include(ProcessorCount)
 
-set(PV_OPENSSL_TAG "openssl-3.5.5")
+set(PV_OPENSSL_TAG "openssl-3.5.7")
 set(PV_NGHTTP3_TAG "v1.15.0")
-set(PV_NGTCP2_TAG "v1.21.0")
 set(PV_NGHTTP2_TAG "v1.68.0")
 
 function(
-  _pv_resolve_dependency_root
+  _pv_resolve_dependency
   DEPENDENCY_NAME
   EXPLICIT_ROOT
   COMMON_ROOT
   BOOTSTRAP_ROOT
   OUT_ROOT
-  OUT_BOOTSTRAP)
+  OUT_BOOTSTRAP
+  OUT_SYSTEM)
   if(EXPLICIT_ROOT)
     set(_pv_root "${EXPLICIT_ROOT}")
     set(_pv_bootstrap FALSE)
+    set(_pv_system FALSE)
   elseif(PV_BOOTSTRAP_DEPS)
     if(COMMON_ROOT)
       set(_pv_root "${COMMON_ROOT}/${DEPENDENCY_NAME}")
@@ -31,14 +32,15 @@ function(
       set(_pv_root "${BOOTSTRAP_ROOT}")
     endif()
     set(_pv_bootstrap TRUE)
-  elseif(COMMON_ROOT)
+    set(_pv_system FALSE)
+  elseif(COMMON_ROOT AND IS_DIRECTORY "${COMMON_ROOT}/${DEPENDENCY_NAME}")
     set(_pv_root "${COMMON_ROOT}/${DEPENDENCY_NAME}")
     set(_pv_bootstrap FALSE)
+    set(_pv_system FALSE)
   else()
-    message(
-      FATAL_ERROR
-        "No root was provided for ${DEPENDENCY_NAME}. Set PV_DEPS_ROOT or the matching per-dependency root, "
-        "or enable PV_BOOTSTRAP_DEPS.")
+    set(_pv_root "")
+    set(_pv_bootstrap FALSE)
+    set(_pv_system TRUE)
   endif()
 
   set(${OUT_ROOT}
@@ -46,6 +48,9 @@ function(
       PARENT_SCOPE)
   set(${OUT_BOOTSTRAP}
       "${_pv_bootstrap}"
+      PARENT_SCOPE)
+  set(${OUT_SYSTEM}
+      "${_pv_system}"
       PARENT_SCOPE)
 endfunction()
 
@@ -59,17 +64,14 @@ function(_pv_define_imported_library TARGET_NAME LIBRARY_PATH INCLUDE_DIR)
   if(NOT TARGET "${TARGET_NAME}")
     add_library("${TARGET_NAME}" UNKNOWN IMPORTED GLOBAL)
   endif()
-
   set_target_properties(
     "${TARGET_NAME}" PROPERTIES IMPORTED_LOCATION "${LIBRARY_PATH}"
                                 INTERFACE_INCLUDE_DIRECTORIES "${INCLUDE_DIR}")
-
   if(PV_INTERFACE_LINK_LIBRARIES)
     set_property(
       TARGET "${TARGET_NAME}" PROPERTY INTERFACE_LINK_LIBRARIES
                                        "${PV_INTERFACE_LINK_LIBRARIES}")
   endif()
-
   if(PV_DEPENDS)
     add_dependencies("${TARGET_NAME}" ${PV_DEPENDS})
   endif()
@@ -95,23 +97,17 @@ function(_pv_get_library_path ROOT BASENAME OUT_VAR)
       endif()
     endif()
   endif()
-
   set(${OUT_VAR}
       "${_pv_library}"
       PARENT_SCOPE)
 endfunction()
 
 function(_pv_assert_external_layout DEPENDENCY_NAME ROOT)
-  if(NOT ROOT)
-    message(FATAL_ERROR "No root was resolved for ${DEPENDENCY_NAME}.")
-  endif()
-
   if(NOT IS_DIRECTORY "${ROOT}")
     message(
       FATAL_ERROR
         "Dependency root for ${DEPENDENCY_NAME} does not exist: ${ROOT}")
   endif()
-
   foreach(_pv_required_subdir include lib)
     if(NOT IS_DIRECTORY "${ROOT}/${_pv_required_subdir}")
       message(
@@ -129,9 +125,32 @@ function(_pv_assert_library_exists FRIENDLY_NAME LIBRARY_PATH)
   endif()
 endfunction()
 
+function(_pv_assert_openssl_35 ROOT)
+  set(_pv_version_header "${ROOT}/include/openssl/opensslv.h")
+  if(NOT EXISTS "${_pv_version_header}")
+    message(
+      FATAL_ERROR "OpenSSL version header was not found: ${_pv_version_header}")
+  endif()
+  file(READ "${_pv_version_header}" _pv_openssl_version_text)
+  string(REGEX MATCH "OPENSSL_VERSION_MAJOR[ \t]+([0-9]+)" _pv_major_match
+               "${_pv_openssl_version_text}")
+  set(_pv_major "${CMAKE_MATCH_1}")
+  string(REGEX MATCH "OPENSSL_VERSION_MINOR[ \t]+([0-9]+)" _pv_minor_match
+               "${_pv_openssl_version_text}")
+  set(_pv_minor "${CMAKE_MATCH_1}")
+  if(NOT _pv_major
+     OR _pv_major LESS 3
+     OR (_pv_major EQUAL 3 AND _pv_minor LESS 5))
+    message(
+      FATAL_ERROR
+        "Proxy Verifier HTTP/3 requires upstream OpenSSL 3.5 or newer; found ${_pv_major}.${_pv_minor} under ${ROOT}."
+    )
+  endif()
+endfunction()
+
 function(_pv_collect_bootstrap_environment_modifications OUT_VAR)
   set(options)
-  set(oneValueArgs PKG_CONFIG_PATH CFLAGS CXXFLAGS LDFLAGS)
+  set(oneValueArgs CFLAGS CXXFLAGS)
   set(multiValueArgs)
   cmake_parse_arguments(PV "${options}" "${oneValueArgs}" "${multiValueArgs}"
                         ${ARGN})
@@ -151,31 +170,21 @@ function(_pv_collect_bootstrap_environment_modifications OUT_VAR)
       AND CMAKE_OSX_SYSROOT)
       set(_pv_value "${CMAKE_OSX_SYSROOT}")
     endif()
-
     if(_pv_value)
       list(APPEND _pv_modifications "${_pv_name}=set:${_pv_value}")
     endif()
   endforeach()
 
-  if(PV_PKG_CONFIG_PATH)
-    list(APPEND _pv_modifications "PKG_CONFIG_PATH=set:${PV_PKG_CONFIG_PATH}")
-  endif()
-
-  foreach(_pv_flag_name CFLAGS CXXFLAGS LDFLAGS)
+  foreach(_pv_flag_name CFLAGS CXXFLAGS)
     set(_pv_flag_value "")
     if(DEFINED ENV{${_pv_flag_name}} AND NOT "$ENV{${_pv_flag_name}}" STREQUAL
                                          "")
       set(_pv_flag_value "$ENV{${_pv_flag_name}}")
     endif()
-
     if(PV_${_pv_flag_name})
-      if(_pv_flag_value)
-        string(APPEND _pv_flag_value " ${PV_${_pv_flag_name}}")
-      else()
-        set(_pv_flag_value "${PV_${_pv_flag_name}}")
-      endif()
+      string(APPEND _pv_flag_value " ${PV_${_pv_flag_name}}")
     endif()
-
+    string(STRIP "${_pv_flag_value}" _pv_flag_value)
     if(_pv_flag_value)
       string(REPLACE " " "\\ " _pv_flag_value_escaped "${_pv_flag_value}")
       list(APPEND _pv_modifications
@@ -194,13 +203,11 @@ function(_pv_append_bootstrap_install_byproducts OUT_VAR ROOT)
   set(multiValueArgs LIBRARIES)
   cmake_parse_arguments(PV "${options}" "${oneValueArgs}" "${multiValueArgs}"
                         ${ARGN})
-
   set(_pv_byproducts)
   foreach(_pv_library IN LISTS PV_LIBRARIES)
     _pv_get_library_path("${ROOT}" "${_pv_library}" _pv_library_path)
     list(APPEND _pv_byproducts "${_pv_library_path}")
   endforeach()
-
   set(${OUT_VAR}
       "${_pv_byproducts}"
       PARENT_SCOPE)
@@ -211,11 +218,9 @@ function(_pv_add_bootstrap_projects)
   set(oneValueArgs
       OPENSSL_ROOT
       NGHTTP3_ROOT
-      NGTCP2_ROOT
       NGHTTP2_ROOT
       BOOTSTRAP_OPENSSL
       BOOTSTRAP_NGHTTP3
-      BOOTSTRAP_NGTCP2
       BOOTSTRAP_NGHTTP2
       OUT_TARGETS)
   set(multiValueArgs)
@@ -226,35 +231,15 @@ function(_pv_add_bootstrap_projects)
   if(NOT _pv_jobs)
     set(_pv_jobs 1)
   endif()
-
   _pv_collect_bootstrap_environment_modifications(
-    _pv_base_env_modifications CFLAGS "${PV_PORTABLE_C_FLAGS}" CXXFLAGS
+    _pv_environment CFLAGS "${PV_PORTABLE_C_FLAGS}" CXXFLAGS
     "${PV_PORTABLE_CXX_FLAGS}")
-  _pv_collect_bootstrap_environment_modifications(
-    _pv_ngtcp2_configure_env_modifications
-    CFLAGS
-    "${PV_PORTABLE_C_FLAGS}"
-    CXXFLAGS
-    "${PV_PORTABLE_CXX_FLAGS}"
-    PKG_CONFIG_PATH
-    "${PV_OPENSSL_ROOT}/lib/pkgconfig:${PV_NGHTTP3_ROOT}/lib/pkgconfig"
-    LDFLAGS
-    "-Wl,-rpath,${PV_OPENSSL_ROOT}/lib")
-  _pv_collect_bootstrap_environment_modifications(
-    _pv_nghttp2_configure_env_modifications
-    CFLAGS
-    "${PV_PORTABLE_C_FLAGS}"
-    CXXFLAGS
-    "${PV_PORTABLE_CXX_FLAGS}"
-    PKG_CONFIG_PATH
-    "${PV_OPENSSL_ROOT}/lib/pkgconfig:${PV_NGTCP2_ROOT}/lib/pkgconfig:${PV_NGHTTP3_ROOT}/lib/pkgconfig"
-  )
 
   set(_pv_targets)
 
   if(PV_BOOTSTRAP_OPENSSL)
     _pv_append_bootstrap_install_byproducts(
-      _pv_openssl_install_byproducts "${PV_OPENSSL_ROOT}" LIBRARIES crypto ssl)
+      _pv_openssl_byproducts "${PV_OPENSSL_ROOT}" LIBRARIES crypto ssl)
     ExternalProject_Add(
       pv_dep_openssl
       PREFIX "${CMAKE_BINARY_DIR}/_deps/openssl"
@@ -264,13 +249,13 @@ function(_pv_add_bootstrap_projects)
       UPDATE_DISCONNECTED TRUE
       BUILD_IN_SOURCE TRUE
       CONFIGURE_ENVIRONMENT_MODIFICATION
-      ${_pv_base_env_modifications}
+      ${_pv_environment}
       BUILD_ENVIRONMENT_MODIFICATION
-      ${_pv_base_env_modifications}
+      ${_pv_environment}
       INSTALL_ENVIRONMENT_MODIFICATION
-      ${_pv_base_env_modifications}
+      ${_pv_environment}
       INSTALL_BYPRODUCTS
-      ${_pv_openssl_install_byproducts}
+      ${_pv_openssl_byproducts}
       CONFIGURE_COMMAND ./config enable-tls1_3 --prefix=${PV_OPENSSL_ROOT}
                         --libdir=lib
       BUILD_COMMAND make -j ${_pv_jobs}
@@ -280,7 +265,7 @@ function(_pv_add_bootstrap_projects)
 
   if(PV_BOOTSTRAP_NGHTTP3)
     _pv_append_bootstrap_install_byproducts(
-      _pv_nghttp3_install_byproducts "${PV_NGHTTP3_ROOT}" LIBRARIES nghttp3)
+      _pv_nghttp3_byproducts "${PV_NGHTTP3_ROOT}" LIBRARIES nghttp3)
     set(_pv_nghttp3_configure
         "autoreconf -if && ./configure --prefix='${PV_NGHTTP3_ROOT}' --enable-lib-only"
     )
@@ -294,79 +279,22 @@ function(_pv_add_bootstrap_projects)
       UPDATE_COMMAND git submodule update --init --recursive
       BUILD_IN_SOURCE TRUE
       CONFIGURE_ENVIRONMENT_MODIFICATION
-      ${_pv_base_env_modifications}
+      ${_pv_environment}
       BUILD_ENVIRONMENT_MODIFICATION
-      ${_pv_base_env_modifications}
+      ${_pv_environment}
       INSTALL_ENVIRONMENT_MODIFICATION
-      ${_pv_base_env_modifications}
+      ${_pv_environment}
       INSTALL_BYPRODUCTS
-      ${_pv_nghttp3_install_byproducts}
+      ${_pv_nghttp3_byproducts}
       CONFIGURE_COMMAND /bin/sh -c "${_pv_nghttp3_configure}"
       BUILD_COMMAND make -j ${_pv_jobs}
       INSTALL_COMMAND make install)
     list(APPEND _pv_targets pv_dep_nghttp3)
   endif()
 
-  set(_pv_ngtcp2_depends_args)
-  set(_pv_ngtcp2_depends)
-  if(PV_BOOTSTRAP_OPENSSL)
-    list(APPEND _pv_ngtcp2_depends pv_dep_openssl)
-  endif()
-  if(PV_BOOTSTRAP_NGHTTP3)
-    list(APPEND _pv_ngtcp2_depends pv_dep_nghttp3)
-  endif()
-  if(_pv_ngtcp2_depends)
-    set(_pv_ngtcp2_depends_args DEPENDS ${_pv_ngtcp2_depends})
-  endif()
-
-  if(PV_BOOTSTRAP_NGTCP2)
-    _pv_append_bootstrap_install_byproducts(
-      _pv_ngtcp2_install_byproducts "${PV_NGTCP2_ROOT}" LIBRARIES ngtcp2
-      ngtcp2_crypto_ossl)
-    set(_pv_ngtcp2_configure
-        "autoreconf -if && ./configure --prefix='${PV_NGTCP2_ROOT}' --enable-lib-only"
-    )
-    ExternalProject_Add(
-      pv_dep_ngtcp2
-      PREFIX "${CMAKE_BINARY_DIR}/_deps/ngtcp2"
-      GIT_REPOSITORY "https://github.com/ngtcp2/ngtcp2.git"
-      GIT_TAG "${PV_NGTCP2_TAG}"
-      GIT_SHALLOW TRUE
-      UPDATE_DISCONNECTED TRUE
-      UPDATE_COMMAND git submodule update --init --recursive
-      BUILD_IN_SOURCE TRUE
-      CONFIGURE_ENVIRONMENT_MODIFICATION
-      ${_pv_ngtcp2_configure_env_modifications}
-      BUILD_ENVIRONMENT_MODIFICATION
-      ${_pv_base_env_modifications}
-      INSTALL_ENVIRONMENT_MODIFICATION
-      ${_pv_base_env_modifications}
-      INSTALL_BYPRODUCTS
-      ${_pv_ngtcp2_install_byproducts}
-      CONFIGURE_COMMAND /bin/sh -c "${_pv_ngtcp2_configure}"
-      BUILD_COMMAND make -j ${_pv_jobs}
-      INSTALL_COMMAND make install ${_pv_ngtcp2_depends_args})
-    list(APPEND _pv_targets pv_dep_ngtcp2)
-  endif()
-
-  set(_pv_nghttp2_depends_args)
-  set(_pv_nghttp2_depends)
-  if(PV_BOOTSTRAP_OPENSSL)
-    list(APPEND _pv_nghttp2_depends pv_dep_openssl)
-  endif()
-  if(PV_BOOTSTRAP_NGHTTP3)
-    list(APPEND _pv_nghttp2_depends pv_dep_nghttp3)
-  endif()
-  if(PV_BOOTSTRAP_NGTCP2)
-    list(APPEND _pv_nghttp2_depends pv_dep_ngtcp2)
-  endif()
-  if(_pv_nghttp2_depends)
-    set(_pv_nghttp2_depends_args DEPENDS ${_pv_nghttp2_depends})
-  endif()
-
   if(PV_BOOTSTRAP_NGHTTP2)
     _pv_append_bootstrap_install_byproducts(
-      _pv_nghttp2_install_byproducts "${PV_NGHTTP2_ROOT}" LIBRARIES nghttp2)
+      _pv_nghttp2_byproducts "${PV_NGHTTP2_ROOT}" LIBRARIES nghttp2)
     set(_pv_nghttp2_configure
         "autoreconf -if && ./configure --prefix='${PV_NGHTTP2_ROOT}' --enable-lib-only"
     )
@@ -380,16 +308,16 @@ function(_pv_add_bootstrap_projects)
       UPDATE_COMMAND git submodule update --init --recursive
       BUILD_IN_SOURCE TRUE
       CONFIGURE_ENVIRONMENT_MODIFICATION
-      ${_pv_nghttp2_configure_env_modifications}
+      ${_pv_environment}
       BUILD_ENVIRONMENT_MODIFICATION
-      ${_pv_base_env_modifications}
+      ${_pv_environment}
       INSTALL_ENVIRONMENT_MODIFICATION
-      ${_pv_base_env_modifications}
+      ${_pv_environment}
       INSTALL_BYPRODUCTS
-      ${_pv_nghttp2_install_byproducts}
+      ${_pv_nghttp2_byproducts}
       CONFIGURE_COMMAND /bin/sh -c "${_pv_nghttp2_configure}"
       BUILD_COMMAND make -j ${_pv_jobs}
-      INSTALL_COMMAND make install ${_pv_nghttp2_depends_args})
+      INSTALL_COMMAND make install)
     list(APPEND _pv_targets pv_dep_nghttp2)
   endif()
 
@@ -406,6 +334,13 @@ function(pv_define_http_dependencies)
   cmake_parse_arguments(PV "${options}" "${oneValueArgs}" "${multiValueArgs}"
                         ${ARGN})
 
+  if(PV_NGTCP2_ROOT)
+    message(
+      DEPRECATION
+        "PV_NGTCP2_ROOT is ignored because OpenSSL 3.5 now provides the QUIC transport."
+    )
+  endif()
+
   if(PV_BOOTSTRAP_DEPS)
     if(PV_DEPS_ROOT)
       set(_pv_bootstrap_prefix "${PV_DEPS_ROOT}")
@@ -416,18 +351,30 @@ function(pv_define_http_dependencies)
     set(_pv_bootstrap_prefix "")
   endif()
 
-  _pv_resolve_dependency_root(
-    "openssl" "${PV_OPENSSL_ROOT}" "${PV_DEPS_ROOT}"
-    "${_pv_bootstrap_prefix}/openssl" _pv_openssl_root _pv_bootstrap_openssl)
-  _pv_resolve_dependency_root(
-    "nghttp3" "${PV_NGHTTP3_ROOT}" "${PV_DEPS_ROOT}"
-    "${_pv_bootstrap_prefix}/nghttp3" _pv_nghttp3_root _pv_bootstrap_nghttp3)
-  _pv_resolve_dependency_root(
-    "ngtcp2" "${PV_NGTCP2_ROOT}" "${PV_DEPS_ROOT}"
-    "${_pv_bootstrap_prefix}/ngtcp2" _pv_ngtcp2_root _pv_bootstrap_ngtcp2)
-  _pv_resolve_dependency_root(
-    "nghttp2" "${PV_NGHTTP2_ROOT}" "${PV_DEPS_ROOT}"
-    "${_pv_bootstrap_prefix}/nghttp2" _pv_nghttp2_root _pv_bootstrap_nghttp2)
+  _pv_resolve_dependency(
+    "openssl"
+    "${PV_OPENSSL_ROOT}"
+    "${PV_DEPS_ROOT}"
+    "${_pv_bootstrap_prefix}/openssl"
+    _pv_openssl_root
+    _pv_bootstrap_openssl
+    _pv_system_openssl)
+  _pv_resolve_dependency(
+    "nghttp3"
+    "${PV_NGHTTP3_ROOT}"
+    "${PV_DEPS_ROOT}"
+    "${_pv_bootstrap_prefix}/nghttp3"
+    _pv_nghttp3_root
+    _pv_bootstrap_nghttp3
+    _pv_system_nghttp3)
+  _pv_resolve_dependency(
+    "nghttp2"
+    "${PV_NGHTTP2_ROOT}"
+    "${PV_DEPS_ROOT}"
+    "${_pv_bootstrap_prefix}/nghttp2"
+    _pv_nghttp2_root
+    _pv_bootstrap_nghttp2
+    _pv_system_nghttp2)
 
   if(PV_BOOTSTRAP_DEPS)
     if(_pv_bootstrap_openssl)
@@ -438,30 +385,21 @@ function(pv_define_http_dependencies)
       file(MAKE_DIRECTORY "${_pv_nghttp3_root}" "${_pv_nghttp3_root}/include"
            "${_pv_nghttp3_root}/lib")
     endif()
-    if(_pv_bootstrap_ngtcp2)
-      file(MAKE_DIRECTORY "${_pv_ngtcp2_root}" "${_pv_ngtcp2_root}/include"
-           "${_pv_ngtcp2_root}/lib")
-    endif()
     if(_pv_bootstrap_nghttp2)
       file(MAKE_DIRECTORY "${_pv_nghttp2_root}" "${_pv_nghttp2_root}/include"
            "${_pv_nghttp2_root}/lib")
     endif()
-
     _pv_add_bootstrap_projects(
       OPENSSL_ROOT
       "${_pv_openssl_root}"
       NGHTTP3_ROOT
       "${_pv_nghttp3_root}"
-      NGTCP2_ROOT
-      "${_pv_ngtcp2_root}"
       NGHTTP2_ROOT
       "${_pv_nghttp2_root}"
       BOOTSTRAP_OPENSSL
       "${_pv_bootstrap_openssl}"
       BOOTSTRAP_NGHTTP3
       "${_pv_bootstrap_nghttp3}"
-      BOOTSTRAP_NGTCP2
-      "${_pv_bootstrap_ngtcp2}"
       BOOTSTRAP_NGHTTP2
       "${_pv_bootstrap_nghttp2}"
       OUT_TARGETS
@@ -470,90 +408,90 @@ function(pv_define_http_dependencies)
     set(_pv_bootstrap_targets)
   endif()
 
-  _pv_assert_external_layout("OpenSSL" "${_pv_openssl_root}")
-  _pv_assert_external_layout("nghttp3" "${_pv_nghttp3_root}")
-  _pv_assert_external_layout("ngtcp2" "${_pv_ngtcp2_root}")
-  _pv_assert_external_layout("nghttp2" "${_pv_nghttp2_root}")
+  set(_pv_libraries)
+  set(_pv_rpath_dirs)
 
-  _pv_get_library_path("${_pv_openssl_root}" "crypto"
-                       _pv_openssl_crypto_library)
-  _pv_get_library_path("${_pv_openssl_root}" "ssl" _pv_openssl_ssl_library)
-  _pv_get_library_path("${_pv_nghttp2_root}" "nghttp2" _pv_nghttp2_library)
-  _pv_get_library_path("${_pv_nghttp3_root}" "nghttp3" _pv_nghttp3_library)
-  _pv_get_library_path("${_pv_ngtcp2_root}" "ngtcp2" _pv_ngtcp2_library)
-  _pv_get_library_path("${_pv_ngtcp2_root}" "ngtcp2_crypto_ossl"
-                       _pv_ngtcp2_crypto_ossl_library)
-
-  if(NOT _pv_bootstrap_openssl)
-    _pv_assert_library_exists("OpenSSL crypto" "${_pv_openssl_crypto_library}")
-    _pv_assert_library_exists("OpenSSL ssl" "${_pv_openssl_ssl_library}")
-  endif()
-  if(NOT _pv_bootstrap_nghttp2)
-    _pv_assert_library_exists("nghttp2" "${_pv_nghttp2_library}")
-  endif()
-  if(NOT _pv_bootstrap_nghttp3)
-    _pv_assert_library_exists("nghttp3" "${_pv_nghttp3_library}")
-  endif()
-  if(NOT _pv_bootstrap_ngtcp2)
-    _pv_assert_library_exists("ngtcp2" "${_pv_ngtcp2_library}")
-    _pv_assert_library_exists("ngtcp2_crypto_ossl"
-                              "${_pv_ngtcp2_crypto_ossl_library}")
-  endif()
-
-  set(_pv_openssl_depends)
-  if(_pv_bootstrap_openssl)
-    list(APPEND _pv_openssl_depends pv_dep_openssl)
-  endif()
-  set(_pv_nghttp2_depends)
-  if(_pv_bootstrap_nghttp2)
-    list(APPEND _pv_nghttp2_depends pv_dep_nghttp2)
-  endif()
-  set(_pv_nghttp3_depends)
-  if(_pv_bootstrap_nghttp3)
-    list(APPEND _pv_nghttp3_depends pv_dep_nghttp3)
-  endif()
-  set(_pv_ngtcp2_depends)
-  if(_pv_bootstrap_ngtcp2)
-    list(APPEND _pv_ngtcp2_depends pv_dep_ngtcp2)
+  if(_pv_system_openssl)
+    find_package(OpenSSL 3.5 REQUIRED COMPONENTS SSL Crypto)
+    list(APPEND _pv_libraries OpenSSL::SSL OpenSSL::Crypto)
+  else()
+    _pv_assert_external_layout("OpenSSL" "${_pv_openssl_root}")
+    if(NOT _pv_bootstrap_openssl)
+      _pv_assert_openssl_35("${_pv_openssl_root}")
+    endif()
+    _pv_get_library_path("${_pv_openssl_root}" "crypto" _pv_openssl_crypto)
+    _pv_get_library_path("${_pv_openssl_root}" "ssl" _pv_openssl_ssl)
+    if(NOT _pv_bootstrap_openssl)
+      _pv_assert_library_exists("OpenSSL crypto" "${_pv_openssl_crypto}")
+      _pv_assert_library_exists("OpenSSL ssl" "${_pv_openssl_ssl}")
+    endif()
+    set(_pv_openssl_depends)
+    if(_pv_bootstrap_openssl)
+      list(APPEND _pv_openssl_depends pv_dep_openssl)
+    endif()
+    _pv_define_imported_library(
+      pv_openssl_crypto "${_pv_openssl_crypto}" "${_pv_openssl_root}/include"
+      DEPENDS ${_pv_openssl_depends})
+    _pv_define_imported_library(
+      pv_openssl_ssl
+      "${_pv_openssl_ssl}"
+      "${_pv_openssl_root}/include"
+      DEPENDS
+      ${_pv_openssl_depends}
+      INTERFACE_LINK_LIBRARIES
+      pv_openssl_crypto)
+    list(APPEND _pv_libraries pv_openssl_ssl pv_openssl_crypto)
+    list(APPEND _pv_rpath_dirs "${_pv_openssl_root}/lib")
   endif()
 
-  _pv_define_imported_library(
-    pv_openssl_crypto "${_pv_openssl_crypto_library}"
-    "${_pv_openssl_root}/include" DEPENDS ${_pv_openssl_depends})
-  _pv_define_imported_library(
-    pv_openssl_ssl
-    "${_pv_openssl_ssl_library}"
-    "${_pv_openssl_root}/include"
-    DEPENDS
-    ${_pv_openssl_depends}
-    INTERFACE_LINK_LIBRARIES
-    pv_openssl_crypto)
-  _pv_define_imported_library(
-    pv_nghttp2 "${_pv_nghttp2_library}" "${_pv_nghttp2_root}/include" DEPENDS
-    ${_pv_nghttp2_depends})
-  _pv_define_imported_library(
-    pv_nghttp3 "${_pv_nghttp3_library}" "${_pv_nghttp3_root}/include" DEPENDS
-    ${_pv_nghttp3_depends})
-  _pv_define_imported_library(
-    pv_ngtcp2 "${_pv_ngtcp2_library}" "${_pv_ngtcp2_root}/include" DEPENDS
-    ${_pv_ngtcp2_depends})
-  _pv_define_imported_library(
-    pv_ngtcp2_crypto_ossl
-    "${_pv_ngtcp2_crypto_ossl_library}"
-    "${_pv_ngtcp2_root}/include"
-    DEPENDS
-    ${_pv_ngtcp2_depends}
-    INTERFACE_LINK_LIBRARIES
-    "pv_ngtcp2;pv_openssl_ssl;pv_openssl_crypto")
+  if(_pv_system_nghttp2 OR _pv_system_nghttp3)
+    find_package(PkgConfig REQUIRED)
+  endif()
+  if(_pv_system_nghttp2)
+    pkg_check_modules(PV_SYSTEM_NGHTTP2 REQUIRED IMPORTED_TARGET GLOBAL
+                      libnghttp2)
+    list(APPEND _pv_libraries PkgConfig::PV_SYSTEM_NGHTTP2)
+  else()
+    _pv_assert_external_layout("nghttp2" "${_pv_nghttp2_root}")
+    _pv_get_library_path("${_pv_nghttp2_root}" "nghttp2" _pv_nghttp2_library)
+    if(NOT _pv_bootstrap_nghttp2)
+      _pv_assert_library_exists("nghttp2" "${_pv_nghttp2_library}")
+    endif()
+    set(_pv_nghttp2_depends)
+    if(_pv_bootstrap_nghttp2)
+      list(APPEND _pv_nghttp2_depends pv_dep_nghttp2)
+    endif()
+    _pv_define_imported_library(
+      pv_nghttp2 "${_pv_nghttp2_library}" "${_pv_nghttp2_root}/include" DEPENDS
+      ${_pv_nghttp2_depends})
+    list(APPEND _pv_libraries pv_nghttp2)
+    list(APPEND _pv_rpath_dirs "${_pv_nghttp2_root}/lib")
+  endif()
 
-  set(_pv_libraries pv_nghttp2 pv_nghttp3 pv_ngtcp2_crypto_ossl pv_ngtcp2
-                    pv_openssl_ssl pv_openssl_crypto)
+  if(_pv_system_nghttp3)
+    pkg_check_modules(PV_SYSTEM_NGHTTP3 REQUIRED IMPORTED_TARGET GLOBAL
+                      libnghttp3)
+    list(APPEND _pv_libraries PkgConfig::PV_SYSTEM_NGHTTP3)
+  else()
+    _pv_assert_external_layout("nghttp3" "${_pv_nghttp3_root}")
+    _pv_get_library_path("${_pv_nghttp3_root}" "nghttp3" _pv_nghttp3_library)
+    if(NOT _pv_bootstrap_nghttp3)
+      _pv_assert_library_exists("nghttp3" "${_pv_nghttp3_library}")
+    endif()
+    set(_pv_nghttp3_depends)
+    if(_pv_bootstrap_nghttp3)
+      list(APPEND _pv_nghttp3_depends pv_dep_nghttp3)
+    endif()
+    _pv_define_imported_library(
+      pv_nghttp3 "${_pv_nghttp3_library}" "${_pv_nghttp3_root}/include" DEPENDS
+      ${_pv_nghttp3_depends})
+    list(APPEND _pv_libraries pv_nghttp3)
+    list(APPEND _pv_rpath_dirs "${_pv_nghttp3_root}/lib")
+  endif()
 
   if(PV_STATIC_BUILD)
     set(_pv_rpath_dirs)
   else()
-    set(_pv_rpath_dirs "${_pv_nghttp2_root}/lib" "${_pv_nghttp3_root}/lib"
-                       "${_pv_ngtcp2_root}/lib" "${_pv_openssl_root}/lib")
     list(REMOVE_DUPLICATES _pv_rpath_dirs)
   endif()
 

--- a/docker/alpine_3.20/Dockerfile
+++ b/docker/alpine_3.20/Dockerfile
@@ -3,15 +3,13 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-FROM docker.io/library/alpine:3.20 AS pv-libs-builder-base
+FROM docker.io/library/alpine:3.20 AS dev-base
 
 ENV PATH="/opt/pv-venv/bin:${PATH}" \
     PV_DEPS_ROOT="/opt/pv_libs"
 
 RUN apk add --no-cache \
   bash \
-  autoconf \
-  automake \
   build-base \
   ca-certificates \
   coreutils \
@@ -19,15 +17,12 @@ RUN apk add --no-cache \
   diffutils \
   git \
   libffi-dev \
-  libtool \
   linux-headers \
   openssl-dev \
-  perl \
   pkgconf \
   python3 \
   python3-dev \
-  py3-pip \
-  sudo
+  py3-pip
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
@@ -42,19 +37,30 @@ export PATH="/opt/pv-venv/bin:${PATH}"
 PROFILE
 EOF
 
-# Build the HTTP dependency stack once during image creation.
-FROM pv-libs-builder-base AS dev
+FROM dev-base AS deps-builder
 
-ARG PV_REPO_URL="https://github.com/yahoo/proxy-verifier.git"
-ARG PV_REPO_REF="master"
+RUN apk add --no-cache \
+  autoconf \
+  automake \
+  libtool \
+  perl
+
+COPY tools/build-library-dependencies.sh /tmp/build-library-dependencies.sh
 
 RUN <<'EOF'
 set -eux
 
-git clone --depth 1 --branch "${PV_REPO_REF}" "${PV_REPO_URL}" /tmp/proxy-verifier
-chmod +x /tmp/proxy-verifier/tools/build-library-dependencies.sh
-/tmp/proxy-verifier/tools/build-library-dependencies.sh /opt/pv_libs
-rm -rf /tmp/proxy-verifier
+chmod +x /tmp/build-library-dependencies.sh
+/tmp/build-library-dependencies.sh /opt/pv_libs
+rm -f /tmp/build-library-dependencies.sh
 EOF
+
+FROM dev-base AS dev-external
+
+COPY --from=deps-builder /opt/pv_libs /opt/pv_libs
+
+WORKDIR /workspace
+
+FROM deps-builder AS dev
 
 WORKDIR /workspace

--- a/docker/rockylinux_10/Dockerfile
+++ b/docker/rockylinux_10/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-FROM docker.io/rockylinux/rockylinux:10 AS pv-libs-builder-base
+FROM docker.io/rockylinux/rockylinux:10 AS dev-base
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
@@ -16,8 +16,6 @@ set -eux
 dnf install -y dnf-plugins-core
 dnf config-manager --set-enabled crb
 dnf install -y \
-  autoconf \
-  automake \
   ca-certificates \
   curl \
   diffutils \
@@ -27,13 +25,9 @@ dnf install -y \
   glibc-static \
   libffi-devel \
   libstdc++-static \
-  libtool \
-  make \
   openssl-devel \
-  perl \
   procps-ng \
   pkgconf-pkg-config \
-  sudo \
   python3 \
   python3-devel \
   python3-pip
@@ -49,19 +43,38 @@ dnf clean all
 rm -rf /var/cache/dnf
 EOF
 
-# Build the HTTP dependency stack once during image creation.
-FROM pv-libs-builder-base AS dev
-
-ARG PV_REPO_URL="https://github.com/yahoo/proxy-verifier.git"
-ARG PV_REPO_REF="master"
+FROM dev-base AS deps-builder
 
 RUN <<'EOF'
 set -eux
 
-git clone --depth 1 --branch "${PV_REPO_REF}" "${PV_REPO_URL}" /tmp/proxy-verifier
-chmod +x /tmp/proxy-verifier/tools/build-library-dependencies.sh
-/tmp/proxy-verifier/tools/build-library-dependencies.sh /opt/pv_libs
-rm -rf /tmp/proxy-verifier
+dnf install -y \
+  autoconf \
+  automake \
+  libtool \
+  make \
+  perl
+
+dnf clean all
+rm -rf /var/cache/dnf
 EOF
+
+COPY tools/build-library-dependencies.sh /tmp/build-library-dependencies.sh
+
+RUN <<'EOF'
+set -eux
+
+chmod +x /tmp/build-library-dependencies.sh
+/tmp/build-library-dependencies.sh /opt/pv_libs
+rm -f /tmp/build-library-dependencies.sh
+EOF
+
+FROM dev-base AS dev-external
+
+COPY --from=deps-builder /opt/pv_libs /opt/pv_libs
+
+WORKDIR /workspace
+
+FROM deps-builder AS dev
 
 WORKDIR /workspace

--- a/docker/rockylinux_8/Dockerfile
+++ b/docker/rockylinux_8/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-FROM docker.io/rockylinux/rockylinux:8 AS pv-libs-builder-base
+FROM docker.io/rockylinux/rockylinux:8 AS dev-base
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
@@ -16,8 +16,6 @@ set -eux
 dnf install -y dnf-plugins-core
 dnf config-manager --set-enabled powertools
 dnf --refresh --nobest install -y \
-  autoconf \
-  automake \
   ca-certificates \
   curl \
   diffutils \
@@ -27,13 +25,9 @@ dnf --refresh --nobest install -y \
   glibc-static \
   libffi-devel \
   libstdc++-static \
-  libtool \
-  make \
   openssl-devel \
-  perl \
   procps-ng \
   pkgconf-pkg-config \
-  sudo \
   python3.12 \
   python3.12-devel \
   python3.12-pip
@@ -55,19 +49,38 @@ dnf clean all
 rm -rf /var/cache/dnf
 EOF
 
-# Build the HTTP dependency stack once during image creation.
-FROM pv-libs-builder-base AS dev
-
-ARG PV_REPO_URL="https://github.com/yahoo/proxy-verifier.git"
-ARG PV_REPO_REF="master"
+FROM dev-base AS deps-builder
 
 RUN <<'EOF'
 set -eux
 
-git clone --depth 1 --branch "${PV_REPO_REF}" "${PV_REPO_URL}" /tmp/proxy-verifier
-chmod +x /tmp/proxy-verifier/tools/build-library-dependencies.sh
-/tmp/proxy-verifier/tools/build-library-dependencies.sh /opt/pv_libs
-rm -rf /tmp/proxy-verifier
+dnf --refresh --nobest install -y \
+  autoconf \
+  automake \
+  libtool \
+  make \
+  perl
+
+dnf clean all
+rm -rf /var/cache/dnf
 EOF
+
+COPY tools/build-library-dependencies.sh /tmp/build-library-dependencies.sh
+
+RUN <<'EOF'
+set -eux
+
+chmod +x /tmp/build-library-dependencies.sh
+/tmp/build-library-dependencies.sh /opt/pv_libs
+rm -f /tmp/build-library-dependencies.sh
+EOF
+
+FROM dev-base AS dev-external
+
+COPY --from=deps-builder /opt/pv_libs /opt/pv_libs
+
+WORKDIR /workspace
+
+FROM deps-builder AS dev
 
 WORKDIR /workspace

--- a/docker/rockylinux_9/Dockerfile
+++ b/docker/rockylinux_9/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-FROM docker.io/rockylinux/rockylinux:9 AS pv-libs-builder-base
+FROM docker.io/rockylinux/rockylinux:9 AS dev-base
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
@@ -16,10 +16,8 @@ set -eux
 dnf install -y dnf-plugins-core
 dnf config-manager --set-enabled crb
 dnf install -y \
-  autoconf \
-  automake \
   ca-certificates \
-  curl \
+  curl-minimal \
   diffutils \
   gcc \
   gcc-c++ \
@@ -27,13 +25,9 @@ dnf install -y \
   glibc-static \
   libffi-devel \
   libstdc++-static \
-  libtool \
-  make \
   openssl-devel \
-  perl \
   procps-ng \
   pkgconf-pkg-config \
-  sudo \
   python3.11 \
   python3.11-devel \
   python3.11-pip
@@ -51,19 +45,38 @@ dnf clean all
 rm -rf /var/cache/dnf
 EOF
 
-# Build the HTTP dependency stack once during image creation.
-FROM pv-libs-builder-base AS dev
-
-ARG PV_REPO_URL="https://github.com/yahoo/proxy-verifier.git"
-ARG PV_REPO_REF="master"
+FROM dev-base AS deps-builder
 
 RUN <<'EOF'
 set -eux
 
-git clone --depth 1 --branch "${PV_REPO_REF}" "${PV_REPO_URL}" /tmp/proxy-verifier
-chmod +x /tmp/proxy-verifier/tools/build-library-dependencies.sh
-/tmp/proxy-verifier/tools/build-library-dependencies.sh /opt/pv_libs
-rm -rf /tmp/proxy-verifier
+dnf install -y \
+  autoconf \
+  automake \
+  libtool \
+  make \
+  perl
+
+dnf clean all
+rm -rf /var/cache/dnf
 EOF
+
+COPY tools/build-library-dependencies.sh /tmp/build-library-dependencies.sh
+
+RUN <<'EOF'
+set -eux
+
+chmod +x /tmp/build-library-dependencies.sh
+/tmp/build-library-dependencies.sh /opt/pv_libs
+rm -f /tmp/build-library-dependencies.sh
+EOF
+
+FROM dev-base AS dev-external
+
+COPY --from=deps-builder /opt/pv_libs /opt/pv_libs
+
+WORKDIR /workspace
+
+FROM deps-builder AS dev
 
 WORKDIR /workspace

--- a/docker/ubuntu_24.04/Dockerfile
+++ b/docker/ubuntu_24.04/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-FROM docker.io/library/ubuntu:24.04 AS pv-libs-builder-base
+FROM docker.io/library/ubuntu:24.04 AS dev-base
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
@@ -17,8 +17,6 @@ set -eux
 
 apt-get update
 apt-get install -y --no-install-recommends \
-  autoconf \
-  automake \
   ca-certificates \
   curl \
   diffutils \
@@ -28,11 +26,7 @@ apt-get install -y --no-install-recommends \
   libc6-dev \
   libffi-dev \
   libssl-dev \
-  libtool \
-  make \
-  perl \
   pkg-config \
-  sudo \
   python3-dev \
   python3-pip \
   python3-venv
@@ -47,19 +41,37 @@ PROFILE
 rm -rf /var/lib/apt/lists/*
 EOF
 
-# Build the HTTP dependency stack once during image creation.
-FROM pv-libs-builder-base AS dev
-
-ARG PV_REPO_URL="https://github.com/yahoo/proxy-verifier.git"
-ARG PV_REPO_REF="master"
+FROM dev-base AS deps-builder
 
 RUN <<'EOF'
 set -eux
 
-git clone --depth 1 --branch "${PV_REPO_REF}" "${PV_REPO_URL}" /tmp/proxy-verifier
-chmod +x /tmp/proxy-verifier/tools/build-library-dependencies.sh
-/tmp/proxy-verifier/tools/build-library-dependencies.sh /opt/pv_libs
-rm -rf /tmp/proxy-verifier
+apt-get update
+apt-get install -y --no-install-recommends \
+  autoconf \
+  automake \
+  libtool \
+  make \
+  perl
+rm -rf /var/lib/apt/lists/*
 EOF
+
+COPY tools/build-library-dependencies.sh /tmp/build-library-dependencies.sh
+
+RUN <<'EOF'
+set -eux
+
+chmod +x /tmp/build-library-dependencies.sh
+/tmp/build-library-dependencies.sh /opt/pv_libs
+rm -f /tmp/build-library-dependencies.sh
+EOF
+
+FROM dev-base AS dev-external
+
+COPY --from=deps-builder /opt/pv_libs /opt/pv_libs
+
+WORKDIR /workspace
+
+FROM deps-builder AS dev
 
 WORKDIR /workspace

--- a/src/core/http3.cc
+++ b/src/core/http3.cc
@@ -1,5 +1,5 @@
 /** @file
- * Common implementation for Proxy Verifier
+ * HTTP/3 over OpenSSL native QUIC.
  *
  * Copyright 2026, Verizon Media
  * SPDX-License-Identifier: Apache-2.0
@@ -10,37 +10,33 @@
 #include "core/verification.h"
 #include "core/ProxyVerifier.h"
 
+#include <algorithm>
+#include <array>
 #include <cassert>
 #include <cstring>
-#include <filesystem>
 #include <fcntl.h>
-#include <ngtcp2/ngtcp2.h>
-#include <ngtcp2/ngtcp2_crypto_ossl.h>
-#include <netdb.h>
+#include <filesystem>
+#include <limits>
+#include <netinet/in.h>
+#include <openssl/bio.h>
+#include <openssl/err.h>
+#include <openssl/quic.h>
+#include <poll.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <unistd.h>
+#include <vector>
 
 #include "swoc/bwf_ex.h"
 #include "swoc/bwf_ip.h"
 #include "swoc/bwf_std.h"
 
-/*
- * ngtcp2/nghttp3 does not currently have any code examples. The curl
- * implementation was helpful in forming this code:
- *
- * From curl/lib/quic/:
- *
- *   #ifdef ENABLE_QUIC
- *   #ifdef USE_NGTCP2
- *   #include "vquic/ngtcp2.h" // <------ Use this
- *   #endif
- *   #ifdef USE_QUICHE
- *   #include "vquic/quiche.h"
- *   #endif
- */
+#if OPENSSL_VERSION_NUMBER < 0x30500000L
+#error "HTTP/3 requires OpenSSL 3.5 or newer"
+#endif
 
 using swoc::Errata;
 using swoc::TextView;
-using swoc::bwf::Ngtcp2Error;
-using swoc::bwf::Nghttp3Error;
 using swoc::bwf::Errno;
 using namespace swoc::literals;
 using namespace std::literals;
@@ -50,1020 +46,76 @@ namespace chrono = std::chrono;
 using ClockType = chrono::steady_clock;
 using chrono::duration_cast;
 using chrono::milliseconds;
-using chrono::nanoseconds;
 
-constexpr auto QUIC_MAX_STREAMS = 256 * 1024;
-constexpr auto QUIC_IDLE_TIMEOUT = 60s;
+namespace
+{
 constexpr auto QUIC_HANDSHAKE_TIMEOUT = 10s;
+constexpr auto QUIC_EVENT_FALLBACK_TIMEOUT = 10ms;
+constexpr size_t QUIC_STREAM_BUFFER_SIZE = 64 * 1024;
+constexpr size_t MAX_HTTP3_VECTORS = 16;
+constexpr uint64_t H3_STREAM_CREATION_ERROR = 0x103;
+constexpr bool UNIDIRECTIONAL = true;
+constexpr unsigned char H3_ALPN[] = {2, 'h', '3'};
 
-constexpr auto H3_STREAM_WINDOW_SIZE = 128 * 1024;
-
-TextView H3_ALPN_H3 = "\x2h3";
-constexpr char const *QUIC_CIPHERS = "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_"
-                                     "POLY1305_SHA256:TLS_AES_128_CCM_SHA256";
-
-constexpr char const *QUIC_GROUPS = "P-256:X25519:P-384:P-521";
-
-int *H3Session::process_exit_code = nullptr;
-
-std::random_device QuicSocket::_rd;
-std::mt19937 QuicSocket::_rng(_rd());
-std::uniform_int_distribution<int> QuicSocket::_uni_id(0, std::numeric_limits<uint8_t>::max());
-swoc::file::path QuicSocket::_qlog_dir;
-std::mutex QuicSocket::_qlog_mutex;
-
-namespace swoc
+char const *
+nghttp3_error(int error)
 {
-inline namespace SWOC_VERSION_NS
-{
-BufferWriter &
-bwformat(BufferWriter &w, bwf::Spec const &spec, bwf::Ngtcp2Error const &error)
-{
-  // Hand rolled, might not be totally compliant everywhere, but probably close
-  // enough. The long string will be locally accurate. Clang requires the double
-  // braces.
-  static const std::unordered_map<int, std::string_view> SHORT_NAME = {
-      {-201, "NGTCP2_ERR_INVALID_ARGUMENT: "},
-      {-203, "NGTCP2_ERR_NOBUF: "},
-      {-205, "NGTCP2_ERR_PROTO: "},
-      {-206, "NGTCP2_ERR_INVALID_STATE: "},
-      {-207, "NGTCP2_ERR_ACK_FRAME: "},
-      {-208, "NGTCP2_ERR_STREAM_ID_BLOCKED: "},
-      {-209, "NGTCP2_ERR_STREAM_IN_USE: "},
-      {-210, "NGTCP2_ERR_STREAM_DATA_BLOCKED: "},
-      {-211, "NGTCP2_ERR_FLOW_CONTROL: "},
-      {-212, "NGTCP2_ERR_CONNECTION_ID_LIMIT: "},
-      {-213, "NGTCP2_ERR_STREAM_LIMIT: "},
-      {-214, "NGTCP2_ERR_FINAL_SIZE: "},
-      {-215, "NGTCP2_ERR_CRYPTO: "},
-      {-216, "NGTCP2_ERR_PKT_NUM_EXHAUSTED: "},
-      {-217, "NGTCP2_ERR_REQUIRED_TRANSPORT_PARAM: "},
-      {-218, "NGTCP2_ERR_MALFORMED_TRANSPORT_PARAM: "},
-      {-219, "NGTCP2_ERR_FRAME_ENCODING: "},
-      {-220, "NGTCP2_ERR_TLS_DECRYPT: "},
-      {-221, "NGTCP2_ERR_STREAM_SHUT_WR: "},
-      {-222, "NGTCP2_ERR_STREAM_NOT_FOUND: "},
-      {-226, "NGTCP2_ERR_STREAM_STATE: "},
-      {-229, "NGTCP2_ERR_RECV_VERSION_NEGOTIATION: "},
-      {-230, "NGTCP2_ERR_CLOSING: "},
-      {-231, "NGTCP2_ERR_DRAINING: "},
-      {-234, "NGTCP2_ERR_TRANSPORT_PARAM: "},
-      {-235, "NGTCP2_ERR_DISCARD_PKT: "},
-      {-236, "NGTCP2_ERR_PATH_VALIDATION_FAILED: "},
-      {-237, "NGTCP2_ERR_CONN_ID_BLOCKED: "},
-      {-238, "NGTCP2_ERR_INTERNAL: "},
-      {-239, "NGTCP2_ERR_CRYPTO_BUFFER_EXCEEDED: "},
-      {-240, "NGTCP2_ERR_WRITE_MORE: "},
-      {-241, "NGTCP2_ERR_RETRY: "},
-      {-242, "NGTCP2_ERR_DROP_CONN: "},
-      {-243, "NGTCP2_ERR_AEAD_LIMIT_REACHED: "},
-      {-244, "NGTCP2_ERR_NO_VIABLE_PATH: "},
-      {-500, "NGTCP2_ERR_FATAL: "},
-      {-501, "NGTCP2_ERR_NOMEM: "},
-      {-502, "NGTCP2_ERR_CALLBACK_FAILURE: "},
-  };
-
-  auto short_name = [](int n) -> std::string_view {
-    if (n > -201 || n < -502) {
-      return "Unknown ngtcp2 error: ";
-    }
-    auto spot = SHORT_NAME.find(n);
-    if (spot == SHORT_NAME.end()) {
-      return "Unknown ngtcp2 error: ";
-    }
-    return spot->second;
-  };
-  static const bwf::Format number_fmt{"[{}]"sv}; // numeric value format.
-  if (spec.has_numeric_type()) {                 // if numeric type, print just the numeric
-                                                 // part.
-    w.print(number_fmt, error._e);
-  } else {
-    w.write(short_name(error._e));
-    auto const *error_reason = ngtcp2_strerror(error._e);
-    if (error_reason != nullptr) {
-      w.write(error_reason, std::strlen(error_reason));
-    }
-    if (spec._type != 's' && spec._type != 'S') {
-      w.write(' ');
-      w.print(number_fmt, error._e);
-    }
-  }
-  return w;
+  auto const *message = nghttp3_strerror(error);
+  return message == nullptr ? "unknown nghttp3 error" : message;
 }
 
-BufferWriter &
-bwformat(BufferWriter &w, bwf::Spec const &spec, bwf::Nghttp3Error const &error)
+milliseconds
+quic_event_timeout(SSL *connection, milliseconds maximum)
 {
-  // Hand rolled, might not be totally compliant everywhere, but probably close
-  // enough. The long string will be locally accurate. Clang requires the double
-  // braces.
-  static const std::unordered_map<int, std::string_view> SHORT_NAME = {
-      {-101, "NGHTTP3_ERR_INVALID_ARGUMENT: "},
-      {-102, "NGHTTP3_ERR_NOBUF: "},
-      {-103, "NGHTTP3_ERR_INVALID_STATE: "},
-      {-104, "NGHTTP3_ERR_WOULDBLOCK: "},
-      {-105, "NGHTTP3_ERR_STREAM_IN_USE: "},
-      {-106, "NGHTTP3_ERR_PUSH_ID_BLOCKED: "},
-      {-107, "NGHTTP3_ERR_MALFORMED_HTTP_HEADER: "},
-      {-108, "NGHTTP3_ERR_REMOVE_HTTP_HEADER: "},
-      {-109, "NGHTTP3_ERR_MALFORMED_HTTP_MESSAGING: "},
-      {-111, "NGHTTP3_ERR_QPACK_FATAL: "},
-      {-112, "NGHTTP3_ERR_QPACK_HEADER_TOO_LARGE: "},
-      {-113, "NGHTTP3_ERR_IGNORE_STREAM: "},
-      {-114, "NGHTTP3_ERR_STREAM_NOT_FOUND: "},
-      {-115, "NGHTTP3_ERR_IGNORE_PUSH_PROMISE: "},
-      {-116, "NGHTTP3_ERR_CONN_CLOSING: "},
-      {-402, "NGHTTP3_ERR_QPACK_DECOMPRESSION_FAILED: "},
-      {-403, "NGHTTP3_ERR_QPACK_ENCODER_STREAM_ERROR: "},
-      {-404, "NGHTTP3_ERR_QPACK_DECODER_STREAM_ERROR: "},
-      {-408, "NGHTTP3_ERR_H3_FRAME_UNEXPECTED: "},
-      {-409, "NGHTTP3_ERR_H3_FRAME_ERROR: "},
-      {-665, "NGHTTP3_ERR_H3_MISSING_SETTINGS: "},
-      {-667, "NGHTTP3_ERR_H3_INTERNAL_ERROR: "},
-      {-668, "NGHTTP3_ERR_H3_CLOSED_CRITICAL_STREAM: "},
-      {-669, "NGHTTP3_ERR_H3_GENERAL_PROTOCOL_ERROR: "},
-      {-670, "NGHTTP3_ERR_H3_ID_ERROR: "},
-      {-671, "NGHTTP3_ERR_H3_SETTINGS_ERROR: "},
-      {-672, "NGHTTP3_ERR_H3_STREAM_CREATION_ERROR: "},
-      {-900, "NGHTTP3_ERR_FATAL: "},
-      {-901, "NGHTTP3_ERR_NOMEM: "},
-      {-902, "NGHTTP3_ERR_CALLBACK_FAILURE: "},
-  };
-
-  auto short_name = [](int n) -> std::string_view {
-    if (n > -201 || n < -502) {
-      return "Unknown nghttp3 error: ";
-    }
-    auto spot = SHORT_NAME.find(n);
-    if (spot == SHORT_NAME.end()) {
-      return "Unknown nghttp3 error: ";
-    }
-    return spot->second;
-  };
-  static const bwf::Format number_fmt{"[{}]"sv}; // numeric value format.
-  if (spec.has_numeric_type()) {                 // if numeric type, print just the numeric
-                                                 // part.
-    w.print(number_fmt, error._e);
-  } else {
-    w.write(short_name(error._e));
-    auto const *error_reason = nghttp3_strerror(error._e);
-    if (error_reason != nullptr) {
-      w.write(error_reason, std::strlen(error_reason));
-    }
-    if (spec._type != 's' && spec._type != 'S') {
-      w.write(' ');
-      w.print(number_fmt, error._e);
-    }
+  struct timeval timeout = {};
+  int is_infinite = 1;
+  if (SSL_get_event_timeout(connection, &timeout, &is_infinite) != 1 || is_infinite) {
+    return std::min(maximum, QUIC_EVENT_FALLBACK_TIMEOUT);
   }
-  return w;
-}
-} // namespace SWOC_VERSION_NS
-} // namespace swoc
 
-/** Return a representation of the current time compatible with ngtcp
- * expectations.
- *
- * ngtcp2 expects timestamps from a monotonic clock.
- *
- * @return The current time.
- */
-static ngtcp2_tstamp
-timestamp()
-{
-  auto const current_time = ClockType::now();
-  auto const duration_since_epoch = current_time.time_since_epoch();
-  return duration_cast<nanoseconds>(duration_since_epoch).count();
+  auto const timeout_us = chrono::seconds{timeout.tv_sec} + chrono::microseconds{timeout.tv_usec};
+  auto timeout_ms = chrono::ceil<milliseconds>(timeout_us);
+  return std::min(maximum, timeout_ms);
 }
 
-PacketIoContext::PacketIoContext()
-{
-  ts = timestamp();
-  ngtcp2_path_storage_zero(&ps);
-}
-
-/** Receive data off of the socket.
- *
- * @return -1 on failure, otherwise the number of bytes received.
- */
-static swoc::Rv<int>
-ngtcp2_progress_ingress(H3Session &session, milliseconds timeout, PacketIoContext *packet_context);
-
-/** Send data on the socket.
- *
- * @return -1 on failure, otherwise the number of bytes sent.
- */
-static swoc::Rv<int> ngtcp2_progress_egress(H3Session &session, PacketIoContext *packet_context);
-
-static ngtcp2_conn *
-get_conn(ngtcp2_crypto_conn_ref *conn_ref)
-{
-  H3Session *h3_session = reinterpret_cast<H3Session *>(conn_ref->user_data);
-  return h3_session->quic_socket.qconn;
-}
-
-// --------------------------------------------
-// Begin ngtcp2 callbacks.
-// --------------------------------------------
-static int
-cb_handshake_completed(ngtcp2_conn * /* tconn */, void * /* user_data */)
-{
-  Errata errata;
-  errata.note(S_DIAG, R"(h3 is negotiated.)");
-  return 0;
-}
-
-static int
-cb_recv_stream_data(
-    ngtcp2_conn *tconn,
-    uint32_t flags,
-    int64_t stream_id,
-    uint64_t /* offset */,
-    const uint8_t *buf,
-    size_t buflen,
-    void *conn_data,
-    void * /* stream_user_data */)
-{
-  H3Session *h3_session = reinterpret_cast<H3Session *>(conn_data);
-  int fin = (flags & NGTCP2_STREAM_DATA_FLAG_FIN) ? 1 : 0;
-
-  ssize_t nconsumed =
-      nghttp3_conn_read_stream(h3_session->quic_socket.h3conn, stream_id, buf, buflen, fin);
-  if (nconsumed < 0) {
-    ngtcp2_ccerr_set_application_error(
-        &h3_session->quic_socket.last_error,
-        nghttp3_err_infer_quic_app_error_code((int)nconsumed),
-        NULL,
-        0);
-    return NGTCP2_ERR_CALLBACK_FAILURE;
-  }
-
-  /* A comment from the CURL code:
-   *
-   * number of bytes inside buflen which consists of framing overhead
-   * including QPACK HEADERS. In other words, it does not consume payload of
-   * DATA frame. */
-  ngtcp2_conn_extend_max_stream_offset(tconn, stream_id, nconsumed);
-  ngtcp2_conn_extend_max_offset(tconn, nconsumed);
-
-  return 0;
-}
-
-static int
-cb_acked_stream_data_offset(
-    ngtcp2_conn * /* tconn */,
-    int64_t stream_id,
-    uint64_t /* offset */,
-    uint64_t datalen,
-    void *conn_data,
-    void * /* stream_user_data */)
-{
-  H3Session *h3_session = reinterpret_cast<H3Session *>(conn_data);
-  int rv = nghttp3_conn_add_ack_offset(h3_session->quic_socket.h3conn, stream_id, datalen);
-  if (rv != 0) {
-    return NGTCP2_ERR_CALLBACK_FAILURE;
-  }
-
-  return 0;
-}
-
-static int
-cb_stream_close(
-    ngtcp2_conn * /* tconn */,
-    uint32_t flags,
-    int64_t stream_id,
-    uint64_t app_error_code,
-    void *conn_data,
-    void * /* stream_user_data */)
-{
-  H3Session *h3_session = reinterpret_cast<H3Session *>(conn_data);
-
-  if (!(flags & NGTCP2_STREAM_CLOSE_FLAG_APP_ERROR_CODE_SET)) {
-    app_error_code = NGHTTP3_H3_NO_ERROR;
-  }
-
-  int rv = nghttp3_conn_close_stream(h3_session->quic_socket.h3conn, stream_id, app_error_code);
-  if (rv != 0) {
-    ngtcp2_ccerr_set_application_error(
-        &h3_session->quic_socket.last_error,
-        nghttp3_err_infer_quic_app_error_code(rv),
-        NULL,
-        0);
-    return NGTCP2_ERR_CALLBACK_FAILURE;
-  }
-
-  return 0;
-}
-
-static void
-cb_rand(uint8_t *dest, size_t destlen, const ngtcp2_rand_ctx * /* rand_ctx */)
-{
-  QuicSocket::randomly_populate_array(dest, destlen);
-}
-
-static int
-cb_get_new_connection_id(
-    ngtcp2_conn * /* tconn */,
-    ngtcp2_cid *cid,
-    uint8_t *token,
-    size_t cidlen,
-    void * /* user_data */)
-{
-  QuicSocket::randomly_populate_array(cid->data, cidlen);
-  cid->datalen = cidlen;
-  QuicSocket::randomly_populate_array(token, NGTCP2_STATELESS_RESET_TOKENLEN);
-  return 0;
-}
-
-static int
-cb_stream_reset(
-    ngtcp2_conn * /* tconn */,
-    int64_t stream_id,
-    uint64_t /* final_size */,
-    uint64_t /* app_error_code */,
-    void *conn_data,
-    void * /* stream_user_data */)
-{
-  H3Session *h3_session = reinterpret_cast<H3Session *>(conn_data);
-  int rv = nghttp3_conn_shutdown_stream_read(h3_session->quic_socket.h3conn, stream_id);
-  if (rv != 0) {
-    return NGTCP2_ERR_CALLBACK_FAILURE;
-  }
-
-  return 0;
-}
-
-static int
-cb_stream_stop_sending(
-    ngtcp2_conn * /* tconn */,
-    int64_t stream_id,
-    uint64_t app_error_code,
-    void *conn_data,
-    void * /* stream_user_data */)
-{
-  H3Session *h3_session = reinterpret_cast<H3Session *>(conn_data);
-  int rv =
-      ngtcp2_conn_shutdown_stream_read(h3_session->quic_socket.qconn, 0, stream_id, app_error_code);
-  if (rv && rv != NGTCP2_ERR_STREAM_NOT_FOUND) {
-    return NGTCP2_ERR_CALLBACK_FAILURE;
-  }
-
-  return 0;
-}
-
-constexpr int SUCCEEDED = 0;
-constexpr int FAILED = 1;
-
-/// @return SUCCEEDED on success, FAILED on failure.
-static int initialize_nghttp3_connection(H3Session *session);
-
-static int
-cb_recv_rx_key(ngtcp2_conn * /* tconn */, ngtcp2_encryption_level level, void *conn_data)
-{
-  H3Session *h3_session = reinterpret_cast<H3Session *>(conn_data);
-
-  if (level != NGTCP2_ENCRYPTION_LEVEL_1RTT) {
-    return 0;
-  }
-
-  if (initialize_nghttp3_connection(h3_session) != SUCCEEDED) {
-    return NGTCP2_ERR_CALLBACK_FAILURE;
-  }
-
-  return 0;
-}
-
-static int
-cb_extend_max_local_streams_bidi(
-    ngtcp2_conn * /* tconn */,
-    uint64_t /*max_streams */,
-    void * /*user_data */)
-{
-  return 0;
-}
-
-static int
-cb_extend_max_stream_data(
-    ngtcp2_conn * /* tconn */,
-    int64_t stream_id,
-    uint64_t /* max_data */,
-    void *conn_data,
-    void * /* stream_user_data */)
-{
-  H3Session *h3_session = reinterpret_cast<H3Session *>(conn_data);
-  int rv = nghttp3_conn_unblock_stream(h3_session->quic_socket.h3conn, stream_id);
-  if (rv != 0) {
-    return NGTCP2_ERR_CALLBACK_FAILURE;
-  }
-
-  return 0;
-}
-
-static ngtcp2_callbacks client_ngtcp2_callbacks = {
-    ngtcp2_crypto_client_initial_cb,
-    nullptr, /* recv_client_initial */
-    ngtcp2_crypto_recv_crypto_data_cb,
-    cb_handshake_completed,
-    nullptr, /* recv_version_negotiation */
-    ngtcp2_crypto_encrypt_cb,
-    ngtcp2_crypto_decrypt_cb,
-    ngtcp2_crypto_hp_mask_cb,
-    cb_recv_stream_data,
-    cb_acked_stream_data_offset,
-    nullptr, /* stream_open */
-    cb_stream_close,
-    nullptr, /* recv_stateless_reset */
-    ngtcp2_crypto_recv_retry_cb,
-    cb_extend_max_local_streams_bidi,
-    nullptr, /* extend_max_local_streams_uni */
-    cb_rand,
-    cb_get_new_connection_id,
-    nullptr,                     /* remove_connection_id */
-    ngtcp2_crypto_update_key_cb, /* update_key */
-    nullptr,                     /* path_validation */
-    nullptr,                     /* select_preferred_addr */
-    cb_stream_reset,
-    nullptr, /* extend_max_remote_streams_bidi */
-    nullptr, /* extend_max_remote_streams_uni */
-    cb_extend_max_stream_data,
-    nullptr, /* dcid_status */
-    nullptr, /* handshake_confirmed */
-    nullptr, /* recv_new_token */
-    ngtcp2_crypto_delete_crypto_aead_ctx_cb,
-    ngtcp2_crypto_delete_crypto_cipher_ctx_cb,
-    nullptr, /* recv_datagram */
-    nullptr, /* ack_datagram */
-    nullptr, /* lost_datagram */
-    ngtcp2_crypto_get_path_challenge_data_cb,
-    cb_stream_stop_sending,
-    ngtcp2_crypto_version_negotiation_cb,
-    cb_recv_rx_key,
-    nullptr, /* recv_tx_key */
-    nullptr, /* early_data_rejected */
-    nullptr, /* begin_path_validation */
-};
-
-// TODO: fill this out when we add server-side code.
-#if 0
-static ngtcp2_callbacks server_ngtcp2_callbacks = {
-  nullptr, /* client_initial */
-  ngtcp2_crypto_recv_client_initial_cb, /* recv_client_initial */
-  ngtcp2_crypto_recv_crypto_data_cb,
-  cb_handshake_completed,
-  nullptr, /* recv_version_negotiation */
-  ngtcp2_crypto_encrypt_cb,
-  ngtcp2_crypto_decrypt_cb,
-  ngtcp2_crypto_hp_mask_cb,
-  cb_recv_stream_data,
-  cb_acked_stream_data_offset,
-  nullptr, /* stream_open */
-  cb_stream_close,
-  nullptr, /* recv_stateless_reset */
-  ngtcp2_crypto_recv_retry_cb,
-  cb_extend_max_local_streams_bidi,
-  nullptr, /* extend_max_local_streams_uni */
-  cb_rand,
-  cb_get_new_connection_id,
-  nullptr, /* remove_connection_id */
-  ngtcp2_crypto_update_key_cb, /* update_key */
-  nullptr, /* path_validation */
-  nullptr, /* select_preferred_addr */
-  cb_stream_reset,
-  nullptr, /* extend_max_remote_streams_bidi */
-  nullptr, /* extend_max_remote_streams_uni */
-  cb_extend_max_stream_data,
-  nullptr, /* dcid_status */
-  nullptr, /* handshake_confirmed */
-  nullptr, /* recv_new_token */
-  ngtcp2_crypto_delete_crypto_aead_ctx_cb,
-  ngtcp2_crypto_delete_crypto_cipher_ctx_cb,
-  nullptr /* recv_datagram */
-};
-#endif
-
-// --------------------------------------------
-// End ngtcp2 callbacks.
-// --------------------------------------------
-
-/** Handle expired ngtcp2 timers.
- *
- * @return @c true if an expiry was handled, @c false otherwise.
- */
-static swoc::Rv<bool>
-handle_expiry(H3Session &session, PacketIoContext *packet_context)
-{
-  swoc::Rv<bool> zret{false};
-  PacketIoContext local_packet_context;
-
-  if (packet_context == nullptr) {
-    packet_context = &local_packet_context;
-  } else {
-    packet_context->ts = timestamp();
-  }
-
-  ngtcp2_conn *qconn = session.quic_socket.qconn;
-  if (ngtcp2_conn_get_handshake_completed(qconn) == 0) {
-    return zret;
-  }
-
-  ngtcp2_tstamp const expiry = ngtcp2_conn_get_expiry(qconn);
-  if (expiry == 0 || expiry == UINT64_MAX || expiry > packet_context->ts) {
-    return zret;
-  }
-
-  int const rv = ngtcp2_conn_handle_expiry(qconn, packet_context->ts);
-  if (rv != 0) {
-    zret.note(S_ERROR, "ngtcp2_conn_handle_expiry returned error: {}", Ngtcp2Error{rv});
-    ngtcp2_ccerr_set_liberr(&session.quic_socket.last_error, rv, nullptr, 0);
-    return zret;
-  }
-
-  zret = true;
-  return zret;
-}
-
-/** Calculate the poll timeout, taking ngtcp2's next expiry into account.
- *
- * @param[in] session The H3 session whose QUIC timer is checked.
- * @param[in] timeout The caller's upper-bound timeout.
- * @param[in,out] packet_context Packet context with the current timestamp.
- * @param[out] limited_by_expiry Whether the returned timeout is bounded by the QUIC timer.
- *
- * @return A timeout suitable for poll().
- */
-static swoc::Rv<milliseconds>
-expiry_aware_poll_timeout(
-    H3Session &session,
-    milliseconds timeout,
-    PacketIoContext *packet_context,
-    bool &limited_by_expiry)
-{
-  swoc::Rv<milliseconds> zret{timeout};
-
-  limited_by_expiry = false;
-  packet_context->ts = timestamp();
-
-  if (ngtcp2_conn_get_handshake_completed(session.quic_socket.qconn) == 0) {
-    return zret;
-  }
-
-  auto &&[handled_expiry, expiry_errata] = handle_expiry(session, packet_context);
-  zret.note(std::move(expiry_errata));
-  if (!zret.is_ok()) {
-    return zret;
-  }
-  if (handled_expiry) {
-    limited_by_expiry = true;
-    zret = 0ms;
-    return zret;
-  }
-
-  ngtcp2_tstamp const expiry = ngtcp2_conn_get_expiry(session.quic_socket.qconn);
-  if (expiry == 0 || expiry == UINT64_MAX) {
-    return zret;
-  }
-
-  auto const until_expiry = nanoseconds{expiry - packet_context->ts};
-  auto expiry_timeout = duration_cast<milliseconds>(until_expiry);
-  if (expiry_timeout == 0ms && until_expiry > 0ns) {
-    expiry_timeout = 1ms;
-  }
-
-  if (expiry_timeout < timeout) {
-    limited_by_expiry = true;
-    zret = expiry_timeout;
-  }
-
-  return zret;
-}
-
-/** Receive a single QUIC packet.
- *
- * @return 0 on success, -1 on error.
- */
-static swoc::Rv<int>
-receive_packet(
-    QuicSocket &qs,
-    const unsigned char *pkt,
-    size_t pktlen,
-    struct sockaddr_storage *remote_addr,
-    socklen_t remote_addrlen,
-    int ecn,
-    PacketIoContext *packet_context)
-{
-  ngtcp2_pkt_info pi;
-  ngtcp2_path path;
-  swoc::Rv<int> zret{0};
-
-  ++packet_context->pkt_count;
-  ngtcp2_addr_init(&path.local, qs.local_addr, qs.local_addr.size());
-  ngtcp2_addr_init(&path.remote, (struct sockaddr *)remote_addr, remote_addrlen);
-  pi.ecn = (uint32_t)ecn;
-
-  int const rv = ngtcp2_conn_read_pkt(qs.qconn, &path, &pi, pkt, pktlen, packet_context->ts);
-  if (rv != 0) {
-    zret = -1;
-    if (!qs.last_error.error_code) {
-      if (rv == NGTCP2_ERR_CRYPTO) {
-        ngtcp2_ccerr_set_tls_alert(&qs.last_error, ngtcp2_conn_get_tls_alert(qs.qconn), NULL, 0);
-      } else {
-        ngtcp2_ccerr_set_liberr(&qs.last_error, rv, NULL, 0);
-      }
-    }
-
-    if (rv == NGTCP2_ERR_CRYPTO) {
-      zret.note(
-          S_ERROR,
-          "receive_packet: ngtcp2_conn_read_pkt() had an error return "
-          "(likely a certificate verification problem): {}",
-          Ngtcp2Error{rv});
-      return zret;
-    }
-    zret.note(
-        S_ERROR,
-        "receive_packet: ngtcp2_conn_read_pkt() had a non-Crypto error return: {}",
-        Ngtcp2Error{rv});
-    return zret;
-  }
-
-  return zret;
-}
-
-static swoc::Rv<int>
-receive_packets(
-    H3Session &session,
-    milliseconds timeout,
-    size_t max_pkts,
-    PacketIoContext *packet_context)
-{
-  uint8_t buf[64 * 1024];
-  int bufsize = (int)sizeof(buf);
-  struct sockaddr_storage remote_addr;
-  socklen_t remote_addrlen = sizeof(remote_addr);
-  size_t pkts;
-  ssize_t nread;
-  swoc::Rv<int> zret{-1};
-
-  assert(max_pkts > 0);
-  bool have_polled = false;
-  for (pkts = 0; pkts < max_pkts;) {
-    while (true) {
-      if (session.is_closed()) {
-        return zret;
-      }
-      nread = ::recvfrom(
-          session.get_fd(),
-          (char *)buf,
-          bufsize,
-          0,
-          (struct sockaddr *)&remote_addr,
-          &remote_addrlen);
-      if (nread > 0) {
-        // Success. We read data off the socekt.
-        Session::increment_total_bytes_read(nread);
-        break;
-      }
-      if (nread == -1) {
-        if (errno == EINTR) {
-          // Interrupted by a signal. Retry.
-          continue;
-        } else if (errno == EAGAIN || errno == EWOULDBLOCK) {
-          if (pkts > 0) {
-            return zret;
-          }
-          bool limited_by_expiry = false;
-          auto &&[poll_timeout, timeout_errata] =
-              expiry_aware_poll_timeout(session, timeout, packet_context, limited_by_expiry);
-          zret.note(std::move(timeout_errata));
-          if (!zret.is_ok()) {
-            return zret;
-          }
-          if (limited_by_expiry && poll_timeout == 0ms) {
-            zret = 0;
-            return zret;
-          }
-          if (have_polled) {
-            // We only poll once in this loop.
-            return zret;
-          }
-          auto &&[poll_return, poll_errata] = session.poll_for_data_on_socket(poll_timeout);
-          have_polled = true;
-          zret.note(std::move(poll_errata));
-          if (!zret.is_ok()) {
-            zret.note(std::move(poll_errata));
-            zret.note(S_ERROR, "Failed to poll for HTTP/3 data.");
-            session.close();
-            zret = -1;
-            return zret;
-          } else if (poll_return > 0) {
-            // Simply repeat the read now that poll says something is ready.
-          } else if (poll_return == 0) {
-            if (limited_by_expiry) {
-              auto &&[handled_expiry, expiry_errata] = handle_expiry(session, packet_context);
-              zret.note(std::move(expiry_errata));
-              if (!zret.is_ok()) {
-                return zret;
-              }
-              if (handled_expiry) {
-                zret = 0;
-                return zret;
-              }
-              zret = 0;
-              return zret;
-            }
-            zret.note(S_ERROR, "Poll timed out waiting to read HTTP/3 content.");
-            session.close();
-            zret = -1;
-            return zret;
-          } else if (poll_return < 0) {
-            // Connection was closed. Nothing to do.
-            zret.note(S_DIAG, "The peer closed the HTTP/3 connection while reading during poll.");
-            zret = 0;
-            return zret;
-          }
-          continue;
-          return zret;
-        } else if (errno == ECONNREFUSED) {
-          zret.note(S_ERROR, "Connection to peer refused.");
-          zret = -1;
-          return zret;
-        } else {
-          zret.note(S_ERROR, "receive_from_packets: unexpected recvfrom() errno: {}", Errno{});
-          session.close();
-          zret = -1;
-          return zret;
-        }
-      }
-    }
-
-    ++pkts;
-    zret.result() += (size_t)nread;
-    auto receive_result = receive_packet(
-        session.quic_socket,
-        buf,
-        (size_t)nread,
-        &remote_addr,
-        remote_addrlen,
-        0,
-        packet_context);
-    if (!receive_result.is_ok()) {
-      zret.note(std::move(receive_result));
-      return zret;
-    }
-  }
-
-  zret.note(S_DIAG, "recvfrom of {} packets with {} bytes", pkts, zret.result());
-  return zret;
-}
-
-static swoc::Rv<int>
-ngtcp2_progress_ingress(H3Session &session, milliseconds timeout, PacketIoContext *packet_context)
-{
-  swoc::Rv<int> zret{-1};
-  constexpr size_t pkts_chunk = 128;
-  constexpr size_t pkts_max = 10 * pkts_chunk;
-
-  PacketIoContext local_packet_context;
-  if (packet_context == nullptr) {
-    packet_context = &local_packet_context;
-  } else {
-    packet_context->ts = timestamp();
-  }
-
-  for (size_t i = 0; i < pkts_max; i += pkts_chunk) {
-    packet_context->pkt_count = 0;
-    auto &&[received_bytes, receive_errata] =
-        receive_packets(session, timeout, pkts_chunk, packet_context);
-    zret.note(std::move(receive_errata));
-    if (!zret.is_ok()) {
-      break;
-    }
-    zret.result() += received_bytes;
-    if (packet_context->pkt_count < pkts_chunk) /* got less than we could */
-      break;
-    /* give egress a chance before we receive more */
-    auto &&[flushed_bytes, flushed_errata] = ngtcp2_progress_egress(session, packet_context);
-    zret.note(std::move(flushed_errata));
-    if (!zret.is_ok()) {
-      break;
-    }
-    zret.result() += flushed_bytes;
-  }
-  return zret;
-}
-
-static swoc::Rv<int>
-ngtcp2_progress_egress(H3Session &session, PacketIoContext *packet_context)
+swoc::Rv<int>
+poll_for_quic(H3Session &session, milliseconds timeout, int ssl_error = SSL_ERROR_WANT_READ)
 {
   swoc::Rv<int> zret{0};
-  auto &qs = session.quic_socket;
-
-  assert(qs.local_addr.is_valid());
-
-  PacketIoContext local_packet_context;
-  if (packet_context == nullptr) {
-    packet_context = &local_packet_context;
-  } else {
-    packet_context->ts = timestamp();
-    ngtcp2_path_storage_zero(&packet_context->ps);
-  }
-  ngtcp2_tstamp ts = packet_context->ts;
-  ngtcp2_path_storage ps;
-  ngtcp2_path_storage_zero(&ps);
-  bool wrote_packet = false;
-
-  // TODO: ouch. Looks like this loop has to change too. See Curl_bufq_sipn.
-  for (;;) {
-    ssize_t veccnt = 0;
-    int64_t stream_id = -1;
-    int fin = 0;
-    nghttp3_vec vec[16];
-
-    if (qs.h3conn && ngtcp2_conn_get_max_data_left(qs.qconn)) {
-      veccnt = nghttp3_conn_writev_stream(
-          qs.h3conn,
-          &stream_id,
-          &fin,
-          vec,
-          sizeof(vec) / sizeof(vec[0]));
-      if (veccnt < 0) {
-        ngtcp2_ccerr_set_application_error(
-            &qs.last_error,
-            nghttp3_err_infer_quic_app_error_code((int)veccnt),
-            NULL,
-            0);
-
-        zret.note(
-            S_ERROR,
-            "nghttp3_conn_writev_stream returned error: {}",
-            Nghttp3Error{(int)veccnt});
-        zret = -1;
-        return zret;
-      }
-    }
-
-    uint32_t flags = NGTCP2_WRITE_STREAM_FLAG_MORE | (fin ? NGTCP2_WRITE_STREAM_FLAG_FIN : 0);
-    uint8_t out[NGTCP2_MAX_PMTUD_UDP_PAYLOAD_SIZE];
-    ssize_t ndatalen = 0;
-    ssize_t outlen = ngtcp2_conn_writev_stream(
-        qs.qconn,
-        &ps.path,
-        nullptr,
-        out,
-        sizeof(out),
-        &ndatalen,
-        flags,
-        stream_id,
-        (const ngtcp2_vec *)vec,
-        veccnt,
-        ts);
-    if (outlen == 0) {
-      // Nothing more to write.
-      break;
-    }
-    if (outlen < 0) {
-      switch (outlen) {
-      case NGTCP2_ERR_STREAM_DATA_BLOCKED: {
-        assert(ndatalen == -1);
-        nghttp3_conn_block_stream(qs.h3conn, stream_id);
-        continue;
-      }
-      case NGTCP2_ERR_STREAM_SHUT_WR: {
-        assert(ndatalen == -1);
-        nghttp3_conn_shutdown_stream_write(qs.h3conn, stream_id);
-        continue;
-      }
-      case NGTCP2_ERR_WRITE_MORE: {
-        assert(ndatalen >= 0);
-        int const rv = nghttp3_conn_add_write_offset(qs.h3conn, stream_id, ndatalen);
-        if (rv != 0) {
-          zret.note(S_ERROR, "nghttp3_conn_add_write_offset returned error: {}", Nghttp3Error{rv});
-          zret = -1;
-          return zret;
-        }
-        continue;
-      }
-      default: {
-        assert(ndatalen == -1);
-        ngtcp2_ccerr_set_liberr(&qs.last_error, (int)outlen, NULL, 0);
-        zret.note(
-            S_ERROR,
-            "ngtcp2_conn_writev_stream returned error: {}",
-            Ngtcp2Error{(int)outlen});
-        zret = -1;
-        return zret;
-      }
-      }
-    } else if (ndatalen >= 0) {
-      int const rv = nghttp3_conn_add_write_offset(qs.h3conn, stream_id, ndatalen);
-      if (rv != 0) {
-        zret.note(S_ERROR, "nghttp3_conn_add_write_offset returned error: {}", Nghttp3Error{rv});
-        zret = -1;
-        return zret;
-      }
-    }
-
-    ssize_t nsent = 0;
-    while ((nsent = ::send(session.get_fd(), (const char *)out, outlen, 0)) == -1) {
-      if (errno == EINTR) {
-        continue;
-      } else if (errno == EAGAIN || errno == EWOULDBLOCK) {
-        auto &&[poll_return, poll_errata] = session.poll_for_data_on_socket(Poll_Timeout, POLLOUT);
-        zret.note(std::move(poll_errata));
-        if (poll_return > 0) {
-          // The socket is available again for writing. Simply repeat the write.
-          continue;
-        } else if (!zret.is_ok()) {
-          zret.note(S_ERROR, "Error polling on a socket to write: {}", swoc::bwf::Errno{});
-          zret = -1;
-          return zret;
-        } else if (poll_return == 0) {
-          zret.note(S_ERROR, "Timed out waiting to write to a socket.");
-          zret = -1;
-          return zret;
-        } else if (poll_return < 0) {
-          zret.note(S_DIAG, "write failed during poll: session is closed");
-          zret = 0;
-          return zret;
-        }
-      } else {
-        zret.note(S_ERROR, "send() failed: {}", swoc::bwf::Errno{});
-        zret = -1;
-        return zret;
-      }
-    }
-    zret.result() += nsent;
-    wrote_packet = true;
-    Session::increment_total_bytes_written(nsent);
-  }
-  if (wrote_packet) {
-    ngtcp2_conn_update_pkt_tx_time(qs.qconn, ts);
+  short events = POLLIN;
+  if (ssl_error == SSL_ERROR_WANT_WRITE || SSL_net_write_desired(session.quic_socket.connection)) {
+    events |= POLLOUT;
   }
 
+  auto &&[poll_result, poll_errata] = session.poll_for_data_on_socket(
+      quic_event_timeout(session.quic_socket.connection, timeout),
+      events);
+  zret = poll_result;
+  zret.note(std::move(poll_errata));
   return zret;
 }
 
-/** Listen on the Session's socket for incoming data and then respond with any
- * resulting packets.
- *
- * Listening on the socket will poll() until data comes in or a timeout is
- * experienced. Writing any packets will not delay if there is nothing to write.
- */
-static Errata
-nghttp3_receive_and_send_data(H3Session &session, milliseconds timeout)
-{
-  Errata errata;
-  PacketIoContext packet_context;
-
-  auto &&[initial_num_bytes_written, initial_egress_errata] =
-      ngtcp2_progress_egress(session, &packet_context);
-  errata.note(std::move(initial_egress_errata));
-  if (!errata.is_ok() || initial_num_bytes_written < 0) {
-    return errata;
-  }
-
-  // This may poll until packets come in to read.
-  auto &&[num_bytes_received, ingress_errata] =
-      ngtcp2_progress_ingress(session, timeout, &packet_context);
-  errata.note(std::move(ingress_errata));
-  if (!errata.is_ok() || num_bytes_received < 0) {
-    return errata;
-  }
-
-  // Write packets that came in from ngtcp2_process_ingress, if there are any.
-  auto &&[num_bytes_written, egress_errata] = ngtcp2_progress_egress(session, &packet_context);
-  errata.note(std::move(egress_errata));
-  if (!errata.is_ok() || num_bytes_written < 0) {
-    return errata;
-  }
-  return errata;
-}
-
-static void
+void
 finalize_h3_stream(int64_t stream_id, H3StreamState &stream_state)
 {
   Errata errata;
 
   if (stream_state.will_receive_request()) {
-    if (stream_state.specified_request && stream_state.specified_request->_content_rule) {
-      if (!stream_state.specified_request->_content_rule
-               ->test(stream_state.key, "body", swoc::TextView(stream_state.body_received)))
-      {
-        errata.note(S_DIAG, R"(Body content did not match expected value.)");
-      }
+    if (stream_state.specified_request && stream_state.specified_request->_content_rule &&
+        !stream_state.specified_request->_content_rule
+             ->test(stream_state.key, "body", TextView(stream_state.body_received)))
+    {
+      errata.note(S_DIAG, R"(Body content did not match expected value.)");
     }
-  } else {
-    if (stream_state.specified_response && stream_state.specified_response->_content_rule) {
-      if (!stream_state.specified_response->_content_rule
-               ->test(stream_state.key, "body", swoc::TextView(stream_state.body_received)))
-      {
-        errata.note(S_DIAG, R"(Body content did not match expected value.)");
-      }
-    }
+  } else if (
+      stream_state.specified_response && stream_state.specified_response->_content_rule &&
+      !stream_state.specified_response->_content_rule
+           ->test(stream_state.key, "body", TextView(stream_state.body_received)))
+  {
+    errata.note(S_DIAG, R"(Body content did not match expected value.)");
   }
 
-  auto const &message_start = stream_state.stream_start;
-  auto const message_end = ClockType::now();
-  auto const elapsed_ms = duration_cast<milliseconds>(message_end - message_start);
+  auto const elapsed_ms = duration_cast<milliseconds>(ClockType::now() - stream_state.stream_start);
   if (elapsed_ms > Transaction_Delay_Cutoff) {
     errata.note(
         S_ERROR,
@@ -1074,61 +126,49 @@ finalize_h3_stream(int64_t stream_id, H3StreamState &stream_state)
   }
 }
 
-// --------------------------------------------
-// Begin nghttp3 callbacks.
-// --------------------------------------------
-
-/** Called to populate data frames of a request or response.
- *
- * @return The number of objects populated in vec.
- */
-static ssize_t
+ssize_t
 cb_h3_readfunction(
-    nghttp3_conn * /* conn */,
+    nghttp3_conn *,
     int64_t stream_id,
     nghttp3_vec *vec,
-    size_t /* veccnt */,
+    size_t,
     uint32_t *pflags,
-    void * /* conn_data */,
+    void *,
     void *stream_user_data)
 {
   Errata errata;
-  auto *stream_state = reinterpret_cast<H3StreamState *>(stream_user_data);
+  auto *stream_state = static_cast<H3StreamState *>(stream_user_data);
 
   if (stream_state->wait_for_continue) {
     errata.note(S_DIAG, R"(Not sending HTTP/3 body for "Expect: 100" request.)");
     *pflags = NGHTTP3_DATA_FLAG_EOF;
     return 0;
   }
-  vec[0].base = (uint8_t *)stream_state->body_to_send.data();
 
-  auto const body_size = stream_state->body_to_send.size();
-  vec[0].len = body_size;
-  stream_state->num_data_bytes_written += body_size;
-
+  vec[0].base = reinterpret_cast<uint8_t *>(const_cast<char *>(stream_state->body_to_send.data()));
+  vec[0].len = stream_state->body_to_send.size();
+  stream_state->num_data_bytes_written += vec[0].len;
   *pflags = NGHTTP3_DATA_FLAG_EOF;
   errata.note(
       S_DIAG,
       "Sent an HTTP/3 body of {} bytes for key {} of stream id {}:\n{}",
-      body_size,
+      vec[0].len,
       stream_state->key,
       stream_id,
-      TextView{stream_state->body_to_send.data(), body_size});
-
+      TextView{stream_state->body_to_send.data(), vec[0].len});
   return 1;
 }
 
-/* this amount of data has now been acked on this stream */
-static int
+int
 cb_h3_acked_stream_data(
-    nghttp3_conn * /* conn */,
+    nghttp3_conn *,
     int64_t stream_id,
     uint64_t datalen,
-    void * /* conn_user_data */,
+    void *,
     void *stream_user_data)
 {
   Errata errata;
-  auto *stream_state = reinterpret_cast<H3StreamState *>(stream_user_data);
+  auto *stream_state = static_cast<H3StreamState *>(stream_user_data);
   auto const outstanding_bytes = stream_state->num_data_bytes_written;
   errata.note(
       S_DIAG,
@@ -1138,72 +178,45 @@ cb_h3_acked_stream_data(
       outstanding_bytes);
 
   if (datalen >= outstanding_bytes) {
-    if (datalen > outstanding_bytes) {
-      errata.note(
-          S_DIAG,
-          "HTTP/3 stream with id {} and key {} acked more bytes ({}) than remain "
-          "outstanding ({}). Treating the body as fully acknowledged.",
-          stream_id,
-          stream_state->key,
-          datalen,
-          outstanding_bytes);
-    }
     stream_state->num_data_bytes_written = 0;
   } else {
     stream_state->num_data_bytes_written -= datalen;
   }
-
-  if (stream_state->num_data_bytes_written == 0) {
-    errata.note(
-        S_DIAG,
-        "HTTP/3 stream with id {} and key {} has no outstanding body bytes",
-        stream_id,
-        stream_state->key);
-  }
   return 0;
 }
 
-static int
+int
 cb_h3_stream_close(
-    nghttp3_conn * /* conn */,
+    nghttp3_conn *,
     int64_t stream_id,
-    uint64_t /* app_error_code */,
+    uint64_t,
     void *conn_user_data,
     void *stream_user_data)
 {
-  Errata errata;
-
-  auto *session = reinterpret_cast<H3Session *>(conn_user_data);
+  auto *session = static_cast<H3Session *>(conn_user_data);
   auto iter = session->stream_map.find(stream_id);
   if (iter == session->stream_map.end()) {
-    if (session->clear_completed_response_stream(stream_id)) {
-      return 0;
-    }
+    session->clear_completed_response_stream(stream_id);
     return 0;
   }
-  auto &stream_state = *reinterpret_cast<H3StreamState *>(stream_user_data);
+
+  auto &stream_state = *static_cast<H3StreamState *>(stream_user_data);
   finalize_h3_stream(stream_id, stream_state);
-
-  session->stream_map.erase(stream_id);
-
-  /* make sure that ngh3_stream_recv is called again to complete the transfer
-   * even if there are no more packets to be received from the server. */
-  errata.note(nghttp3_receive_and_send_data(*session, Poll_Timeout));
+  session->stream_map.erase(iter);
   return 0;
 }
 
-static int
+int
 cb_h3_recv_data(
-    nghttp3_conn * /* conn */,
+    nghttp3_conn *,
     int64_t stream_id,
-    const uint8_t *buf,
+    uint8_t const *buf,
     size_t buflen,
-    void *conn_user_data,
+    void *,
     void *stream_user_data)
 {
   Errata errata;
-  auto *h3_session = reinterpret_cast<H3Session *>(conn_user_data);
-  auto *stream_state = reinterpret_cast<H3StreamState *>(stream_user_data);
+  auto *stream_state = static_cast<H3StreamState *>(stream_user_data);
   errata.note(
       S_DIAG,
       "Received an HTTP/3 body of {} bytes for transaction with key {}, "
@@ -1212,47 +225,33 @@ cb_h3_recv_data(
       stream_state->key,
       stream_id,
       TextView(reinterpret_cast<char const *>(buf), buflen));
-  stream_state->body_received += std::string(reinterpret_cast<char const *>(buf), buflen);
-
-  auto &qs = h3_session->quic_socket;
-  ngtcp2_conn_extend_max_stream_offset(qs.qconn, stream_id, buflen);
-  ngtcp2_conn_extend_max_offset(qs.qconn, buflen);
-
+  stream_state->body_received.append(reinterpret_cast<char const *>(buf), buflen);
   return 0;
 }
 
-static int
-cb_h3_deferred_consume(
-    nghttp3_conn * /* conn */,
-    int64_t stream_id,
-    size_t consumed,
-    void *conn_user_data,
-    void * /* stream_user_data */)
+int
+cb_h3_deferred_consume(nghttp3_conn *, int64_t, size_t, void *, void *)
 {
-  auto *h3_session = reinterpret_cast<H3Session *>(conn_user_data);
-  auto &qs = h3_session->quic_socket;
-
-  ngtcp2_conn_extend_max_stream_offset(qs.qconn, stream_id, consumed);
-  ngtcp2_conn_extend_max_offset(qs.qconn, consumed);
+  // OpenSSL manages QUIC flow-control credit internally.
   return 0;
 }
 
-static int
+int
 cb_h3_recv_header(
-    nghttp3_conn * /* conn */,
-    int64_t /* stream_id */,
-    int32_t /* token */,
+    nghttp3_conn *,
+    int64_t,
+    int32_t,
     nghttp3_rcbuf *name,
     nghttp3_rcbuf *value,
-    uint8_t /* flags */,
-    void * /* conn_user_data */,
+    uint8_t,
+    void *,
     void *stream_user_data)
 {
-  auto *stream_state = reinterpret_cast<H3StreamState *>(stream_user_data);
+  auto *stream_state = static_cast<H3StreamState *>(stream_user_data);
   stream_state->have_received_headers = true;
 
-  TextView name_view = stream_state->register_rcbuf(name);
-  TextView value_view = stream_state->register_rcbuf(value);
+  TextView const name_view = stream_state->register_rcbuf(name);
+  TextView const value_view = stream_state->register_rcbuf(value);
 
   if (stream_state->will_receive_request()) {
     auto &request_headers = stream_state->request_from_client;
@@ -1266,35 +265,31 @@ cb_h3_recv_header(
       request_headers->_path = value_view;
     }
     request_headers->_fields_rules->add_field(name_view, value_view);
-  } else { // stream_state receives a response.
+  } else {
     auto &response_headers = stream_state->response_from_server;
     if (name_view == ":status") {
       response_headers->_status = swoc::svtou(value_view);
       response_headers->_status_string = std::string(value_view);
-    }
-    response_headers->_fields_rules->add_field(name_view, value_view);
-    // See if we are expecting a 100 response.
-    if (stream_state->wait_for_continue) {
-      if (name_view == ":status" && value_view == "100") {
-        // We got our 100 Continue. No need to wait for it anymore.
+      if (stream_state->wait_for_continue && value_view == "100") {
         stream_state->wait_for_continue = false;
       }
     }
+    response_headers->_fields_rules->add_field(name_view, value_view);
   }
   return 0;
 }
 
-static int
+int
 cb_h3_end_headers(
-    nghttp3_conn * /* conn */,
+    nghttp3_conn *,
     int64_t stream_id,
-    int /* fin */,
+    int,
     void *conn_user_data,
     void *stream_user_data)
 {
   Errata errata;
-  auto *session_data = reinterpret_cast<H3Session *>(conn_user_data);
-  auto *stream_state = reinterpret_cast<H3StreamState *>(stream_user_data);
+  auto *session = static_cast<H3Session *>(conn_user_data);
+  auto *stream_state = static_cast<H3StreamState *>(stream_user_data);
   if (stream_state->will_receive_request()) {
     auto &request_from_client = *stream_state->request_from_client;
     request_from_client.derive_key();
@@ -1311,8 +306,7 @@ cb_h3_end_headers(
             request_from_client._fields_rules->_fields.find(HttpHeader::FIELD_CONTENT_LENGTH)};
         spot != request_from_client._fields_rules->_fields.end())
     {
-      size_t expected_size = swoc::svtou(spot->second);
-      stream_state->body_received.reserve(expected_size);
+      stream_state->body_received.reserve(swoc::svtou(spot->second));
     }
     errata.note(
         S_DIAG,
@@ -1320,13 +314,10 @@ cb_h3_end_headers(
         stream_state->key,
         stream_id,
         request_from_client);
-  } else { // stream_state receives a response
+  } else {
     auto &response_from_wire = *stream_state->response_from_server;
     response_from_wire.derive_key();
     if (stream_state->key.empty()) {
-      // A response for which we didn't process the request, presumably. A
-      // server push? Maybe? In theory we can support that but currently we
-      // do not. Emit a warning for now.
       stream_state->key = response_from_wire.get_key();
       errata.note(
           S_ERROR,
@@ -1334,20 +325,13 @@ cb_h3_end_headers(
           "response: {}.",
           stream_state->key);
     } else {
-      // Make sure the key is set and give preference to the associated
-      // request over the content of the response. There shouldn't be a
-      // difference, but if there is, the user has the YAML file with the
-      // request's key in front of them, and identifying that transaction
-      // is more helpful than so some abberant response's key from the
-      // wire. If they are looking into issues, debug logging will show
-      // the fields of both the request and response.
       response_from_wire.set_key(stream_state->key);
     }
+
     if (auto spot{response_from_wire._fields_rules->_fields.find(HttpHeader::FIELD_CONTENT_LENGTH)};
         spot != response_from_wire._fields_rules->_fields.end())
     {
-      size_t expected_size = swoc::svtou(spot->second);
-      stream_state->body_received.reserve(expected_size);
+      stream_state->body_received.reserve(swoc::svtou(spot->second));
     }
     errata.note(
         S_DIAG,
@@ -1355,26 +339,27 @@ cb_h3_end_headers(
         stream_state->key,
         stream_id,
         response_from_wire);
-    auto const &key = stream_state->key;
-    auto const &specified_response = stream_state->specified_response;
-    if (specified_response) {
+
+    auto const *specified_response = stream_state->specified_response;
+    if (specified_response != nullptr) {
       specified_response->mark_verification_performed();
-    }
-    if (response_from_wire.verify_headers(key, *specified_response->_fields_rules)) {
-      errata.note(S_ERROR, R"(HTTP/3 response headers did not match expected response headers.)");
-      session_data->set_non_zero_exit_status();
-    }
-    if (specified_response->_status != 0 &&
-        response_from_wire._status != specified_response->_status &&
-        (response_from_wire._status != 200 || specified_response->_status != 304) &&
-        (response_from_wire._status != 304 || specified_response->_status != 200))
-    {
-      errata.note(
-          S_ERROR,
-          R"(HTTP/3 Status Violation: expected {} got {}, key: {}.)",
-          specified_response->_status,
-          response_from_wire._status,
-          key);
+      if (response_from_wire.verify_headers(stream_state->key, *specified_response->_fields_rules))
+      {
+        errata.note(S_ERROR, R"(HTTP/3 response headers did not match expected response headers.)");
+        session->set_non_zero_exit_status();
+      }
+      if (specified_response->_status != 0 &&
+          response_from_wire._status != specified_response->_status &&
+          (response_from_wire._status != 200 || specified_response->_status != 304) &&
+          (response_from_wire._status != 304 || specified_response->_status != 200))
+      {
+        errata.note(
+            S_ERROR,
+            R"(HTTP/3 Status Violation: expected {} got {}, key: {}.)",
+            specified_response->_status,
+            response_from_wire._status,
+            stream_state->key);
+      }
     }
   }
 
@@ -1384,28 +369,21 @@ cb_h3_end_headers(
   return 0;
 }
 
-static int
-cb_h3_end_stream(
-    nghttp3_conn * /* conn */,
-    int64_t stream_id,
-    void *conn_user_data,
-    void *stream_user_data)
+int
+cb_h3_end_stream(nghttp3_conn *, int64_t stream_id, void *conn_user_data, void *stream_user_data)
 {
   Errata errata;
-  auto *session_data = reinterpret_cast<H3Session *>(conn_user_data);
-  auto *stream_state = reinterpret_cast<H3StreamState *>(stream_user_data);
+  auto *session = static_cast<H3Session *>(conn_user_data);
+  auto *stream_state = static_cast<H3StreamState *>(stream_user_data);
   std::string key;
   if (stream_state->will_receive_request()) {
     auto &request_from_client = *stream_state->request_from_client;
     request_from_client.derive_key();
     key = request_from_client.get_key();
-  } else { // stream_state receives a response
+  } else {
     auto &response_from_wire = *stream_state->response_from_server;
     response_from_wire.derive_key();
     if (stream_state->key.empty()) {
-      // A response for which we didn't process the request, presumably. A
-      // server push? Maybe? In theory we can support that but currently we
-      // do not. Emit a warning for now.
       stream_state->key = response_from_wire.get_key();
       errata.note(
           S_ERROR,
@@ -1413,646 +391,453 @@ cb_h3_end_stream(
           "response: {}.",
           stream_state->key);
     } else {
-      // Make sure the key is set and give preference to the associated
-      // request over the content of the response. There shouldn't be a
-      // difference, but if there is, the user has the YAML file with the
-      // request's key in front of them, and identifying that transaction
-      // is more helpful than so some abberant response's key from the
-      // wire. If they are looking into issues, debug logging will show
-      // the fields of both the request and response.
       response_from_wire.set_key(stream_state->key);
     }
     key = stream_state->key;
   }
-  session_data->set_stream_has_ended(stream_id, key);
+
+  session->set_stream_has_ended(stream_id, key);
   if (stream_state->will_receive_response()) {
     finalize_h3_stream(stream_id, *stream_state);
-    session_data->stream_map.erase(stream_id);
-    session_data->mark_completed_response_stream(stream_id);
+    session->stream_map.erase(stream_id);
+    session->mark_completed_response_stream(stream_id);
   }
   return 0;
 }
 
-static int
+int
 cb_h3_send_stop_sending(
-    nghttp3_conn * /* conn */,
-    int64_t /* stream_id */,
-    uint64_t /* app_error_code */,
-    void * /* conn_user_data */,
-    void * /* stream_user_data */)
+    nghttp3_conn *,
+    int64_t stream_id,
+    uint64_t app_error_code,
+    void *conn_user_data,
+    void *)
 {
-  // The nghttp3 API is telling us to tell the QUIC stack to send a
-  // STOP_SENDING frame here. That is currently not implemented.
-  Errata errata;
-  errata.note(
-      S_ERROR,
-      "Got a STOP_SENDING request from nghttp3. Proxy Verifier does not implement this.");
+  auto *session = static_cast<H3Session *>(conn_user_data);
+  auto *stream = session->quic_socket.find_stream(stream_id);
+  if (stream == nullptr) {
+    return 0;
+  }
+
+  SSL_STREAM_RESET_ARGS args{.quic_error_code = app_error_code};
+  if (SSL_stream_reset(stream, &args, sizeof(args)) != 1) {
+    Errata errata;
+    errata.note(S_ERROR, "Failed to reset HTTP/3 stream {}: {}", stream_id, swoc::bwf::SSLError{});
+    return NGHTTP3_ERR_CALLBACK_FAILURE;
+  }
   return 0;
 }
 
-static int
+int
 cb_h3_reset_stream(
-    nghttp3_conn * /* conn */,
+    nghttp3_conn *,
     int64_t stream_id,
     uint64_t app_error_code,
     void *conn_user_data,
     void *stream_user_data)
 {
-  auto *h3_session = reinterpret_cast<H3Session *>(conn_user_data);
-  auto &qs = h3_session->quic_socket;
-  auto *stream_state = reinterpret_cast<H3StreamState *>(stream_user_data);
-  Errata errata;
+  auto *session = static_cast<H3Session *>(conn_user_data);
+  auto *stream_state = static_cast<H3StreamState *>(stream_user_data);
+  auto *stream = session->quic_socket.find_stream(stream_id);
+  if (stream == nullptr) {
+    return 0;
+  }
 
-  int rv = ngtcp2_conn_shutdown_stream_write(qs.qconn, 0, stream_id, app_error_code);
+  SSL_STREAM_RESET_ARGS args{.quic_error_code = app_error_code};
+  auto const result = SSL_stream_reset(stream, &args, sizeof(args));
+  Errata errata;
   errata.note(
       S_DIAG,
-      "Received an HTTP/3 reset stream for key {} with stream id {}, app error code {} rv {}",
-      stream_state->key,
+      "Received an HTTP/3 reset stream for key {} with stream id {}, app error code {} "
+      "result {}",
+      stream_state == nullptr ? "" : stream_state->key,
       stream_id,
       app_error_code,
-      rv);
-  if (rv && rv != NGTCP2_ERR_STREAM_NOT_FOUND) {
-    return NGTCP2_ERR_CALLBACK_FAILURE;
-  }
-
-  return 0;
+      result);
+  return result == 1 ? 0 : NGHTTP3_ERR_CALLBACK_FAILURE;
 }
 
-static nghttp3_callbacks nghttp3_client_callbacks = {
-    cb_h3_acked_stream_data,
-    cb_h3_stream_close,
-    cb_h3_recv_data,
-    cb_h3_deferred_consume,
-    nullptr, /* begin_headers */
-    cb_h3_recv_header,
-    cb_h3_end_headers,
-    nullptr, /* begin_trailers */
-    cb_h3_recv_header,
-    nullptr, /* end_trailers */
-    cb_h3_send_stop_sending,
-    cb_h3_end_stream,
-    cb_h3_reset_stream,
-    nullptr, /* shutdown */
-    nullptr, /* rcv_settings */
-    nullptr, /* recv_origin */
-    nullptr, /* end_origin */
-    nullptr, /* rand */
-    nullptr, /* recv_settings2 */
-};
-// -----------------------------------------------------
-// End nghttp3 callbacks.
-// When comparing with curl:
-//  * H3Session session corresponds with Curl_cfilter cf.
-//  * h3settings corresponds with h3conn.
-// -----------------------------------------------------
+nghttp3_callbacks const NGHTTP3_CLIENT_CALLBACKS = [] {
+  nghttp3_callbacks callbacks{};
+  callbacks.acked_stream_data = cb_h3_acked_stream_data;
+  callbacks.stream_close = cb_h3_stream_close;
+  callbacks.recv_data = cb_h3_recv_data;
+  callbacks.deferred_consume = cb_h3_deferred_consume;
+  callbacks.recv_header = cb_h3_recv_header;
+  callbacks.end_headers = cb_h3_end_headers;
+  callbacks.recv_trailer = cb_h3_recv_header;
+  callbacks.stop_sending = cb_h3_send_stop_sending;
+  callbacks.end_stream = cb_h3_end_stream;
+  callbacks.reset_stream = cb_h3_reset_stream;
+  return callbacks;
+}();
 
-static int
-initialize_nghttp3_connection(H3Session *session)
+swoc::Rv<bool>
+progress_http3_egress(H3Session &session)
 {
-  Errata errata;
-  auto &qs = session->quic_socket;
-  int64_t ctrl_stream_id = 0;
-  int64_t qpack_enc_stream_id = 0;
-  int64_t qpack_dec_stream_id = 0;
+  swoc::Rv<bool> zret{false};
+  auto &quic_socket = session.quic_socket;
 
-  if (qs.h3conn != nullptr) {
-    return SUCCEEDED;
+  std::vector<int64_t> pending_concludes{
+      quic_socket.streams_pending_conclude.begin(),
+      quic_socket.streams_pending_conclude.end()};
+  for (auto const stream_id : pending_concludes) {
+    auto *stream = quic_socket.find_stream(stream_id);
+    if (stream == nullptr) {
+      quic_socket.streams_pending_conclude.erase(stream_id);
+      continue;
+    }
+    auto const conclude_result = SSL_stream_conclude(stream, 0);
+    if (conclude_result == 1) {
+      quic_socket.streams_pending_conclude.erase(stream_id);
+      quic_socket.streams_concluded.insert(stream_id);
+      zret = true;
+      continue;
+    }
+    auto const ssl_error = SSL_get_error(stream, conclude_result);
+    if (ssl_error != SSL_ERROR_WANT_READ && ssl_error != SSL_ERROR_WANT_WRITE) {
+      zret.note(
+          S_ERROR,
+          "Failed to conclude HTTP/3 stream {}: {}",
+          stream_id,
+          swoc::bwf::SSLError{});
+      return zret;
+    }
   }
 
-  auto const max_streams = ngtcp2_conn_get_streams_uni_left(qs.qconn);
-  if (max_streams < 3) {
-    errata.note(S_ERROR, "Too few max streams: {}", max_streams);
-    return 1;
+  for (;;) {
+    std::array<nghttp3_vec, MAX_HTTP3_VECTORS> vectors;
+    int64_t stream_id = -1;
+    int fin = 0;
+    auto const vector_count = nghttp3_conn_writev_stream(
+        quic_socket.h3conn,
+        &stream_id,
+        &fin,
+        vectors.data(),
+        vectors.size());
+    if (vector_count < 0) {
+      zret.note(
+          S_ERROR,
+          "nghttp3_conn_writev_stream failed: {} ({})",
+          nghttp3_error(vector_count),
+          vector_count);
+      return zret;
+    }
+    if (stream_id == -1) {
+      return zret;
+    }
+
+    auto *stream = quic_socket.find_stream(stream_id);
+    if (stream == nullptr) {
+      zret.note(S_ERROR, "nghttp3 selected unknown QUIC stream {} for writing.", stream_id);
+      return zret;
+    }
+
+    nghttp3_ssize vector_index = 0;
+    while (vector_index < vector_count && vectors[static_cast<size_t>(vector_index)].len == 0) {
+      ++vector_index;
+    }
+
+    bool can_conclude = fin != 0;
+    size_t accepted = 0;
+    if (vector_index < vector_count) {
+      auto const &vector = vectors[static_cast<size_t>(vector_index)];
+      size_t written = 0;
+      auto const result = SSL_write_ex(stream, vector.base, vector.len, &written);
+      if (result != 1) {
+        auto const ssl_error = SSL_get_error(stream, result);
+        if (ssl_error == SSL_ERROR_WANT_READ || ssl_error == SSL_ERROR_WANT_WRITE) {
+          return zret;
+        }
+        zret.note(
+            S_ERROR,
+            "Failed writing HTTP/3 stream {}: SSL error {}, {}",
+            stream_id,
+            ssl_error,
+            swoc::bwf::SSLError{});
+        return zret;
+      }
+      if (written == 0) {
+        return zret;
+      }
+
+      accepted = written;
+      Session::increment_total_bytes_written(written);
+      auto const write_result =
+          nghttp3_conn_add_write_offset(quic_socket.h3conn, stream_id, written);
+      // OpenSSL copies accepted stream bytes into its QUIC send buffers. It
+      // does not expose per-stream acknowledgement callbacks, so accepted
+      // bytes can immediately be released by nghttp3.
+      auto const ack_result = nghttp3_conn_add_ack_offset(quic_socket.h3conn, stream_id, written);
+      if (write_result != 0 || ack_result != 0) {
+        zret.note(
+            S_ERROR,
+            "Failed to update nghttp3 offsets for stream {}: write {}, ack {}.",
+            stream_id,
+            write_result,
+            ack_result);
+        return zret;
+      }
+      zret = true;
+
+      can_conclude = can_conclude && written == vector.len;
+      for (++vector_index; vector_index < vector_count; ++vector_index) {
+        if (vectors[static_cast<size_t>(vector_index)].len != 0) {
+          can_conclude = false;
+          break;
+        }
+      }
+      if (!can_conclude) {
+        continue;
+      }
+    }
+
+    if (can_conclude &&
+        quic_socket.streams_concluded.find(stream_id) == quic_socket.streams_concluded.end())
+    {
+      auto const conclude_result = SSL_stream_conclude(stream, 0);
+      if (conclude_result == 1) {
+        quic_socket.streams_concluded.insert(stream_id);
+        zret = true;
+      } else {
+        auto const ssl_error = SSL_get_error(stream, conclude_result);
+        if (ssl_error == SSL_ERROR_WANT_READ || ssl_error == SSL_ERROR_WANT_WRITE) {
+          quic_socket.streams_pending_conclude.insert(stream_id);
+          return zret;
+        }
+        zret.note(
+            S_ERROR,
+            "Failed to conclude HTTP/3 stream {} after accepting {} bytes: {}",
+            stream_id,
+            accepted,
+            swoc::bwf::SSLError{});
+        return zret;
+      }
+    }
   }
-
-  nghttp3_settings_default(&qs.h3settings);
-
-  int rc = nghttp3_conn_client_new(
-      &qs.h3conn,
-      &nghttp3_client_callbacks,
-      &qs.h3settings,
-      nghttp3_mem_default(),
-      session);
-  if (rc != 0) {
-    errata.note(S_ERROR, "nghttp3_conn_client_new failed: {}", Ngtcp2Error{rc});
-    return FAILED;
-  }
-
-  rc = ngtcp2_conn_open_uni_stream(qs.qconn, &ctrl_stream_id, nullptr);
-  if (rc != 0) {
-    errata.note(S_ERROR, "ngtcp2_conn_open_uni_stream failed: {}", Ngtcp2Error{rc});
-    return FAILED;
-  }
-
-  rc = nghttp3_conn_bind_control_stream(qs.h3conn, ctrl_stream_id);
-  if (rc != 0) {
-    errata.note(S_ERROR, "nghttp3_conn_bind_control_stream failed: {}", Ngtcp2Error{rc});
-    return FAILED;
-  }
-
-  rc = ngtcp2_conn_open_uni_stream(qs.qconn, &qpack_enc_stream_id, nullptr);
-  if (rc != 0) {
-    errata.note(S_ERROR, "ngtcp2_conn_open_uni_stream failed: {}", Ngtcp2Error{rc});
-    return FAILED;
-  }
-
-  rc = ngtcp2_conn_open_uni_stream(qs.qconn, &qpack_dec_stream_id, nullptr);
-  if (rc != 0) {
-    errata.note(S_ERROR, "ngtcp2_conn_open_uni_stream failed: {}", Ngtcp2Error{rc});
-    return FAILED;
-  }
-
-  rc = nghttp3_conn_bind_qpack_streams(qs.h3conn, qpack_enc_stream_id, qpack_dec_stream_id);
-  if (rc != 0) {
-    errata.note(S_ERROR, "nghttp3_conn_bind_qpack_streams failed: {}", Ngtcp2Error{rc});
-    return FAILED;
-  }
-
-  return SUCCEEDED;
 }
 
-static void
-configure_quic_socket_settings(QuicSocket &qs, PacketIoContext *packet_context)
+swoc::Rv<bool>
+progress_http3_ingress(H3Session &session)
 {
-  ngtcp2_settings *s = &qs.settings;
-  ngtcp2_transport_params *t = &qs.transport_params;
-  ngtcp2_settings_default(s);
-  ngtcp2_transport_params_default(t);
-#ifdef DEBUG_NGTCP2
-  s->log_printf = quic_printf;
-#else
-  s->log_printf = nullptr;
-#endif
-  s->initial_ts = packet_context->ts;
-  s->handshake_timeout = duration_cast<nanoseconds>(QUIC_HANDSHAKE_TIMEOUT).count();
-  s->max_window = 100 * H3_STREAM_WINDOW_SIZE;
-  s->max_stream_window = H3_STREAM_WINDOW_SIZE;
+  swoc::Rv<bool> zret{false};
+  auto &quic_socket = session.quic_socket;
+  while (auto *stream = SSL_accept_stream(quic_socket.connection, SSL_ACCEPT_STREAM_NO_BLOCK)) {
+    quic_socket.add_stream(stream);
+    zret = true;
+  }
 
-  t->initial_max_data = 10 * H3_STREAM_WINDOW_SIZE;
-  t->initial_max_stream_data_bidi_local = H3_STREAM_WINDOW_SIZE;
-  t->initial_max_stream_data_bidi_remote = H3_STREAM_WINDOW_SIZE;
-  t->initial_max_stream_data_uni = H3_STREAM_WINDOW_SIZE;
-  t->initial_max_streams_bidi = QUIC_MAX_STREAMS;
-  t->initial_max_streams_uni = QUIC_MAX_STREAMS;
-  t->max_idle_timeout = duration_cast<nanoseconds>(QUIC_IDLE_TIMEOUT).count();
-  if (qs.qlogfd != -1) {
-    s->qlog_write = QuicSocket::qlog_callback;
+  std::array<uint8_t, QUIC_STREAM_BUFFER_SIZE> buffer;
+  for (auto const &[stream_id, stream] : quic_socket.streams) {
+    if ((SSL_get_stream_type(stream) & SSL_STREAM_TYPE_READ) == 0 ||
+        quic_socket.streams_with_fin.find(stream_id) != quic_socket.streams_with_fin.end())
+    {
+      continue;
+    }
+
+    for (;;) {
+      size_t bytes_read = 0;
+      auto const result = SSL_read_ex(stream, buffer.data(), buffer.size(), &bytes_read);
+      if (result == 1) {
+        Session::increment_total_bytes_read(bytes_read);
+        auto const consumed =
+            nghttp3_conn_read_stream(quic_socket.h3conn, stream_id, buffer.data(), bytes_read, 0);
+        if (consumed < 0) {
+          zret.note(
+              S_ERROR,
+              "nghttp3_conn_read_stream failed for stream {}: {} ({})",
+              stream_id,
+              nghttp3_error(consumed),
+              consumed);
+          return zret;
+        }
+        zret = true;
+        continue;
+      }
+
+      auto const ssl_error = SSL_get_error(stream, result);
+      if (ssl_error == SSL_ERROR_WANT_READ || ssl_error == SSL_ERROR_WANT_WRITE) {
+        break;
+      }
+      if (ssl_error == SSL_ERROR_ZERO_RETURN) {
+        auto const consumed =
+            nghttp3_conn_read_stream(quic_socket.h3conn, stream_id, nullptr, 0, 1);
+        if (consumed < 0) {
+          zret.note(
+              S_ERROR,
+              "nghttp3 failed to process FIN on stream {}: {} ({})",
+              stream_id,
+              nghttp3_error(consumed),
+              consumed);
+          return zret;
+        }
+        quic_socket.streams_with_fin.insert(stream_id);
+        zret = true;
+        break;
+      }
+
+      zret.note(
+          S_ERROR,
+          "Failed reading HTTP/3 stream {}: SSL error {}, {}",
+          stream_id,
+          ssl_error,
+          swoc::bwf::SSLError{});
+      return zret;
+    }
+  }
+  return zret;
+}
+
+swoc::Rv<bool>
+progress_http3(H3Session &session, milliseconds timeout)
+{
+  swoc::Rv<bool> zret{false};
+  auto const deadline = ClockType::now() + timeout;
+
+  for (;;) {
+    auto &&[egress_progress, egress_errata] = progress_http3_egress(session);
+    zret.note(std::move(egress_errata));
+    if (!zret.is_ok()) {
+      return zret;
+    }
+
+    if (SSL_handle_events(session.quic_socket.connection) != 1) {
+      zret.note(S_ERROR, "SSL_handle_events failed: {}", swoc::bwf::SSLError{});
+      return zret;
+    }
+
+    auto &&[ingress_progress, ingress_errata] = progress_http3_ingress(session);
+    zret.note(std::move(ingress_errata));
+    if (!zret.is_ok()) {
+      return zret;
+    }
+
+    auto &&[final_egress_progress, final_egress_errata] = progress_http3_egress(session);
+    zret.note(std::move(final_egress_errata));
+    if (!zret.is_ok()) {
+      return zret;
+    }
+
+    if (egress_progress || ingress_progress || final_egress_progress) {
+      zret = true;
+      return zret;
+    }
+    if (timeout <= 0ms || ClockType::now() >= deadline) {
+      return zret;
+    }
+
+    auto const remaining = duration_cast<milliseconds>(deadline - ClockType::now());
+    auto &&[poll_result, poll_errata] = poll_for_quic(session, remaining);
+    zret.note(std::move(poll_errata));
+    if (!zret.is_ok() || poll_result < 0) {
+      zret.note(S_ERROR, "Failed polling the OpenSSL QUIC socket.");
+      return zret;
+    }
   }
 }
 
-QuicSocket::QuicSocket()
-{
-  // Zero out all of our data so that if it gets uses uninitialized by mistake
-  // at least it will fail early and consistently.
-  memset(&dcid, 0, sizeof(dcid));
-  memset(&scid, 0, sizeof(scid));
-  memset(&settings, 0, sizeof(settings));
-  memset(&transport_params, 0, sizeof(transport_params));
-  memset(&h3settings, 0, sizeof(h3settings));
-  memset(&conn_ref, 0, sizeof(conn_ref));
-  memset(&last_error, 0, sizeof(last_error));
-}
+} // namespace
+
+swoc::file::path QuicSocket::m_qlog_dir;
+SSL_CTX *H3Session::m_h3_client_context = nullptr;
+SSL_CTX *H3Session::m_h3_server_context = nullptr;
+int *H3Session::m_process_exit_code = nullptr;
 
 QuicSocket::~QuicSocket()
 {
-  if (qlogfd != -1) {
-    ::close(qlogfd);
-  }
-  qlogfd = -1;
-  if (ssl != nullptr) {
-    SSL_set_app_data(ssl, nullptr);
-    SSL_free(ssl);
-  }
-  ssl = nullptr;
-  if (ossl_ctx != nullptr) {
-    ngtcp2_crypto_ossl_ctx_del(ossl_ctx);
-  }
-  ossl_ctx = nullptr;
-  ngtcp2_conn_del(qconn);
-  nghttp3_conn_del(h3conn);
+  reset();
 }
 
-Errata
-QuicSocket::open_qlog_file()
-{
-  Errata errata;
-  qlogfd = -1;
-  if (_qlog_dir.empty()) {
-    return errata;
-  }
-
-  if (scid.datalen == 0) {
-    errata.note(S_ERROR, "QUIC logging is configured, but scid was not set for this connection.");
-    return errata;
-  }
-  swoc::file::path qlog_path{_qlog_dir};
-  std::string qlog_filename;
-  for (auto i = 0u; i < scid.datalen; ++i) {
-    // Two hex digits to represent each byte followed by a NULL-terminator.
-    char hex[3];
-    snprintf(hex, sizeof(hex), "%02x", scid.data[i]);
-    qlog_filename += std::string{hex, strlen(hex)};
-  }
-  qlog_filename += std::string{".qlog"};
-  qlog_path /= std::string_view{qlog_filename};
-
-  qlogfd = ::open(qlog_path.c_str(), O_WRONLY | O_CREAT, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
-
-  if (qlogfd < 0) {
-    errata.note(S_ERROR, "Failed to open QUIC log at {}: {}", qlog_path, Errno{});
-    return errata;
-  }
-  errata.note(S_DIAG, "Writing QUIC log to: {}", qlog_path);
-  return errata;
-}
-
-// static
 void
-QuicSocket::qlog_callback(void *user_data, uint32_t flags, const void *data, size_t datalen)
+QuicSocket::reset()
 {
-  Errata errata;
-  H3Session *h3_session = reinterpret_cast<H3Session *>(user_data);
-  QuicSocket &qs = h3_session->quic_socket;
-  if (qs.qlogfd == -1) {
-    // Likely a previous write has failed and the log was closed.
-    return;
+  if (h3conn != nullptr) {
+    nghttp3_conn_del(h3conn);
+    h3conn = nullptr;
   }
-  std::scoped_lock _{_qlog_mutex};
-  ssize_t rc = ::write(qs.qlogfd, data, datalen);
-  if (rc == -1) {
-    errata.note(S_ERROR, "Failed to write to QUIC log file: {}", Errno{});
-    ::close(qs.qlogfd);
-    qs.qlogfd = -1;
+  for (auto &[stream_id, stream] : streams) {
+    static_cast<void>(stream_id);
+    SSL_free(stream);
   }
+  streams.clear();
+  streams_with_fin.clear();
+  streams_concluded.clear();
+  streams_pending_conclude.clear();
 
-  if (flags & NGTCP2_QLOG_WRITE_FLAG_FIN) {
-    ::close(qs.qlogfd);
-    qs.qlogfd = -1;
+  if (connection != nullptr) {
+    SSL_SHUTDOWN_EX_ARGS args{.quic_error_code = 0, .quic_reason = "Proxy Verifier shutdown"};
+    SSL_shutdown_ex(
+        connection,
+        SSL_SHUTDOWN_FLAG_RAPID | SSL_SHUTDOWN_FLAG_NO_BLOCK,
+        &args,
+        sizeof(args));
+    SSL_free(connection);
+    connection = nullptr;
   }
 }
 
-// static
+swoc::Rv<SSL *>
+QuicSocket::open_stream(bool unidirectional)
+{
+  swoc::Rv<SSL *> zret{nullptr};
+  auto const flags = SSL_STREAM_FLAG_NO_BLOCK | (unidirectional ? SSL_STREAM_FLAG_UNI : 0);
+  auto *stream = SSL_new_stream(connection, flags);
+  if (stream == nullptr) {
+    zret.note(S_ERROR, "Failed to create an OpenSSL QUIC stream: {}", swoc::bwf::SSLError{});
+    return zret;
+  }
+  add_stream(stream);
+  zret = stream;
+  return zret;
+}
+
 void
-QuicSocket::randomly_populate_array(uint8_t *array, size_t array_len)
+QuicSocket::add_stream(SSL *stream)
 {
-  for (auto i = 0u; i < array_len; ++i) {
-    array[i] = _uni_id(_rng);
-  }
+  SSL_set_blocking_mode(stream, 0);
+  SSL_set_event_handling_mode(stream, SSL_VALUE_EVENT_HANDLING_MODE_EXPLICIT);
+  SSL_set_mode(stream, SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER | SSL_MODE_ENABLE_PARTIAL_WRITE);
+  auto const stream_id = SSL_get_stream_id(stream);
+  streams.emplace(static_cast<int64_t>(stream_id), stream);
 }
 
-// static
+SSL *
+QuicSocket::find_stream(int64_t stream_id) const
+{
+  auto const spot = streams.find(stream_id);
+  return spot == streams.end() ? nullptr : spot->second;
+}
+
 Errata
 QuicSocket::configure_qlog_dir(TextView qlog_dir)
 {
   Errata errata;
+  m_qlog_dir = qlog_dir;
   if (qlog_dir.empty()) {
-    errata.note(S_DIAG, "qlog is not enabled.");
     return errata;
   }
-  _qlog_dir = qlog_dir;
+
   std::error_code ec;
-  auto stat{swoc::file::status(qlog_dir, ec)};
+  auto stat = swoc::file::status(m_qlog_dir, ec);
   if (ec.value() == ENOENT) {
     std::filesystem::create_directories(qlog_dir, ec);
-    if (ec.value() != 0) {
+    if (ec) {
       errata.note(S_ERROR, R"(Could not create qlog directory path "{}": {})", qlog_dir, ec);
       return errata;
     }
-  } else if (ec.value() != 0) {
+  } else if (ec) {
     errata.note(S_ERROR, R"(Invalid qlog directory path "{}": {}.)", qlog_dir, ec);
     return errata;
   }
-  stat = swoc::file::status(qlog_dir, ec);
+  stat = swoc::file::status(m_qlog_dir, ec);
   if (!swoc::file::is_dir(stat)) {
     errata.note(S_ERROR, R"(Specified qlog path is not a directory: "{}")", qlog_dir);
     return errata;
   }
-  errata.note(S_DIAG, "QUIC log files will be written to {}", qlog_dir);
-  return errata;
-}
-
-// static
-void
-H3Session::set_non_zero_exit_status()
-{
-  *H3Session::process_exit_code = 1;
-}
-
-Errata
-H3Session::configure_udp_socket(swoc::TextView interface, swoc::IPEndpoint const *target)
-{
-  Errata errata;
-  int const socket_fd = ::socket(target->family(), SOCK_DGRAM, 0);
-  if (0 > socket_fd) {
-    errata.note(S_ERROR, R"(Failed to open a UDP socket - {})", Errno{});
-    return errata;
-  }
-  static constexpr int ONE = 1;
-  struct linger l;
-  l.l_onoff = 0;
-  l.l_linger = 0;
-  setsockopt(socket_fd, SOL_SOCKET, SO_LINGER, (char *)&l, sizeof(l));
-  if (setsockopt(socket_fd, SOL_SOCKET, SO_REUSEADDR, &ONE, sizeof(int)) < 0) {
-    errata.note(S_ERROR, R"(Could not set reuseaddr on socket {} - {}.)", socket_fd, Errno{});
-    return errata;
-  }
-  errata.note(this->set_fd(socket_fd));
-  if (!errata.is_ok()) {
-    return errata;
-  }
-
-  if (!interface.empty()) {
-    InterfaceNameToEndpoint interface_to_endpoint{interface, target->family()};
-    auto &&[device_endpoint, device_errata] = interface_to_endpoint.find_ip_endpoint();
-    errata.note(std::move(device_errata));
-    if (!errata.is_ok()) {
-      return errata;
-    }
-    if (::bind(socket_fd, device_endpoint, device_endpoint.size()) == -1) {
-      errata.note(S_ERROR, "Failed to bind on interface {}: {}", interface, swoc::bwf::Errno{});
-      return errata;
-    }
-  }
-
-  if (-1 == ::connect(socket_fd, &target->sa, target->size())) {
-    errata.note(S_ERROR, R"(Failed to connect socket {}: - {})", *target, Errno{});
-    return errata;
-  }
-  if (0 != ::fcntl(socket_fd, F_SETFL, fcntl(socket_fd, F_GETFL, 0) | O_NONBLOCK)) {
-    errata.note(
-        S_ERROR,
-        R"(Failed to make the client socket non-blocking {}: - {})",
-        *target,
-        Errno{});
-    return errata;
-  }
-  this->_endpoint = target;
-  return errata;
-}
-
-Errata
-H3Session::do_connect(
-    swoc::TextView interface,
-    swoc::IPEndpoint const *target,
-    ProxyProtocolMsg * /*pp_msg*/)
-{
-  Errata errata = configure_udp_socket(interface, target);
-  if (!errata.is_ok()) {
-    return errata;
-  }
-
-  // A generic UDP socket has been configured and connected. Now finish the
-  // connection phase by configuring a QUIC and HTTP/3 connection over this
-  // socket.
-  errata.note(this->connect());
-  return errata;
-}
-
-swoc::Rv<int>
-H3Session::poll_for_headers(milliseconds timeout)
-{
-  assert(0);
-  if (this->get_a_stream_has_ended()) {
-    return 1;
-  }
-  swoc::Rv<int> zret{-1};
-  auto &&[poll_result, poll_errata] = Session::poll_for_data_on_socket(timeout);
-  zret.note(std::move(poll_errata));
-  if (!zret.is_ok()) {
-    return zret;
-  } else if (poll_result == 0) {
-    return 0;
-  } else if (poll_result < 0) {
-    // Connection closed.
-    close();
-    return -1;
-  }
-  zret.note(nghttp3_receive_and_send_data(*this, Poll_Timeout));
-  if (!zret.is_ok()) {
-    zret.note(
-        S_ERROR,
-        "Calling nghttp3_receive_and_send_data in H3Session::poll_for_headers failed.");
-    close();
-    return zret;
-  }
-  if (is_closed()) {
-    return -1;
-  } else if (this->get_a_stream_has_ended()) {
-    return 1;
-  } else {
-    // The caller will retry.
-    return 0;
-  }
-}
-
-bool
-H3Session::get_a_stream_has_ended() const
-{
-  return !_ended_streams.empty();
-}
-
-void
-H3Session::record_stream_state(int64_t stream_id, std::shared_ptr<H3StreamState> stream_state)
-{
-  stream_map[stream_id] = stream_state;
-  _last_added_stream = stream_state;
-}
-
-void
-H3Session::mark_completed_response_stream(int64_t stream_id)
-{
-  _completed_response_streams.emplace(stream_id);
-}
-
-bool
-H3Session::clear_completed_response_stream(int64_t stream_id)
-{
-  return _completed_response_streams.erase(stream_id) > 0;
-}
-
-void
-H3Session::set_stream_has_ended(int64_t stream_id, std::string_view key)
-{
-  _ended_streams.push_back(stream_id);
-  if (!key.empty()) {
-    _finished_streams.emplace(key);
-  }
-}
-
-swoc::Rv<std::shared_ptr<HttpHeader>>
-H3Session::read_and_parse_request(swoc::FixedBufferWriter & /* buffer */)
-{
-  swoc::Rv<std::shared_ptr<HttpHeader>> zret{nullptr};
-
-  // This function should only be called after poll_for_headers() says there is
-  // a finished stream.
-  assert(!_ended_streams.empty());
-  auto const stream_id = _ended_streams.front();
-  _ended_streams.pop_front();
-  auto stream_map_iter = stream_map.find(stream_id);
-  if (stream_map_iter == stream_map.end()) {
-    zret.note(
-        S_ERROR,
-        "Requested request headers for stream id {}, but none are available.",
-        stream_id);
-    return zret;
-  }
-  auto &stream_state = stream_map_iter->second;
-  zret = stream_state->request_from_client;
-  return zret;
-}
-
-swoc::Rv<size_t>
-H3Session::drain_body(
-    HttpHeader const & /* hdr */,
-    size_t /* expected_content_size */,
-    TextView /* initial */,
-    std::shared_ptr<RuleCheck> /* rule_check */)
-{
-  // For HTTP/3, we process entire streams once they are ended. Therefore there
-  // is never body to drain.
-  return {0};
-}
-
-// Complete the TLS handshake (server-side).
-Errata
-H3Session::accept()
-{
-  swoc::Errata errata;
-  //
-  // TODO: This is all just stubbed out. Copied over from HTTP/2, so most of it
-  // is wrong. Flesh this out when we implement server-side HTTP/3
-  //
-
-  // Check that the HTTP/3 protocol was negotiated.
-  unsigned char const *alpn = nullptr;
-  unsigned int alpnlen = 0;
-#ifdef OPENSSL_NO_NEXTPROTONEG
-  SSL_get0_next_proto_negotiated(this->_ssl, &alpn, &alpnlen);
-#endif /* !OPENSSL_NO_NEXTPROTONEG */
-#if OPENSSL_VERSION_NUMBER >= 0x10002000L
-  if (alpn == nullptr) {
-    SSL_get0_alpn_selected(this->_ssl, &alpn, &alpnlen);
-  }
-#endif /* OPENSSL_VERSION_NUMBER >= 0x10002000L */
-
-  if (alpn != nullptr && alpnlen == 2 && memcmp("h3", alpn, 2) == 0) {
-    errata.note(
-        S_DIAG,
-        R"(Negotiated ALPN: {}, HTTP/3 is negotiated.)",
-        TextView{(char *)alpn, alpnlen});
-  } else {
-    errata.note(
-        S_ERROR,
-        R"(Negotiated ALPN: {}, HTTP/3 failed to negotiate.)",
-        (alpn == nullptr) ? "none" : TextView{(char *)alpn, alpnlen});
-    return errata;
-  }
-
-  this->server_session_init();
-  errata.note(S_DIAG, "Finished accept using H3Session");
-  return errata;
-}
-
-// Complete the TLS handshake (client-side).
-Errata
-H3Session::connect()
-{
-  swoc::Errata errata;
-
-  PacketIoContext packet_context;
-  errata.note(this->client_session_init(&packet_context));
-  if (!errata.is_ok()) {
-    errata.note(S_ERROR, "TLS initialization failed.");
-    return errata;
-  }
-
-  return errata;
-}
-
-Errata
-H3Session::run_transactions(
-    std::list<Txn> const &transactions,
-    swoc::TextView interface,
-    swoc::IPEndpoint const *target,
-    double rate_multiplier)
-{
-  Errata errata;
-
-  auto const first_time = ClockType::now();
-  for (auto const &transaction : transactions) {
-    Errata txn_errata;
-    auto const key{transaction._req.get_key()};
-    if (this->is_closed()) {
-      txn_errata.note(this->do_connect(interface, target));
-      if (!txn_errata.is_ok()) {
-        txn_errata.note(S_ERROR, R"(Failed to reconnect HTTP/3 key: {}.)", key);
-        // If we don't have a valid connection, there's no point in continuing.
-        break;
-      }
-    }
-    while (this->request_has_outstanding_stream_dependencies(transaction._req)) {
-      txn_errata.note(nghttp3_receive_and_send_data(*this, Poll_Timeout));
-      if (!txn_errata.is_ok()) {
-        errata.note(S_ERROR, R"(Failed HTTP/3 transaction with key: {}.)", key);
-        return errata;
-      }
-    }
-    if (rate_multiplier != 0 || transaction._user_specified_delay_duration > 0us) {
-      std::chrono::duration<double, std::micro> delay_time = 0ms;
-      auto current_time = ClockType::now();
-      auto next_time = current_time + delay_time;
-      if (transaction._user_specified_delay_duration > 0us) {
-        delay_time = transaction._user_specified_delay_duration;
-        next_time = current_time + delay_time;
-      } else {
-        auto const start_offset = transaction._start;
-        next_time = (rate_multiplier * start_offset) + first_time;
-        delay_time = next_time - current_time;
-      }
-      while (delay_time > 0us) {
-        // Make use of our delay time to read any incoming responses.
-        txn_errata.note(
-            nghttp3_receive_and_send_data(*this, duration_cast<milliseconds>(delay_time)));
-        current_time = ClockType::now();
-        delay_time = next_time - current_time;
-        if (delay_time > 0us &&
-            !interruptible_sleep_for(std::chrono::duration_cast<chrono::nanoseconds>(delay_time)))
-        {
-          break;
-        }
-      }
-    }
-    if (shutdown_requested()) {
-      break;
-    }
-    txn_errata.note(this->run_transaction(transaction));
-    if (!txn_errata.is_ok()) {
-      errata.note(S_ERROR, R"(Failed HTTP/3 transaction with key: {}.)", key);
-    }
-  }
-  errata.note(receive_responses());
-  return errata;
-}
-
-bool
-H3Session::request_has_outstanding_stream_dependencies(HttpHeader const &request) const
-{
-  for (auto const &stream_dependency : request._keys_to_await) {
-    if (this->_finished_streams.find(stream_dependency) == this->_finished_streams.end()) {
-      return true;
-    }
-  }
-  return false;
-}
-
-Errata
-H3Session::run_transaction(Txn const &transaction)
-{
-  Errata errata;
-  auto &&[bytes_written, write_errata] = this->write(transaction._req);
-  errata.note(std::move(write_errata));
-  _last_added_stream->specified_response = &transaction._rsp;
+  errata.note(
+      S_INFO,
+      "OpenSSL native QUIC does not expose qlog events; no qlog files will be written to {}.",
+      qlog_dir);
   return errata;
 }
 
@@ -2060,8 +845,8 @@ TextView
 H3StreamState::register_rcbuf(nghttp3_rcbuf *rcbuf)
 {
   nghttp3_rcbuf_incref(rcbuf);
-  _rcbufs_to_free.push_back(rcbuf);
-  auto buf = nghttp3_rcbuf_get_buf(rcbuf);
+  m_rcbufs_to_free.push_back(rcbuf);
+  auto const buf = nghttp3_rcbuf_get_buf(rcbuf);
   return TextView(reinterpret_cast<char *>(buf.base), buf.len);
 }
 
@@ -2069,7 +854,7 @@ H3StreamState::H3StreamState(bool is_client)
   : stream_start{ClockType::now()}
   , request_from_client{std::make_shared<HttpHeader>()}
   , response_from_server{std::make_shared<HttpHeader>()}
-  , _will_receive_request{!is_client}
+  , m_will_receive_request{!is_client}
 {
   request_from_client->set_is_request(HTTP_PROTOCOL_TYPE::HTTP_3);
   response_from_server->set_is_response(HTTP_PROTOCOL_TYPE::HTTP_3);
@@ -2077,7 +862,7 @@ H3StreamState::H3StreamState(bool is_client)
 
 H3StreamState::~H3StreamState()
 {
-  for (auto rcbuf : _rcbufs_to_free) {
+  for (auto *rcbuf : m_rcbufs_to_free) {
     nghttp3_rcbuf_decref(rcbuf);
   }
 }
@@ -2085,71 +870,49 @@ H3StreamState::~H3StreamState()
 bool
 H3StreamState::will_receive_request() const
 {
-  return _will_receive_request;
+  return m_will_receive_request;
 }
 
 bool
 H3StreamState::will_receive_response() const
 {
-  return !_will_receive_request;
+  return !m_will_receive_request;
 }
 
 void
 H3StreamState::set_stream_id(int64_t stream_id)
 {
-  _stream_id = stream_id;
+  m_stream_id = stream_id;
 }
 
 int64_t
 H3StreamState::get_stream_id() const
 {
-  return _stream_id;
+  return m_stream_id;
 }
 
-H3Session::H3Session() { }
+H3Session::H3Session() = default;
 
 H3Session::H3Session(TextView const &client_sni, int client_verify_mode)
-  : _client_sni{client_sni}
-  , _client_verify_mode{client_verify_mode}
+  : m_client_sni{client_sni}
+  , m_client_verify_mode{client_verify_mode}
 {
 }
 
 H3Session::~H3Session()
 {
-  _last_added_stream.reset();
-  char buffer[NGTCP2_MAX_PMTUD_UDP_PAYLOAD_SIZE] = {0};
-  ngtcp2_tstamp ts = 0;
-  ngtcp2_ssize rc = 0;
-  ngtcp2_ccerr error_code;
-  memset(&error_code, 0, sizeof(error_code));
-
-  ts = timestamp();
-  // Create the CONNECTION_CLOSE content in buffer.
-  rc = ngtcp2_conn_write_connection_close(
-      quic_socket.qconn,
-      nullptr, /* path */
-      nullptr, /* pkt_info */
-      (uint8_t *)buffer,
-      sizeof(buffer),
-      &quic_socket.last_error,
-      ts);
-  if (rc > 0) {
-    // Send the CONNECTION_CLOSE.
-    ssize_t num_sent = 0;
-    while (((num_sent = ::send(get_fd(), buffer, rc, 0)) == -1) && errno == EINTR)
-      ;
-    Session::_num_total_bytes_written += num_sent;
-  }
+  m_last_added_stream.reset();
+  quic_socket.reset();
 }
 
-swoc::Rv<ssize_t> H3Session::read(swoc::MemSpan<char> /* span */)
+swoc::Rv<ssize_t> H3Session::read(swoc::MemSpan<char>)
 {
   swoc::Rv<ssize_t> zret{0};
   zret.note(S_ERROR, "HTTP/3 read() called for the unsupported MemSpan overload.");
   return zret;
 }
 
-swoc::Rv<ssize_t> H3Session::write(TextView /* data */)
+swoc::Rv<ssize_t> H3Session::write(TextView)
 {
   swoc::Rv<ssize_t> zret{0};
   zret.note(S_ERROR, "HTTP/3 write() called for the unsupported TextView overload.");
@@ -2157,34 +920,31 @@ swoc::Rv<ssize_t> H3Session::write(TextView /* data */)
 }
 
 nghttp3_nv
-H3Session::tv_to_nv(char const *name, TextView v)
+H3Session::tv_to_nv(char const *name, TextView value)
 {
-  nghttp3_nv res;
-
-  res.name = (unsigned char *)name;
-  res.namelen = strlen(name);
-  res.value = (unsigned char *)v.data();
-  res.valuelen = v.length();
-  res.flags = NGHTTP3_NV_FLAG_NONE;
-
-  return res;
+  return nghttp3_nv{
+      reinterpret_cast<uint8_t *>(const_cast<char *>(name)),
+      reinterpret_cast<uint8_t *>(const_cast<char *>(value.data())),
+      std::strlen(name),
+      value.length(),
+      NGHTTP3_NV_FLAG_NONE};
 }
 
 Errata
 H3Session::pack_headers(HttpHeader const &hdr, nghttp3_nv *&nv_hdr, int &hdr_count)
 {
   Errata errata;
-
-  hdr_count = hdr._fields_rules->_fields.size();
-
-  nv_hdr = reinterpret_cast<nghttp3_nv *>(malloc(sizeof(nghttp3_nv) * hdr_count));
+  hdr_count = static_cast<int>(hdr._fields_rules->_fields.size());
+  nv_hdr = static_cast<nghttp3_nv *>(std::malloc(sizeof(nghttp3_nv) * hdr_count));
+  if (nv_hdr == nullptr) {
+    errata.note(S_ERROR, "Failed to allocate {} HTTP/3 header fields.", hdr_count);
+    return errata;
+  }
 
   int offset = 0;
   if (hdr.is_response()) {
     nv_hdr[offset++] = tv_to_nv(":status", hdr._status_string);
-  } else { // Is a request.
-    // TODO: add error checking and refactor and tolerance for non-required
-    // pseudo-headers
+  } else {
     nv_hdr[offset++] = tv_to_nv(":method", hdr._method);
     nv_hdr[offset++] = tv_to_nv(":scheme", hdr._scheme);
     nv_hdr[offset++] = tv_to_nv(":path", hdr._path);
@@ -2198,42 +958,37 @@ swoc::Rv<ssize_t>
 H3Session::write(HttpHeader const &hdr)
 {
   swoc::Rv<ssize_t> zret{0};
-
   auto const key = hdr.get_key();
   H3StreamState *stream_state = nullptr;
-  std::shared_ptr<H3StreamState> new_stream_state{nullptr};
+  std::shared_ptr<H3StreamState> new_stream_state;
   int64_t stream_id = 0;
+
   if (hdr.is_response()) {
     stream_id = hdr._stream_id;
-    auto stream_map_iter = stream_map.find(stream_id);
-    if (stream_map_iter == stream_map.end()) {
+    auto const spot = stream_map.find(stream_id);
+    if (spot == stream_map.end()) {
       zret.note(S_ERROR, "Could not find registered stream for stream id: {}", stream_id);
       return zret;
     }
-    stream_state = stream_map_iter->second.get();
-  } else { // Is a request.
-    // Only servers write responses while clients write requests.
-    bool const is_client = hdr.is_request();
-    new_stream_state = std::make_shared<H3StreamState>(is_client);
-    stream_state = new_stream_state.get();
-
-    auto const rc = ngtcp2_conn_open_bidi_stream(quic_socket.qconn, &stream_id, nullptr);
-    if (rc != 0) {
-      zret.note(
-          S_ERROR,
-          "Failed ngtcp2_conn_open_bidi_stream for key {}, error code: {}",
-          key,
-          Ngtcp2Error{rc});
+    stream_state = spot->second.get();
+  } else {
+    auto &&[stream, stream_errata] = quic_socket.open_stream(!UNIDIRECTIONAL);
+    zret.note(std::move(stream_errata));
+    if (!zret.is_ok() || stream == nullptr) {
+      zret.note(S_ERROR, "Failed to create an HTTP/3 request stream for key {}.", key);
       return zret;
     }
+    stream_id = static_cast<int64_t>(SSL_get_stream_id(stream));
+    new_stream_state = std::make_shared<H3StreamState>(hdr.is_request());
+    stream_state = new_stream_state.get();
     stream_state->set_stream_id(stream_id);
     record_stream_state(stream_id, new_stream_state);
   }
   stream_state->key = key;
 
-  int num_headers;
-  nghttp3_nv *nva = nullptr;
-  zret.note(pack_headers(hdr, nva, num_headers));
+  int num_headers = 0;
+  nghttp3_nv *headers = nullptr;
+  zret.note(pack_headers(hdr, headers, num_headers));
   if (!zret.is_ok()) {
     zret.note(S_ERROR, "Failed to pack headers for key: {}", key);
     return zret;
@@ -2246,151 +1001,129 @@ H3Session::write(HttpHeader const &hdr)
     if (hdr._content_data_list.front()) {
       content = TextView{hdr._content_data_list.front(), hdr._content_length};
     } else {
-      // If hdr._content_data is null, then there was no explicit description
-      // of the body data via the data node. Instead we'll use our generated
-      // HttpHeader::_content.
       content = TextView{HttpHeader::_content.data(), hdr._content_length};
     }
-    nghttp3_data_reader data_reader;
-    data_reader.read_data = cb_h3_readfunction;
-    stream_state->body_to_send = TextView{content.data(), content.size()};
+    nghttp3_data_reader data_reader{.read_data = cb_h3_readfunction};
+    stream_state->body_to_send = content;
     stream_state->wait_for_continue = hdr.is_request_with_expect_100_continue();
     if (hdr.is_response()) {
       submit_result = nghttp3_conn_submit_response(
           quic_socket.h3conn,
           stream_id,
-          nva,
+          headers,
           num_headers,
           &data_reader);
     } else {
       submit_result = nghttp3_conn_submit_request(
           quic_socket.h3conn,
           stream_id,
-          nva,
+          headers,
           num_headers,
           &data_reader,
           stream_state);
     }
-  } else { // Empty body.
-    if (hdr.is_response()) {
-      submit_result =
-          nghttp3_conn_submit_response(quic_socket.h3conn, stream_id, nva, num_headers, nullptr);
-    } else {
-      submit_result = nghttp3_conn_submit_request(
-          quic_socket.h3conn,
-          stream_id,
-          nva,
-          num_headers,
-          nullptr,
-          stream_state);
-    }
+  } else if (hdr.is_response()) {
+    submit_result =
+        nghttp3_conn_submit_response(quic_socket.h3conn, stream_id, headers, num_headers, nullptr);
+  } else {
+    submit_result = nghttp3_conn_submit_request(
+        quic_socket.h3conn,
+        stream_id,
+        headers,
+        num_headers,
+        nullptr,
+        stream_state);
   }
+
   if (submit_result == 0) {
     zret.note(
         S_DIAG,
         "Sent the following HTTP/3 {}{} headers for key {} with stream id {}:\n{}",
         swoc::bwf::If(hdr.is_request(), "request"),
         swoc::bwf::If(hdr.is_response(), "response"),
-        hdr.get_key(),
+        key,
         stream_id,
         hdr);
   } else {
     zret.note(
         S_ERROR,
-        "Submitting an HTTP/3 {}{} for key {} with stream id {} failed: {}",
+        "Submitting an HTTP/3 {}{} for key {} with stream id {} failed: {} ({})",
         swoc::bwf::If(hdr.is_request(), "request"),
         swoc::bwf::If(hdr.is_response(), "response"),
-        hdr.get_key(),
+        key,
         stream_id,
+        nghttp3_error(submit_result),
         submit_result);
   }
-  if (zret.is_ok()) {
-    // Make sure the logging of the headers are emitted before the body.
-    zret.errata().sink();
-  }
+  std::free(headers);
 
-  PacketIoContext packet_context;
-  if (ngtcp2_progress_egress(*this, &packet_context) < 0) {
-    zret.note(S_ERROR, "Failure calling ngtcp2_flush_egress while writing headers.");
+  if (zret.is_ok()) {
+    zret.errata().sink();
+    auto &&[progressed, progress_errata] = progress_http3(*this, 0ms);
+    static_cast<void>(progressed);
+    zret.note(std::move(progress_errata));
   }
-  free(nva);
   return zret;
 }
 
-SSL_CTX *H3Session::_h3_client_context = nullptr;
-SSL_CTX *H3Session::_h3_server_context = nullptr;
-
-// static
 Errata
-H3Session::init(int *process_exit_code, TextView qlog_dir)
+H3Session::configure_udp_socket(TextView interface, swoc::IPEndpoint const *target)
 {
   Errata errata;
-  H3Session::process_exit_code = process_exit_code;
-  if (ngtcp2_crypto_ossl_init() != 0) {
-    errata.note(S_ERROR, "ngtcp2_crypto_ossl_init failed.");
-    return errata;
+  quic_socket.reset();
+  if (!is_closed()) {
+    close();
   }
-  errata.note(QuicSocket::configure_qlog_dir(qlog_dir));
-  errata.note(H3Session::client_ssl_ctx_init(_h3_client_context));
-  errata.note(H3Session::server_ssl_ctx_init(_h3_server_context));
-  errata.note(S_DIAG, "Finished H3Session::init");
-  return errata;
-}
 
-// static
-void
-H3Session::terminate()
-{
-  H3Session::terminate(_h3_server_context);
-  H3Session::terminate(_h3_server_context);
-}
-
-// static
-void
-H3Session::terminate(SSL_CTX *&context)
-{
-  SSL_CTX_free(context);
-  context = nullptr;
-}
-
-// static
-Errata
-H3Session::client_ssl_ctx_init(SSL_CTX *&client_context)
-{
-  Errata errata;
-  client_context = SSL_CTX_new(TLS_method());
-
-  SSL_CTX_set_default_verify_paths(client_context);
-
-  if (SSL_CTX_set_ciphersuites(client_context, QUIC_CIPHERS) != 1) {
-    errata.note(S_ERROR, "SSL_CTX_set_ciphersuites failed: {}", swoc::bwf::SSLError{});
+  int const socket_fd = ::socket(target->family(), SOCK_DGRAM, 0);
+  if (socket_fd < 0) {
+    errata.note(S_ERROR, R"(Failed to open a UDP socket - {})", Errno{});
     return errata;
   }
 
-  if (SSL_CTX_set1_groups_list(client_context, QUIC_GROUPS) != 1) {
-    errata.note(S_ERROR, "SSL_CTX_set1_groups_list failed: {}", swoc::bwf::SSLError{});
+  static constexpr int ENABLE_OPTION = 1;
+  struct linger linger_option = {.l_onoff = 0, .l_linger = 0};
+  setsockopt(socket_fd, SOL_SOCKET, SO_LINGER, &linger_option, sizeof(linger_option));
+  if (setsockopt(socket_fd, SOL_SOCKET, SO_REUSEADDR, &ENABLE_OPTION, sizeof(ENABLE_OPTION)) < 0) {
+    errata.note(S_ERROR, R"(Could not set reuseaddr on socket {} - {}.)", socket_fd, Errno{});
+    ::close(socket_fd);
     return errata;
   }
-
-  if (TLSSession::tls_secrets_are_being_logged()) {
-    SSL_CTX_set_keylog_callback(client_context, TLSSession::keylog_callback);
+  if (!interface.empty()) {
+    InterfaceNameToEndpoint interface_to_endpoint{interface, target->family()};
+    auto &&[device_endpoint, device_errata] = interface_to_endpoint.find_ip_endpoint();
+    errata.note(std::move(device_errata));
+    if (!errata.is_ok()) {
+      ::close(socket_fd);
+      return errata;
+    }
+    if (::bind(socket_fd, device_endpoint, device_endpoint.size()) == -1) {
+      errata.note(S_ERROR, "Failed to bind on interface {}: {}", interface, Errno{});
+      ::close(socket_fd);
+      return errata;
+    }
   }
 
-  return errata;
-}
-
-// static
-Errata
-H3Session::server_ssl_ctx_init(SSL_CTX *& /* server_context */)
-{
-  Errata errata;
-#if 0
-  // Add this in once we implement server-side HTTP/3.
-  if (TLSSession::tls_secrets_are_being_logged()) {
-    SSL_CTX_set_keylog_callback(client_context, TLSSession::keylog_callback);
+  if (::connect(socket_fd, &target->sa, target->size()) == -1) {
+    errata.note(S_ERROR, R"(Failed to connect socket {}: - {})", *target, Errno{});
+    ::close(socket_fd);
+    return errata;
   }
-#endif
-
+  if (::fcntl(socket_fd, F_SETFL, fcntl(socket_fd, F_GETFL, 0) | O_NONBLOCK) != 0) {
+    errata.note(
+        S_ERROR,
+        R"(Failed to make the client socket non-blocking {}: - {})",
+        *target,
+        Errno{});
+    ::close(socket_fd);
+    return errata;
+  }
+  errata.note(set_fd(socket_fd));
+  if (!errata.is_ok()) {
+    ::close(socket_fd);
+    return errata;
+  }
+  m_endpoint = target;
   return errata;
 }
 
@@ -2398,61 +1131,398 @@ Errata
 H3Session::client_ssl_session_init(SSL_CTX *client_context)
 {
   Errata errata;
-  const uint8_t *alpn = nullptr;
-  size_t alpnlen = 0;
-
-  assert(quic_socket.ssl == nullptr);
-  quic_socket.ssl = SSL_new(client_context);
-  if (quic_socket.ssl == nullptr) {
+  assert(quic_socket.connection == nullptr);
+  quic_socket.connection = SSL_new(client_context);
+  if (quic_socket.connection == nullptr) {
     errata.note(S_ERROR, "SSL_new failed: {}", swoc::bwf::SSLError{});
     return errata;
   }
-  if (ngtcp2_crypto_ossl_ctx_new(&quic_socket.ossl_ctx, nullptr) != 0) {
-    errata.note(S_ERROR, "ngtcp2_crypto_ossl_ctx_new failed.");
-    return errata;
-  }
-  ngtcp2_crypto_ossl_ctx_set_ssl(quic_socket.ossl_ctx, quic_socket.ssl);
-  quic_socket.conn_ref.get_conn = get_conn;
-  quic_socket.conn_ref.user_data = this;
 
-  if (SSL_set_app_data(quic_socket.ssl, &this->quic_socket.conn_ref) == 0) {
-    errata.note(S_ERROR, "SSL_set_app_data failed: {}", swoc::bwf::SSLError{});
-  }
-  if (ngtcp2_crypto_ossl_configure_client_session(quic_socket.ssl) != 0) {
+  auto *connection = quic_socket.connection;
+  if (SSL_set_blocking_mode(connection, 0) != 1 ||
+      SSL_set_event_handling_mode(connection, SSL_VALUE_EVENT_HANDLING_MODE_EXPLICIT) != 1 ||
+      SSL_set_default_stream_mode(connection, SSL_DEFAULT_STREAM_MODE_NONE) != 1 ||
+      SSL_set_incoming_stream_policy(
+          connection,
+          SSL_INCOMING_STREAM_POLICY_ACCEPT,
+          H3_STREAM_CREATION_ERROR) != 1)
+  {
     errata.note(
         S_ERROR,
-        "ngtcp2_crypto_ossl_configure_client_session failed: {}",
+        "Failed to configure OpenSSL QUIC stream handling: {}",
         swoc::bwf::SSLError{});
+    return errata;
   }
-  SSL_set_connect_state(quic_socket.ssl);
+  SSL_set_mode(connection, SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER | SSL_MODE_ENABLE_PARTIAL_WRITE);
 
-  alpn = reinterpret_cast<uint8_t const *>(H3_ALPN_H3.data());
-  alpnlen = H3_ALPN_H3.size();
-  if (alpn) {
-    if (SSL_set_alpn_protos(quic_socket.ssl, alpn, (int)alpnlen) != 0) {
-      errata.note(S_ERROR, "SSL_set_alpn_protos failed: {}", swoc::bwf::SSLError{});
-    }
+  auto *bio = BIO_new(BIO_s_datagram());
+  if (bio == nullptr || BIO_set_fd(bio, get_fd(), BIO_NOCLOSE) != 1) {
+    BIO_free(bio);
+    errata.note(
+        S_ERROR,
+        "Failed to configure the OpenSSL QUIC datagram BIO: {}",
+        swoc::bwf::SSLError{});
+    return errata;
   }
+  SSL_set_bio(connection, bio, bio);
 
-  if (!_client_sni.empty()) {
-    errata.note(S_DIAG, R"(Setting client-side H3 SNI to: "{}")", _client_sni);
-    if (SSL_set_tlsext_host_name(quic_socket.ssl, _client_sni.c_str()) == 0) {
+  auto *peer_address = BIO_ADDR_new();
+  if (peer_address == nullptr) {
+    errata.note(S_ERROR, "BIO_ADDR_new failed: {}", swoc::bwf::SSLError{});
+    return errata;
+  }
+  int address_result = 0;
+  if (m_endpoint->family() == AF_INET) {
+    auto const *address = reinterpret_cast<sockaddr_in const *>(&m_endpoint->sa);
+    address_result = BIO_ADDR_rawmake(
+        peer_address,
+        AF_INET,
+        &address->sin_addr,
+        sizeof(address->sin_addr),
+        address->sin_port);
+  } else if (m_endpoint->family() == AF_INET6) {
+    auto const *address = reinterpret_cast<sockaddr_in6 const *>(&m_endpoint->sa);
+    address_result = BIO_ADDR_rawmake(
+        peer_address,
+        AF_INET6,
+        &address->sin6_addr,
+        sizeof(address->sin6_addr),
+        address->sin6_port);
+  }
+  if (address_result != 1 || SSL_set1_initial_peer_addr(connection, peer_address) != 1) {
+    BIO_ADDR_free(peer_address);
+    errata.note(S_ERROR, "Failed to set the OpenSSL QUIC peer address: {}", swoc::bwf::SSLError{});
+    return errata;
+  }
+  BIO_ADDR_free(peer_address);
+
+  if (SSL_set_alpn_protos(connection, H3_ALPN, sizeof(H3_ALPN)) != 0) {
+    errata.note(S_ERROR, "SSL_set_alpn_protos failed: {}", swoc::bwf::SSLError{});
+    return errata;
+  }
+  if (!m_client_sni.empty()) {
+    errata.note(S_DIAG, R"(Setting client-side H3 SNI to: "{}")", m_client_sni);
+    if (SSL_set_tlsext_host_name(connection, m_client_sni.c_str()) != 1) {
       errata
-          .note(S_ERROR, "Failed to set client SNI to {}: {}", _client_sni, swoc::bwf::SSLError{});
+          .note(S_ERROR, "Failed to set client SNI to {}: {}", m_client_sni, swoc::bwf::SSLError{});
+      return errata;
     }
   }
-
-  if (_client_verify_mode != SSL_VERIFY_NONE) {
+  if (m_client_verify_mode != SSL_VERIFY_NONE) {
     errata.note(
         S_DIAG,
         R"(Setting client H3 verification mode against the proxy to: {}.)",
-        _client_verify_mode);
-    SSL_set_verify(
-        quic_socket.ssl,
-        _client_verify_mode,
-        nullptr /* No verify_callback is passed */);
+        m_client_verify_mode);
+    SSL_set_verify(connection, m_client_verify_mode, nullptr);
+  }
+  return errata;
+}
+
+Errata
+H3Session::initialize_http3_connection()
+{
+  Errata errata;
+  if (quic_socket.h3conn != nullptr) {
+    return errata;
   }
 
+  nghttp3_settings settings;
+  nghttp3_settings_default(&settings);
+  auto const result = nghttp3_conn_client_new(
+      &quic_socket.h3conn,
+      &NGHTTP3_CLIENT_CALLBACKS,
+      &settings,
+      nghttp3_mem_default(),
+      this);
+  if (result != 0) {
+    errata.note(S_ERROR, "nghttp3_conn_client_new failed: {} ({})", nghttp3_error(result), result);
+    return errata;
+  }
+
+  auto &&[control_stream, control_errata] = quic_socket.open_stream(UNIDIRECTIONAL);
+  errata.note(std::move(control_errata));
+  auto &&[encoder_stream, encoder_errata] = quic_socket.open_stream(UNIDIRECTIONAL);
+  errata.note(std::move(encoder_errata));
+  auto &&[decoder_stream, decoder_errata] = quic_socket.open_stream(UNIDIRECTIONAL);
+  errata.note(std::move(decoder_errata));
+  if (!errata.is_ok()) {
+    return errata;
+  }
+
+  auto const control_id = static_cast<int64_t>(SSL_get_stream_id(control_stream));
+  auto const encoder_id = static_cast<int64_t>(SSL_get_stream_id(encoder_stream));
+  auto const decoder_id = static_cast<int64_t>(SSL_get_stream_id(decoder_stream));
+  if (auto const bind_result = nghttp3_conn_bind_control_stream(quic_socket.h3conn, control_id);
+      bind_result != 0)
+  {
+    errata.note(
+        S_ERROR,
+        "nghttp3_conn_bind_control_stream failed: {} ({})",
+        nghttp3_error(bind_result),
+        bind_result);
+    return errata;
+  }
+  if (auto const bind_result =
+          nghttp3_conn_bind_qpack_streams(quic_socket.h3conn, encoder_id, decoder_id);
+      bind_result != 0)
+  {
+    errata.note(
+        S_ERROR,
+        "nghttp3_conn_bind_qpack_streams failed: {} ({})",
+        nghttp3_error(bind_result),
+        bind_result);
+  }
+  return errata;
+}
+
+Errata
+H3Session::connect()
+{
+  Errata errata = client_ssl_session_init(m_h3_client_context);
+  if (!errata.is_ok()) {
+    errata.note(S_ERROR, "TLS initialization failed.");
+    return errata;
+  }
+
+  auto *connection = quic_socket.connection;
+  auto const deadline = ClockType::now() + QUIC_HANDSHAKE_TIMEOUT;
+  for (;;) {
+    auto const result = SSL_connect(connection);
+    if (result == 1) {
+      break;
+    }
+    auto const ssl_error = SSL_get_error(connection, result);
+    if (ssl_error != SSL_ERROR_WANT_READ && ssl_error != SSL_ERROR_WANT_WRITE) {
+      errata.note(
+          S_ERROR,
+          "OpenSSL QUIC handshake failed with SSL error {}: {}",
+          ssl_error,
+          swoc::bwf::SSLError{});
+      return errata;
+    }
+    if (ClockType::now() >= deadline) {
+      errata.note(S_ERROR, "OpenSSL QUIC handshake timed out after {}.", QUIC_HANDSHAKE_TIMEOUT);
+      return errata;
+    }
+    if (SSL_handle_events(connection) != 1) {
+      errata.note(
+          S_ERROR,
+          "SSL_handle_events failed during QUIC handshake: {}",
+          swoc::bwf::SSLError{});
+      return errata;
+    }
+    auto const remaining = duration_cast<milliseconds>(deadline - ClockType::now());
+    auto &&[poll_result, poll_errata] = poll_for_quic(*this, remaining, ssl_error);
+    errata.note(std::move(poll_errata));
+    if (!errata.is_ok() || poll_result < 0) {
+      errata.note(S_ERROR, "Failed polling during the OpenSSL QUIC handshake.");
+      return errata;
+    }
+  }
+
+  unsigned char const *alpn = nullptr;
+  unsigned int alpn_length = 0;
+  SSL_get0_alpn_selected(connection, &alpn, &alpn_length);
+  if (alpn == nullptr || alpn_length != 2 || std::memcmp(alpn, "h3", 2) != 0) {
+    errata.note(
+        S_ERROR,
+        "Negotiated ALPN: {}, HTTP/3 failed to negotiate.",
+        alpn == nullptr ? TextView{"none"} :
+                          TextView{reinterpret_cast<char const *>(alpn), alpn_length});
+    return errata;
+  }
+  errata.note(S_DIAG, "Negotiated ALPN: h3, HTTP/3 is negotiated.");
+  errata.note(initialize_http3_connection());
+  if (errata.is_ok()) {
+    auto &&[progressed, progress_errata] = progress_http3(*this, 0ms);
+    static_cast<void>(progressed);
+    errata.note(std::move(progress_errata));
+  }
+  return errata;
+}
+
+Errata
+H3Session::do_connect(TextView interface, swoc::IPEndpoint const *target, ProxyProtocolMsg *)
+{
+  Errata errata = configure_udp_socket(interface, target);
+  if (errata.is_ok()) {
+    errata.note(connect());
+  }
+  return errata;
+}
+
+swoc::Rv<int>
+H3Session::poll_for_headers(milliseconds timeout)
+{
+  if (get_a_stream_has_ended()) {
+    return 1;
+  }
+  swoc::Rv<int> zret{-1};
+  auto &&[progressed, progress_errata] = progress_http3(*this, timeout);
+  static_cast<void>(progressed);
+  zret.note(std::move(progress_errata));
+  if (!zret.is_ok()) {
+    return zret;
+  }
+  zret = get_a_stream_has_ended() ? 1 : 0;
+  return zret;
+}
+
+bool
+H3Session::get_a_stream_has_ended() const
+{
+  return !m_ended_streams.empty();
+}
+
+void
+H3Session::record_stream_state(int64_t stream_id, std::shared_ptr<H3StreamState> stream_state)
+{
+  stream_map.emplace(stream_id, stream_state);
+  m_last_added_stream = std::move(stream_state);
+}
+
+void
+H3Session::mark_completed_response_stream(int64_t stream_id)
+{
+  m_completed_response_streams.insert(stream_id);
+}
+
+bool
+H3Session::clear_completed_response_stream(int64_t stream_id)
+{
+  return m_completed_response_streams.erase(stream_id) != 0;
+}
+
+void
+H3Session::set_stream_has_ended(int64_t stream_id, std::string_view key)
+{
+  m_ended_streams.push_back(stream_id);
+  if (!key.empty()) {
+    m_finished_streams.emplace(key);
+  }
+}
+
+swoc::Rv<std::shared_ptr<HttpHeader>>
+H3Session::read_and_parse_request(swoc::FixedBufferWriter &)
+{
+  swoc::Rv<std::shared_ptr<HttpHeader>> zret{nullptr};
+  if (m_ended_streams.empty()) {
+    zret.note(S_ERROR, "No completed HTTP/3 request stream is available.");
+    return zret;
+  }
+
+  auto const stream_id = m_ended_streams.front();
+  m_ended_streams.pop_front();
+  auto const spot = stream_map.find(stream_id);
+  if (spot == stream_map.end()) {
+    zret.note(S_ERROR, "Requested headers for stream id {}, but none are available.", stream_id);
+    return zret;
+  }
+  zret = spot->second->request_from_client;
+  return zret;
+}
+
+swoc::Rv<size_t>
+H3Session::drain_body(HttpHeader const &, size_t, TextView, std::shared_ptr<RuleCheck>)
+{
+  return {0};
+}
+
+Errata
+H3Session::accept()
+{
+  Errata errata;
+  errata.note(S_ERROR, "Server-side HTTP/3 is not implemented by Proxy Verifier.");
+  return errata;
+}
+
+bool
+H3Session::request_has_outstanding_stream_dependencies(HttpHeader const &request) const
+{
+  for (auto const &stream_dependency : request._keys_to_await) {
+    if (m_finished_streams.find(stream_dependency) == m_finished_streams.end()) {
+      return true;
+    }
+  }
+  return false;
+}
+
+Errata
+H3Session::run_transactions(
+    std::list<Txn> const &transactions,
+    TextView interface,
+    swoc::IPEndpoint const *target,
+    double rate_multiplier)
+{
+  Errata errata;
+  auto const first_time = ClockType::now();
+  for (auto const &transaction : transactions) {
+    Errata txn_errata;
+    auto const key = transaction._req.get_key();
+    if (is_closed()) {
+      txn_errata.note(do_connect(interface, target));
+      if (!txn_errata.is_ok()) {
+        txn_errata.note(S_ERROR, R"(Failed to reconnect HTTP/3 key: {}.)", key);
+        break;
+      }
+    }
+
+    while (request_has_outstanding_stream_dependencies(transaction._req)) {
+      auto &&[progressed, progress_errata] = progress_http3(*this, Poll_Timeout);
+      txn_errata.note(std::move(progress_errata));
+      if (!txn_errata.is_ok() || !progressed) {
+        errata.note(S_ERROR, R"(Failed HTTP/3 transaction with key: {}.)", key);
+        return errata;
+      }
+    }
+
+    if (rate_multiplier != 0 || transaction._user_specified_delay_duration > 0us) {
+      chrono::duration<double, std::micro> delay_time = 0ms;
+      auto current_time = ClockType::now();
+      auto next_time = current_time;
+      if (transaction._user_specified_delay_duration > 0us) {
+        delay_time = transaction._user_specified_delay_duration;
+        next_time += duration_cast<ClockType::duration>(delay_time);
+      } else {
+        next_time =
+            duration_cast<ClockType::duration>(rate_multiplier * transaction._start) + first_time;
+        delay_time = next_time - current_time;
+      }
+      while (delay_time > 0us) {
+        auto &&[progressed, progress_errata] =
+            progress_http3(*this, duration_cast<milliseconds>(delay_time));
+        static_cast<void>(progressed);
+        txn_errata.note(std::move(progress_errata));
+        current_time = ClockType::now();
+        delay_time = next_time - current_time;
+        if (delay_time > 0us &&
+            !interruptible_sleep_for(duration_cast<chrono::nanoseconds>(delay_time))) {
+          break;
+        }
+      }
+    }
+    if (shutdown_requested()) {
+      break;
+    }
+    txn_errata.note(run_transaction(transaction));
+    if (!txn_errata.is_ok()) {
+      errata.note(S_ERROR, R"(Failed HTTP/3 transaction with key: {}.)", key);
+    }
+  }
+  errata.note(receive_responses());
+  return errata;
+}
+
+Errata
+H3Session::run_transaction(Txn const &transaction)
+{
+  Errata errata;
+  auto &&[bytes_written, write_errata] = write(transaction._req);
+  static_cast<void>(bytes_written);
+  errata.note(std::move(write_errata));
+  if (m_last_added_stream != nullptr) {
+    m_last_added_stream->specified_response = &transaction._rsp;
+  }
   return errata;
 }
 
@@ -2465,102 +1535,76 @@ H3Session::receive_responses()
       errata.note(S_ERROR, "The connection was closed while awaiting HTTP/3 responses.");
       break;
     }
-    errata.note(nghttp3_receive_and_send_data(*this, Poll_Timeout));
+    auto &&[progressed, progress_errata] = progress_http3(*this, Poll_Timeout);
+    errata.note(std::move(progress_errata));
     if (!errata.is_ok()) {
       errata.note(S_ERROR, "Encountered a problem while receiving responses.");
       break;
     }
-  }
-  return errata;
-}
-
-Errata
-H3Session::client_session_init(PacketIoContext *packet_context)
-{
-  Errata errata;
-  quic_socket.version = NGTCP2_PROTO_VER_MAX;
-
-  errata.note(client_ssl_session_init(_h3_client_context));
-  if (!errata.is_ok()) {
-    errata.note(S_ERROR, "Failure initializing client-side SSL object.");
-    return errata;
-  }
-
-  quic_socket.dcid.datalen = NGTCP2_MAX_CIDLEN;
-  QuicSocket::randomly_populate_array(quic_socket.dcid.data, quic_socket.dcid.datalen);
-
-  quic_socket.scid.datalen = NGTCP2_MAX_CIDLEN;
-  QuicSocket::randomly_populate_array(quic_socket.scid.data, quic_socket.scid.datalen);
-
-  errata.note(quic_socket.open_qlog_file());
-
-  configure_quic_socket_settings(quic_socket, packet_context);
-
-  if (!quic_socket.local_addr.is_valid()) {
-    struct sockaddr_storage socket_address;
-    socklen_t socket_address_len = sizeof(socket_address);
-    auto const rv =
-        getsockname(this->get_fd(), (struct sockaddr *)&socket_address, &socket_address_len);
-    if (rv == -1) {
-      errata.note(S_ERROR, "getsockname failed: {}", Errno{});
-      return errata;
-    }
-    quic_socket.local_addr.assign(reinterpret_cast<struct sockaddr *>(&socket_address));
-  }
-
-  ngtcp2_path path;
-  memset(&path, 0, sizeof(path));
-  ngtcp2_addr_init(&path.local, quic_socket.local_addr, quic_socket.local_addr.size());
-  ngtcp2_addr_init(&path.remote, &this->_endpoint->sa, this->_endpoint->size());
-
-  auto const rc = ngtcp2_conn_client_new(
-      &quic_socket.qconn,
-      &quic_socket.dcid,
-      &quic_socket.scid,
-      &path,
-      NGTCP2_PROTO_VER_V1,
-      &client_ngtcp2_callbacks,
-      &quic_socket.settings,
-      &quic_socket.transport_params,
-      nullptr,
-      this /* The user_data in the ngtcp2 callbacks. */);
-  if (rc != 0) {
-    errata.note(S_ERROR, "ngtcp2_conn_client_new failed.");
-    return errata;
-  }
-
-  ngtcp2_conn_set_tls_native_handle(quic_socket.qconn, quic_socket.ossl_ctx);
-  ngtcp2_ccerr_default(&quic_socket.last_error);
-
-  // Commence handshake.
-  if (ngtcp2_progress_egress(*this, packet_context) < 0) {
-    errata.note(S_ERROR, "Error writing bytes during QUIC TLS handshake.");
-    return errata;
-  }
-
-  // TODO: have to read multiple packets????
-
-  // Now that we sent our first packet, exchange packets until the handshake is
-  // complete.
-  bool handshake_completed = ngtcp2_conn_get_handshake_completed(quic_socket.qconn);
-  while (!handshake_completed) {
-    errata.note(nghttp3_receive_and_send_data(*this, Poll_Timeout));
-    if (!errata.is_ok()) {
-      errata.note(S_ERROR, "Encountered a problem while completing the handshake.");
+    if (!progressed) {
+      errata.note(S_ERROR, "Timed out while awaiting HTTP/3 responses.");
       break;
     }
-    handshake_completed = ngtcp2_conn_get_handshake_completed(quic_socket.qconn);
-  }
-  if (!handshake_completed) {
-    errata.note(S_ERROR, "Could not complete the QUIC handshake.");
   }
   return errata;
 }
 
 Errata
-H3Session::server_session_init()
+H3Session::init(int *process_exit_code, TextView qlog_dir)
 {
   Errata errata;
-  // TODO: stubbed out. Flesh this out when we implement server-side HTTP/3.
+  m_process_exit_code = process_exit_code;
+  errata.note(QuicSocket::configure_qlog_dir(qlog_dir));
+  errata.note(client_ssl_ctx_init(m_h3_client_context));
+  errata.note(server_ssl_ctx_init(m_h3_server_context));
+  errata.note(S_DIAG, "Finished H3Session::init");
   return errata;
+}
+
+void
+H3Session::terminate()
+{
+  terminate(m_h3_client_context);
+  terminate(m_h3_server_context);
+}
+
+void
+H3Session::terminate(SSL_CTX *&context)
+{
+  SSL_CTX_free(context);
+  context = nullptr;
+}
+
+Errata
+H3Session::client_ssl_ctx_init(SSL_CTX *&client_context)
+{
+  Errata errata;
+  client_context = SSL_CTX_new(OSSL_QUIC_client_method());
+  if (client_context == nullptr) {
+    errata.note(
+        S_ERROR,
+        "Failed to create the OpenSSL QUIC client context: {}",
+        swoc::bwf::SSLError{});
+    return errata;
+  }
+  SSL_CTX_set_default_verify_paths(client_context);
+  if (TLSSession::tls_secrets_are_being_logged()) {
+    SSL_CTX_set_keylog_callback(client_context, TLSSession::keylog_callback);
+  }
+  return errata;
+}
+
+Errata
+H3Session::server_ssl_ctx_init(SSL_CTX *&server_context)
+{
+  server_context = nullptr;
+  return {};
+}
+
+void
+H3Session::set_non_zero_exit_status()
+{
+  if (m_process_exit_code != nullptr) {
+    *m_process_exit_code = 1;
+  }
 }

--- a/src/core/http3.h
+++ b/src/core/http3.h
@@ -1,5 +1,5 @@
 /** @file
- * Common data structures and definitions for Proxy Verifier tools.
+ * Common data structures and definitions for HTTP/3 support.
  *
  * Copyright 2026, Verizon Media
  * SPDX-License-Identifier: Apache-2.0
@@ -13,295 +13,157 @@
 #include <deque>
 #include <list>
 #include <memory>
-#include <mutex>
-#include <ngtcp2/ngtcp2.h>
-#include <ngtcp2/ngtcp2_crypto.h>
-#include <ngtcp2/ngtcp2_crypto_ossl.h>
 #include <nghttp3/nghttp3.h>
 #include <openssl/ssl.h>
-#include <random>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
-#include <vector>
 
-#include "swoc/BufferWriter.h"
 #include "swoc/Errata.h"
 #include "swoc/MemArena.h"
+#include "swoc/swoc_file.h"
 #include "swoc/swoc_ip.h"
 #include "swoc/TextView.h"
 
 class HttpHeader;
 struct Txn;
 
-namespace swoc
-{
-inline namespace SWOC_VERSION_NS
-{
-namespace bwf
-{
-/** Format wrapper for @c ngtcp2 errors.
- */
-struct Ngtcp2Error
-{
-  int _e;
-  explicit Ngtcp2Error(int e) : _e(e) { }
-};
-
-/** Format wrapper for @c nghttp3 errors.
- */
-struct Nghttp3Error
-{
-  int _e;
-  explicit Nghttp3Error(int e) : _e(e) { }
-};
-} // namespace bwf
-
-BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, bwf::Ngtcp2Error const &error);
-BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, bwf::Nghttp3Error const &error);
-} // namespace SWOC_VERSION_NS
-} // namespace swoc
-
-/** Contains information for a particular cycle of reading QUIC packets.
- *
- * ngtcp2 requires some state to be maintained within a cycle of reading a set
- * of packets. By "cycle" I mean a single set of processing ingress and egress
- * packets. This information is shared across the relevant function calls via
- * an instance of PacketIoContext. In curl, this is the c-struct pkt_io_ctx.
- */
-struct PacketIoContext
-{
-public:
-  /** Initialize PacketIoContext. */
-  PacketIoContext();
-
-public:
-  ngtcp2_tstamp ts = 0;
-  size_t pkt_count = 0;
-  ngtcp2_path_storage ps;
-};
-
-/** Encapsulate the buffer for the QUIC hanshake. */
-class QuicHandshake
-{
-public:
-  QuicHandshake();
-  ~QuicHandshake() = default;
-
-  QuicHandshake(QuicHandshake const &) = delete;
-  QuicHandshake &operator=(QuicHandshake const &) = delete;
-
-public:
-  /** This is the maximum number of bytes we expect to use for the QUIC
-   * handshake.
-   *
-   * This max value is taken from CURL code which has a comment expressing
-   * tentative hope that this should be large enough. There is an assertion in
-   * our (and theirs, I believe) implementation guarding this invariant. If we
-   * trip that, we may need to expand this.
-   */
-  static constexpr size_t max_handshake_size = 4 * 1024;
-
-  /** This contains the storage for the QUIC handshake. */
-  std::vector<char> buf;
-};
-
-/** The various elements related to the ngtcp2 API calls.
- *
- * For reference, this is based off of curl's struct quicsocket in ngtcp2.h.
- */
+/** The OpenSSL QUIC connection and its HTTP/3 streams. */
 class QuicSocket
 {
 public:
-  QuicSocket();
+  QuicSocket() = default;
   ~QuicSocket();
   QuicSocket(QuicSocket const &) = delete;
   QuicSocket &operator=(QuicSocket const &) = delete;
 
-  /** Open a QUIC log file for writing.
-   *
-   * This assumes that scid has been previously configured.
-   */
-  swoc::Errata open_qlog_file();
+  /** Release the current QUIC connection and all associated streams. */
+  void reset();
 
-  /** Randomly populate an array of a given size.
+  /** Create a locally initiated QUIC stream.
    *
-   * This is used to initialize the various connection ids.
-   *
-   * @param[in] array The buffer to populate
-   *
-   * @param[in] array_len The number of bytes in the array to populate.
+   * @param[in] unidirectional Whether to create a unidirectional stream.
+   * @return The new stream, or error diagnostics.
    */
-  static void randomly_populate_array(uint8_t *array, size_t array_len);
+  swoc::Rv<SSL *> open_stream(bool unidirectional);
+
+  /** Record a remotely initiated QUIC stream.
+   *
+   * @param[in] stream The OpenSSL stream object to own.
+   */
+  void add_stream(SSL *stream);
+
+  /** Look up an OpenSSL stream by its QUIC stream identifier.
+   *
+   * @param[in] stream_id The QUIC stream identifier.
+   * @return The stream object, or @c nullptr if it is not registered.
+   */
+  SSL *find_stream(int64_t stream_id) const;
 
   /** Configure QUIC logging for the provided directory.
+   *
+   * OpenSSL's native QUIC API does not currently expose qlog events. The
+   * directory is still created and validated so the existing command-line
+   * option remains compatible and can become active when OpenSSL adds that
+   * support.
    *
    * @param[in] qlog_dir The directory into which QUIC log files should be
    * written.
    */
   static swoc::Errata configure_qlog_dir(swoc::TextView qlog_dir);
 
-  /** The callback function for ngtcp2 QUIC logging.
-   *
-   * For details, see the ngtcp2 document for ngtcp2_qlog_write.
-   */
-  static void qlog_callback(void *user_data, uint32_t flags, const void *data, size_t datalen);
-
 public:
-  ngtcp2_conn *qconn = nullptr;
-  ngtcp2_cid dcid;
-  ngtcp2_cid scid;
-  uint32_t version = 0;
-  ngtcp2_settings settings;
-  ngtcp2_transport_params transport_params;
-  ngtcp2_ccerr last_error;
-  ngtcp2_crypto_conn_ref conn_ref;
-  ngtcp2_crypto_ossl_ctx *ossl_ctx = nullptr;
-  SSL_CTX *sslctx = nullptr;
-  SSL *ssl = nullptr;
-  /// 3 is the maximum enum value in ngtcp2_crypto_level.
-  static constexpr int MAX_NGTCP2_CRYPTO_LEVEL = 3;
-  /* The last TLS alert description generated by the local endpoint */
-  uint8_t tls_alert = 0;
-  swoc::IPEndpoint local_addr;
-
-  nghttp3_conn *h3conn = nullptr;
-  nghttp3_settings h3settings;
-  int qlogfd = -1;
+  SSL *connection = nullptr;                            ///< The OpenSSL QUIC connection object.
+  nghttp3_conn *h3conn = nullptr;                       ///< The nghttp3 connection object.
+  std::unordered_map<int64_t, SSL *> streams;           ///< QUIC streams by stream identifier.
+  std::unordered_set<int64_t> streams_with_fin;         ///< Streams whose receive side has ended.
+  std::unordered_set<int64_t> streams_concluded;        ///< Streams whose send side has ended.
+  std::unordered_set<int64_t> streams_pending_conclude; ///< Streams waiting to send FIN.
 
 private:
-  // Members to support random number generation for connection id.
-  static std::random_device _rd;
-  static std::mt19937 _rng;
-  static std::uniform_int_distribution<int> _uni_id;
-
-  /** The directory into which QUIC log files will be written.
-   *
-   * This may be empty. If so, no QUIC logging will take place.
-   */
-  static swoc::file::path _qlog_dir;
-
-  /// A mutex to ensure serialized writing to qlogfd.
-  static std::mutex _qlog_mutex;
+  static swoc::file::path m_qlog_dir;
 };
 
 /** Representation of an HTTP/3 stream (a single transaction). */
 class H3StreamState
 {
 public:
-  /**
-   * @param[in] is_client Whether this stream state is for a client. That is,
-   * is this stream state functioning as a client that will send a request, or
-   * a server receiving a request and sending a response.
+  /** Construct stream state.
+   *
+   * @param[in] is_client Whether this stream sends a request and receives a
+   * response.
    */
-  H3StreamState(bool is_client);
+  explicit H3StreamState(bool is_client);
   ~H3StreamState();
 
-  /// Whether this stream is for a server receiving a request from a client.
+  /** Return whether this stream receives a request. */
   bool will_receive_request() const;
 
-  /// Whether this stream is for a client receiving a response from a server.
+  /** Return whether this stream receives a response. */
   bool will_receive_response() const;
 
-  /// Set the stream_id for this and the appropriate members.
+  /** Set the QUIC stream identifier.
+   *
+   * @param[in] stream_id The stream identifier.
+   */
   void set_stream_id(int64_t stream_id);
 
-  /// Retrieve the stream id for this stream.
+  /** Return the QUIC stream identifier. */
   int64_t get_stream_id() const;
 
-  /** Increment the nghttp3 reference count on buf and return a view of it.
+  /** Retain an nghttp3 reference-counted buffer and return a view of it.
    *
-   * A reference count to the buffer will be held for the remainder of the
-   * lifetime of the stream.
-   *
-   * @param[in] buf The nghttp3 ref counted buffer to register and for which a
-   * TextView will be returned.
-   *
-   * @return A view representation of the given buffer.
+   * @param[in] rcbuf The nghttp3 buffer to retain.
+   * @return A view of the buffer contents.
    */
   swoc::TextView register_rcbuf(nghttp3_rcbuf *rcbuf);
 
 public:
-  /// The key identifying this HTTP transaction.
-  std::string key;
+  std::string key; ///< The key identifying this HTTP transaction.
 
-  /** The composed URL parts from :method, :authority, and :path pseudo headers
-   * from the request.
-   *
-   * This is stored in this object to persist its storage because parse_url
-   * assigns from this string TextViews.
-   */
+  /** Storage for a URL composed from request pseudo headers. */
   std::string composed_url;
 
-  /// Headers have been received from the peer.
-  bool have_received_headers = false;
-
-  /// The time the stream started. Used for timing calculations.
-  std::chrono::time_point<std::chrono::steady_clock> stream_start;
-
-  /// The HTTP request headers for this stream.
-  std::shared_ptr<HttpHeader> request_from_client;
-
-  /// The HTTP response headers for this stream.
-  std::shared_ptr<HttpHeader> response_from_server;
-
-  /// The request the YAML file indicated should be received from the client.
-  //
-  // This is only used when will_receive_request is True
-  HttpHeader const *specified_request = nullptr;
-
-  /// The response the YAML file indicated should be received from the server.
-  //
-  // This is only used when will_receive_response is True.
-  HttpHeader const *specified_response = nullptr;
-
-  /// The body received.
-  std::string body_received;
-
-  /// The body that will be sent for this message.
-  swoc::TextView body_to_send;
-
-  /** For requests, whether this requests is waiting for a 100 Continue
-   * response. */
-  bool wait_for_continue = false;
-
-  /// The number unacknowledged data frame bytes sent.
-  size_t num_data_bytes_written = 0;
+  bool have_received_headers = false; ///< Whether headers have been received.
+  std::chrono::time_point<std::chrono::steady_clock> stream_start; ///< Stream start time.
+  std::shared_ptr<HttpHeader> request_from_client;  ///< The received request headers.
+  std::shared_ptr<HttpHeader> response_from_server; ///< The received response headers.
+  HttpHeader const *specified_request = nullptr;    ///< Expected request headers.
+  HttpHeader const *specified_response = nullptr;   ///< Expected response headers.
+  std::string body_received;                        ///< The received body.
+  swoc::TextView body_to_send;                      ///< The body to send.
+  bool wait_for_continue = false;    ///< Whether the request waits for a 100 response.
+  size_t num_data_bytes_written = 0; ///< Unacknowledged DATA payload bytes.
 
 private:
-  /// Whether this H3StreamState will be receiving a request (i.e., is an
-  /// H3StreamState for a server).
-  bool _will_receive_request = false;
-
-  /** The QUIC stream ID for this stream. */
-  int64_t _stream_id = 0;
-  std::deque<nghttp3_rcbuf *> _rcbufs_to_free;
+  bool m_will_receive_request = false;
+  int64_t m_stream_id = 0;
+  std::deque<nghttp3_rcbuf *> m_rcbufs_to_free;
 };
 
-/** Representation of an HTTP/3 connection.
- *
- * An H3Session has a one to many relationship with H3StreamState objects.
- */
+/** Representation of a client-side HTTP/3 connection. */
 class H3Session : public Session
 {
 public:
   using super_type = Session;
+
   H3Session();
   H3Session(swoc::TextView const &client_sni, int client_verify_mode = SSL_VERIFY_NONE);
-  ~H3Session();
+  ~H3Session() override;
+
   swoc::Rv<ssize_t> read(swoc::MemSpan<char> span) override;
   swoc::Rv<ssize_t> write(swoc::TextView data) override;
   swoc::Rv<ssize_t> write(HttpHeader const &hdr) override;
 
-  /** Populate an nghttp3_nv header vector structure from an HttpHeader. */
+  /** Populate nghttp3 name/value entries from an HTTP header.
+   *
+   * @param[in] hdr The header to convert.
+   * @param[out] nv_hdr The allocated name/value array.
+   * @param[out] hdr_count The number of populated entries.
+   * @return Any conversion diagnostics.
+   */
   swoc::Errata pack_headers(HttpHeader const &hdr, nghttp3_nv *&nv_hdr, int &hdr_count);
 
-  /** For HTTP/3, we read on the socket until an entire stream is done.
-   *
-   * For HTTP/1, we first read headers to get the Content-Length or other
-   * header information to direct reading the body. For HTTP/3, this isn't
-   * an issue because bodies are explicitly framed.
-   */
   swoc::Rv<int> poll_for_headers(std::chrono::milliseconds timeout) override;
   swoc::Rv<std::shared_ptr<HttpHeader>> read_and_parse_request(swoc::FixedBufferWriter &w) override;
   swoc::Rv<size_t> drain_body(
@@ -310,158 +172,113 @@ public:
       swoc::TextView bytes_read,
       std::shared_ptr<RuleCheck> rule_check = nullptr) override;
 
-  /** Perform the server-side QUIC handshake for a connection. */
+  /** Report that server-side OpenSSL QUIC is unsupported. */
   swoc::Errata accept() override;
 
-  /** Perform the client-side QUIC handshake for a connection. */
+  /** Complete the client-side QUIC handshake. */
   swoc::Errata connect() override;
 
-  /** Establish a QUIC connection from the given interface to the given IP
-   * address.
+  /** Establish an HTTP/3 connection.
    *
-   * @note: the pp_msg parameter is added to fit the override signature of
-   * do_connect(). There is no current support for PROXY Protocol for QUIC
-   * connections.
+   * @param[in] interface The optional local interface.
+   * @param[in] target The remote endpoint.
+   * @param[in] pp_msg Ignored because QUIC does not support PROXY protocol.
+   * @return Connection diagnostics.
    */
   swoc::Errata do_connect(
       swoc::TextView interface,
       swoc::IPEndpoint const *target,
       ProxyProtocolMsg *pp_msg = nullptr) override;
 
-  /** Perform HTTP/3 global initialization.
+  /** Perform process-wide HTTP/3 initialization.
    *
-   * @param[in] process_exit_code: The integer to set to non-zero on failure
-   * conditions. This is necessary because many ngtcp2 and nghttp3 callbacks do
-   * not have direct returns to their callers.
-   *
-   * @param[in] qlog_dir The directory for qlog files. If this is an empty
-   * string, no QUIC logging will be done.
+   * @param[in] process_exit_code The exit status updated on verification
+   * failures.
+   * @param[in] qlog_dir The requested qlog directory.
+   * @return Initialization diagnostics.
    */
   static swoc::Errata init(int *process_exit_code, swoc::TextView qlog_dir);
 
-  /** Delete global instances. */
+  /** Release process-wide HTTP/3 resources. */
   static void terminate();
 
-  /** Indicates that that the user should receive a non-zero status code.
-   *
-   * Most of this code is blocking a procedural and this can be communicated to
-   * the caller via Errata. But the HTTP/2 nghttp2 callbacks do not return
-   * directly to a caller. Therefore this is used to communicate a non-zero
-   * status.
-   */
+  /** Mark the process exit status as unsuccessful. */
   static void set_non_zero_exit_status();
 
-  /** Perform the HTTP/3 (ngtcp2 and nghttp3) configuration and QUIC handshake
-   * for a client connection. */
-  swoc::Errata client_session_init(PacketIoContext *packet_context);
-
-  /** Perform the HTTP/3 (ngtcp2 and nghttp3) configuration for a server
-   * connection. */
-  swoc::Errata server_session_init();
-
-  /** Run all the transactions against the specified target. */
   swoc::Errata run_transactions(
       std::list<Txn> const &transactions,
       swoc::TextView interface,
       swoc::IPEndpoint const *target,
       double rate_multiplier) override;
-
-  /** Replay the given transaction for this session. */
   swoc::Errata run_transaction(Txn const &transaction) override;
 
-  /** Indicate that the stream has ended (received the END_STREAM flag).
+  /** Record that a stream has ended.
    *
-   * @param[in] stream_id The stream identifier for which the end stream has
-   * been processed.
-   *
-   * @param[in] key The key for the stream which ended.
+   * @param[in] stream_id The ended stream identifier.
+   * @param[in] key The transaction key.
    */
   void set_stream_has_ended(int64_t stream_id, std::string_view key);
 
-  /// Whether an entire stream has been received and is ready for processing.
+  /** Return whether a completed stream is ready for processing. */
   bool get_a_stream_has_ended() const;
 
+  /** Associate HTTP/3 state with a QUIC stream.
+   *
+   * @param[in] stream_id The stream identifier.
+   * @param[in] stream_state The state to associate.
+   */
   void record_stream_state(int64_t stream_id, std::shared_ptr<H3StreamState> stream_state);
 
+  /** Remember a response finalized before its close callback.
+   *
+   * @param[in] stream_id The stream identifier.
+   */
   void mark_completed_response_stream(int64_t stream_id);
 
+  /** Remove a remembered finalized response stream.
+   *
+   * @param[in] stream_id The stream identifier.
+   * @return Whether the stream was remembered.
+   */
   bool clear_completed_response_stream(int64_t stream_id);
 
 public:
-  /// A mapping from stream_id to H3StreamState.
   std::unordered_map<int64_t, std::shared_ptr<H3StreamState>> stream_map;
-
-  /// The representation of the QUIC socket for this stream (connection).
   QuicSocket quic_socket;
 
 protected:
-  /** Initialize the client-side SSL_CTS used across all connections. */
+  /** Initialize the client-side OpenSSL QUIC context. */
   static swoc::Errata client_ssl_ctx_init(SSL_CTX *&client_context);
 
-  /** Initialize the server-side SSL_CTS used across all connections. */
+  /** Server-side HTTP/3 is not implemented. */
   static swoc::Errata server_ssl_ctx_init(SSL_CTX *&server_context);
+
+  /** Release an SSL context.
+   *
+   * @param[in,out] client_context The context to release and clear.
+   */
   static void terminate(SSL_CTX *&client_context);
 
 protected:
-  /** The SNI to be sent by the client (as opposed to the one expected by the
-   * server from the proxy). This only applies to the client.
-   */
-  std::string _client_sni;
-
-  /** The verify mode for the client in the TLS handshake with the proxy.
-   * This only applies to the client.
-   */
-  int _client_verify_mode = SSL_VERIFY_NONE;
-
-  SSL *_ssl = nullptr;
+  std::string m_client_sni;
+  int m_client_verify_mode = SSL_VERIFY_NONE;
 
 private:
   nghttp3_nv tv_to_nv(char const *name, swoc::TextView v);
-
-  /** Create and configure the UDP socket for this connection. */
   swoc::Errata configure_udp_socket(swoc::TextView interface, swoc::IPEndpoint const *target);
-
-  /** Create and configure the SSL instance for this session. */
   swoc::Errata client_ssl_session_init(SSL_CTX *client_context);
-
+  swoc::Errata initialize_http3_connection();
   swoc::Errata receive_responses();
-
-  /** Determine whether the transaction is still awaiting upon other configured streams.
-   *
-   * @param[in] txn The transaction to check.
-   * @return Whether the transaction is still awaiting upon other configured streams.
-   */
   bool request_has_outstanding_stream_dependencies(HttpHeader const &request) const;
 
 private:
-  /** The streams which have completed */
-  std::deque<int64_t> _ended_streams;
-  swoc::IPEndpoint const *_endpoint = nullptr;
+  std::deque<int64_t> m_ended_streams;
+  swoc::IPEndpoint const *m_endpoint = nullptr;
+  std::shared_ptr<H3StreamState> m_last_added_stream;
+  std::unordered_set<std::string> m_finished_streams;
+  std::unordered_set<int64_t> m_completed_response_streams;
 
-  std::shared_ptr<H3StreamState> _last_added_stream;
-
-  /// The set of streams which have completed already.
-  std::unordered_set<std::string> _finished_streams;
-
-  /// Response streams that were finalized on END_STREAM before STREAM_CLOSE.
-  std::unordered_set<int64_t> _completed_response_streams;
-
-  /** The client context to use for HTTP/3 connections.
-   *
-   * This is used per HTTP/3 connection so that ALPN advertises h3. For HTTP/1
-   * TLS connections, client_context is used which does not advertise h2
-   * support.
-   */
-  static SSL_CTX *_h3_client_context;
-
-  /** The client context to use for HTTP/3 connections.
-   *
-   * This is used per HTTP/3 connection so that ALPN advertises h3. For HTTP/1
-   * TLS connections, client_context is used which does not advertise h2
-   * support.
-   */
-  static SSL_CTX *_h3_server_context;
-
-  /// The system status code. This is set to non-zero if problems are detected.
-  static int *process_exit_code;
+  static SSL_CTX *m_h3_client_context;
+  static SSL_CTX *m_h3_server_context;
+  static int *m_process_exit_code;
 };

--- a/tools/build-library-dependencies.sh
+++ b/tools/build-library-dependencies.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Build QUIC/HTTP3 library dependencies.
+# Build HTTP and QUIC library dependencies.
 #
 # Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
@@ -15,7 +15,7 @@ usage() {
   cat <<'EOF'
 Usage: tools/build-library-dependencies.sh [--portable] <install-dir>
 
-Build QUIC/HTTP3 library dependencies into <install-dir>.
+Build OpenSSL 3.5, nghttp2, and nghttp3 into <install-dir>.
 
 Use --portable to add conservative Linux amd64 baseline flags suitable for
 portable release builds.
@@ -24,9 +24,8 @@ EOF
 
 set -euo pipefail
 
-OPENSSL_TAG=openssl-3.5.5
+OPENSSL_TAG=openssl-3.5.7
 NGHTTP3_TAG=v1.15.0
-NGTCP2_TAG=v1.21.0
 NGHTTP2_TAG=v1.68.0
 
 os=$(uname)
@@ -81,10 +80,12 @@ then
   portable_cpu_flags="-march=x86-64 -mtune=generic"
 fi
 
-for tool in git make pkg-config autoreconf autoconf automake
+for tool in git make perl pkg-config autoreconf autoconf automake
 do
   command -v "${tool}" >/dev/null 2>&1 || fail "Missing required tool: ${tool}"
 done
+perl -MTime::Piece -e 1 >/dev/null 2>&1 || fail \
+  "Missing required Perl module: Time::Piece"
 
 if [ "${os}" = "Linux" ]
 then
@@ -150,7 +151,7 @@ append_env_flags CFLAGS "${portable_cpu_flags}"
 append_env_flags CXXFLAGS "${portable_cpu_flags}"
 
 mkdir -p "${install_dir}"
-repo_dir=$(mktemp -d /var/tmp/http3_dependency_repos_XXXXXX)
+repo_dir=$(mktemp -d /var/tmp/http_dependency_repos_XXXXXX)
 cleanup() {
   rm -rf "${repo_dir}"
 }
@@ -180,7 +181,7 @@ install_with_permissions() {
 
 cd "${repo_dir}"
 
-# 1. OpenSSL with built-in QUIC support.
+# OpenSSL with built-in QUIC support.
 clone_tagged_repo https://github.com/openssl/openssl.git openssl "${OPENSSL_TAG}"
 cd openssl
 ./config enable-tls1_3 --prefix="${install_dir}/openssl" --libdir=lib
@@ -188,7 +189,7 @@ make -j "${num_threads}"
 ${SUDO} make install_sw
 chmod_with_permissions "${install_dir}/openssl"
 
-# 2. nghttp3
+# nghttp3 provides HTTP/3 framing and QPACK.
 cd "${repo_dir}"
 clone_tagged_repo https://github.com/ngtcp2/nghttp3.git nghttp3 "${NGHTTP3_TAG}"
 cd nghttp3
@@ -198,29 +199,12 @@ autoreconf -if
 make -j "${num_threads}"
 install_with_permissions "${install_dir}/nghttp3"
 
-# 3. ngtcp2
-cd "${repo_dir}"
-clone_tagged_repo https://github.com/ngtcp2/ngtcp2.git ngtcp2 "${NGTCP2_TAG}"
-cd ngtcp2
-git submodule update --init
-autoreconf -if
-PKG_CONFIG_PATH="${install_dir}/openssl/lib/pkgconfig:${install_dir}/nghttp3/lib/pkgconfig" \
-LDFLAGS="-Wl,-rpath,${install_dir}/openssl/lib" \
-./configure \
-  --prefix="${install_dir}/ngtcp2" \
-  --enable-lib-only
-make -j "${num_threads}"
-install_with_permissions "${install_dir}/ngtcp2"
-
-# 4. nghttp2
+# nghttp2 provides HTTP/2 framing and HPACK.
 cd "${repo_dir}"
 clone_tagged_repo https://github.com/nghttp2/nghttp2.git nghttp2 "${NGHTTP2_TAG}"
 cd nghttp2
 git submodule update --init
 autoreconf -if
-PKG_CONFIG_PATH="${install_dir}/openssl/lib/pkgconfig:${install_dir}/ngtcp2/lib/pkgconfig:${install_dir}/nghttp3/lib/pkgconfig" \
-./configure \
-  --prefix="${install_dir}/nghttp2" \
-  --enable-lib-only
+./configure --prefix="${install_dir}/nghttp2" --enable-lib-only
 make -j "${num_threads}"
 install_with_permissions "${install_dir}/nghttp2"


### PR DESCRIPTION
Replace the ngtcp2 transport with OpenSSL's native QUIC API while
retaining nghttp3 for HTTP/3 framing and nghttp2 for HTTP/2.

Require OpenSSL 3.5+, update dependency discovery and builds, and
document the system/prebuilt layouts and qlog limitation. Validate H3
on macOS and Fedora 44 with system and source-built dependencies.