### PR TITLE
Bake system tools into CI image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,11 +39,6 @@ jobs:
       - name: Trust the container workspace
         run: git config --global --add safe.directory "${GITHUB_WORKSPACE}"
 
-      - name: Install formatter dependencies
-        run: |
-          apt-get update
-          DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends lbzip2
-
       - name: Format
         run: bash -e tools/format.sh
 
@@ -56,26 +51,9 @@ jobs:
     timeout-minutes: 30
     container:
       image: ci.trafficserver.apache.org/proxy-verifier/ubuntu:24.04
-    env:
-      RAT_VERSION: 0.17
-      RAT_SHA256: 401939ebe5a52c6ed524029897bf914eaaba503d36c069ebcdbd8847a9e7cf93
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
-
-      - name: Install Java
-        run: |
-          apt-get update
-          DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends default-jre-headless
-
-      - name: Download Apache RAT
-        run: |
-          rat_jar="${RUNNER_TEMP}/apache-rat-${RAT_VERSION}.jar"
-          curl --fail --location --silent --show-error \
-            --output "${rat_jar}" \
-            "https://repo.maven.apache.org/maven2/org/apache/rat/apache-rat/${RAT_VERSION}/apache-rat-${RAT_VERSION}.jar"
-          echo "${RAT_SHA256}  ${rat_jar}" | sha256sum --check
-          echo "RAT_JAR=${rat_jar}" >> "${GITHUB_ENV}"
 
       - name: Run Apache RAT
         run: |
@@ -101,6 +79,9 @@ jobs:
     timeout-minutes: 60
     container:
       image: ci.trafficserver.apache.org/proxy-verifier/ubuntu:24.04
+    env:
+      CC: clang-20
+      CXX: clang++-20
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -128,6 +109,9 @@ jobs:
     timeout-minutes: 60
     container:
       image: ci.trafficserver.apache.org/proxy-verifier/ubuntu:24.04
+    env:
+      CC: gcc-14
+      CXX: g++-14
     steps:
       - name: Check out repository
         uses: actions/checkout@v6

--- a/docker/ubuntu_24.04/Dockerfile
+++ b/docker/ubuntu_24.04/Dockerfile
@@ -8,9 +8,14 @@ FROM docker.io/library/ubuntu:24.04 AS dev-base
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ARG DEBIAN_FRONTEND=noninteractive
+ARG RAT_VERSION=0.17
+ARG RAT_SHA256=401939ebe5a52c6ed524029897bf914eaaba503d36c069ebcdbd8847a9e7cf93
 
-ENV PATH="/opt/pv-venv/bin:${PATH}" \
-    PV_DEPS_ROOT="/opt/pv_libs"
+ENV CC="gcc-14" \
+    CXX="g++-14" \
+    PATH="/opt/pv-venv/bin:${PATH}" \
+    PV_DEPS_ROOT="/opt/pv_libs" \
+    RAT_JAR="/opt/apache-rat/apache-rat-${RAT_VERSION}.jar"
 
 RUN <<'EOF'
 set -eux
@@ -18,11 +23,14 @@ set -eux
 apt-get update
 apt-get install -y --no-install-recommends \
   ca-certificates \
+  clang-20 \
   curl \
+  default-jre-headless \
   diffutils \
-  g++ \
-  gcc \
+  g++-14 \
+  gcc-14 \
   git \
+  lbzip2 \
   libc6-dev \
   libffi-dev \
   libssl-dev \
@@ -39,6 +47,16 @@ export PATH="/opt/pv-venv/bin:${PATH}"
 PROFILE
 
 rm -rf /var/lib/apt/lists/*
+EOF
+
+RUN <<'EOF'
+set -eux
+
+mkdir -p "$(dirname "${RAT_JAR}")"
+curl --fail --location --silent --show-error \
+  --output "${RAT_JAR}" \
+  "https://repo.maven.apache.org/maven2/org/apache/rat/apache-rat/${RAT_VERSION}/apache-rat-${RAT_VERSION}.jar"
+echo "${RAT_SHA256}  ${RAT_JAR}" | sha256sum --check
 EOF
 
 FROM dev-base AS deps-builder

--- a/tools/CI-IMAGES.md
+++ b/tools/CI-IMAGES.md
@@ -7,10 +7,13 @@
 
 # Proxy Verifier CI Images
 
-The Ubuntu CI image provides the Proxy Verifier build and AuTest toolchain plus
-prebuilt OpenSSL, nghttp2, and nghttp3 libraries under `/opt/pv_libs`. CI can
-therefore use the `dev-external` CMake preset without rebuilding those
-dependencies for every pull request.
+The Ubuntu CI image provides GCC 14, Clang 20, the Proxy Verifier build and
+AuTest toolchain, the formatting and license-audit system packages, and a
+checksum-verified Apache RAT JAR. It also provides prebuilt OpenSSL, nghttp2,
+and nghttp3 libraries under `/opt/pv_libs`. CI can therefore use the
+`dev-external` CMake preset without rebuilding those dependencies or installing
+system packages for every pull request. Python dependencies remain managed by
+the repository's locked `uv` environments and are not baked into the image.
 
 These images are for development and CI workflows, not deployment. Use the
 statically linked binaries attached to Proxy Verifier releases for deployment.
@@ -92,7 +95,14 @@ docker run --rm --platform linux/amd64 \
     cmake --version
     ninja --version
     uv --version
-    /opt/pv_libs/openssl/bin/openssl version
+    gcc-14 --version
+    g++-14 --version
+    clang-20 --version
+    clang++-20 --version
+    java -version
+    test -r "${RAT_JAR}"
+    java -jar "${RAT_JAR}" --help >/dev/null
+    LD_LIBRARY_PATH=/opt/pv_libs/openssl/lib /opt/pv_libs/openssl/bin/openssl version
     find /opt/pv_libs -mindepth 1 -maxdepth 1 -type d -printf "%f\n" | sort
   '
 ```
@@ -144,7 +154,14 @@ docker run --rm --platform linux/arm64 \
     cmake --version
     ninja --version
     uv --version
-    /opt/pv_libs/openssl/bin/openssl version
+    gcc-14 --version
+    g++-14 --version
+    clang-20 --version
+    clang++-20 --version
+    java -version
+    test -r "${RAT_JAR}"
+    java -jar "${RAT_JAR}" --help >/dev/null
+    LD_LIBRARY_PATH=/opt/pv_libs/openssl/lib /opt/pv_libs/openssl/bin/openssl version
     find /opt/pv_libs -mindepth 1 -maxdepth 1 -type d -printf "%f\n" | sort
   '
 ```


### PR DESCRIPTION
Install the compiler, formatting, and license-audit system tools in
the Ubuntu CI image so every workflow run does not download them.

Build unit tests with Clang 20 and AuTests with GCC 14 while keeping
their Python dependencies managed at workflow runtime.