### PR TITLE
Update copyright years from git history

### DIFF
--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -9,7 +9,9 @@ When creating a commit for a patch:
 
 - Run `bash tools/format.sh` if formatting has not been run since the last edits.
 - Most files should have a copyright, save files like gold files and .json files which don't take comments.
-- Run `bash tools/copyright-update.sh` after the final edits to update copyrights. With no argument it updates currently changed files; with a commit argument it updates the files touched by that commit.
+- Run `bash tools/copyright-update.sh` after the final edits. It updates each
+  tracked file's copyright to its most recent commit year. With a commit
+  argument it limits the update to files touched by that commit.
 - Verify every changed or new file that carries a copyright header uses the current year before committing.
 - Write a short one-line summary (target: under ~60 characters).
 - Add a concise body (1-3 short paragraphs) focused on why the change is needed and how it resolves the issue.

--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -7,12 +7,11 @@ description: Write a git commit message and verify formatting before committing.
 
 When creating a commit for a patch:
 
-- Run `bash tools/format.sh` if formatting has not been run since the last edits.
+- Run `bash tools/pr-prep.sh` after the final edits to format the worktree and
+  update copyright years.
 - Most files should have a copyright, save files like gold files and .json files which don't take comments.
-- Run `bash tools/copyright-update.sh` after the final edits. It updates each
-  tracked file's copyright to its most recent commit year. With a commit
-  argument it limits the update to files touched by that commit.
-- Verify every changed or new file that carries a copyright header uses the current year before committing.
+- Verify every changed or new file that carries a copyright header ends with
+  its most recent commit year before committing.
 - Write a short one-line summary (target: under ~60 characters).
 - Add a concise body (1-3 short paragraphs) focused on why the change is needed and how it resolves the issue.
 - Wrap all commit message lines at 72 characters or less.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,8 @@ Please follow [best practices](https://github.com/trein/dev-best-practices/wiki/
 
 When your code is ready to be submitted, read github's article about how to [submit a pull request](https://help.github.com/articles/creating-a-pull-request/) to begin the code review process and follow its directions. Before creaing a pull request, please do the following to make sure the patch is ready for review:
 
-1. Run the tools/format.sh script to format the source code according to the repository's formatting standards.
+1. Run `tools/pr-prep.sh` to format the source code and update copyright years
+   according to the repository's standards.
 1. Verify that all AuTests pass (see the [README](https://github.com/yahoo/proxy-verifier/blob/master/README.md) for instructions on how to run the AuTests).
 1. Verify that all unit tests pass (see the [README](https://github.com/yahoo/proxy-verifier/blob/master/README.md) for instructions on how to run the unit tests).
 

--- a/NOTICES
+++ b/NOTICES
@@ -1,6 +1,6 @@
 Proxy Verifier
 
-Copyright 2020, Verizon Media
+Copyright 2026, Verizon Media
 SPDX-License-Identifier: Apache-2.0
 
 ~~~

--- a/NOTICES
+++ b/NOTICES
@@ -1,6 +1,6 @@
 Proxy Verifier
 
-Copyright 2026, Verizon Media
+Copyright 2020-2026, Verizon Media
 SPDX-License-Identifier: Apache-2.0
 
 ~~~

--- a/src/core/case_insensitive_utils.h
+++ b/src/core/case_insensitive_utils.h
@@ -1,7 +1,7 @@
 /** @file
  * Data structures to support case-insensitive containers.
  *
- * Copyright 2021, Verizon Media
+ * Copyright 2026, Verizon Media
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/src/core/case_insensitive_utils.h
+++ b/src/core/case_insensitive_utils.h
@@ -1,7 +1,7 @@
 /** @file
  * Data structures to support case-insensitive containers.
  *
- * Copyright 2026, Verizon Media
+ * Copyright 2021-2026, Verizon Media
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/src/core/http2.h
+++ b/src/core/http2.h
@@ -1,7 +1,7 @@
 /** @file
  * Common data structures and definitions for Proxy Verifier tools.
  *
- * Copyright 2026, Verizon Media
+ * Copyright 2022-2026, Verizon Media
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/src/core/http2.h
+++ b/src/core/http2.h
@@ -1,7 +1,7 @@
 /** @file
  * Common data structures and definitions for Proxy Verifier tools.
  *
- * Copyright 2022, Verizon Media
+ * Copyright 2026, Verizon Media
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/src/core/yaml_util.h
+++ b/src/core/yaml_util.h
@@ -1,6 +1,6 @@
 /** @file
  *
- * Copyright 2020, Verizon Media
+ * Copyright 2026, Verizon Media
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/src/core/yaml_util.h
+++ b/src/core/yaml_util.h
@@ -1,6 +1,6 @@
 /** @file
  *
- * Copyright 2026, Verizon Media
+ * Copyright 2020-2026, Verizon Media
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/tests/autests/gold_tests/arguments/format_argument/format_argument.test.py
+++ b/tests/autests/gold_tests/arguments/format_argument/format_argument.test.py
@@ -3,7 +3,7 @@ Verify --format argument parsing.
 '''
 # @file
 #
-# Copyright 2026, Verizon Media
+# Copyright 2022-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/arguments/format_argument/format_argument.test.py
+++ b/tests/autests/gold_tests/arguments/format_argument/format_argument.test.py
@@ -3,7 +3,7 @@ Verify --format argument parsing.
 '''
 # @file
 #
-# Copyright 2022, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/arguments/keys_argument/keys_arg.test.py
+++ b/tests/autests/gold_tests/arguments/keys_argument/keys_arg.test.py
@@ -3,7 +3,7 @@ Verify the user can white list transactions with --keys.
 '''
 # @file
 #
-# Copyright 2022, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/arguments/keys_argument/keys_arg.test.py
+++ b/tests/autests/gold_tests/arguments/keys_argument/keys_arg.test.py
@@ -3,7 +3,7 @@ Verify the user can white list transactions with --keys.
 '''
 # @file
 #
-# Copyright 2026, Verizon Media
+# Copyright 2022-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/arguments/port_argument/no_port_argument.test.py
+++ b/tests/autests/gold_tests/arguments/port_argument/no_port_argument.test.py
@@ -3,7 +3,7 @@ Verify there is an error if the user provides no port arguments.
 '''
 # @file
 #
-# Copyright 2026, Verizon Media
+# Copyright 2021-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/arguments/port_argument/no_port_argument.test.py
+++ b/tests/autests/gold_tests/arguments/port_argument/no_port_argument.test.py
@@ -3,7 +3,7 @@ Verify there is an error if the user provides no port arguments.
 '''
 # @file
 #
-# Copyright 2021, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/arguments/repeat_argument/repeat_argument.test.py
+++ b/tests/autests/gold_tests/arguments/repeat_argument/repeat_argument.test.py
@@ -3,7 +3,7 @@ Verify the user can repeat transactions with --repeat.
 '''
 # @file
 #
-# Copyright 2026, Verizon Media
+# Copyright 2021-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/arguments/repeat_argument/repeat_argument.test.py
+++ b/tests/autests/gold_tests/arguments/repeat_argument/repeat_argument.test.py
@@ -3,7 +3,7 @@ Verify the user can repeat transactions with --repeat.
 '''
 # @file
 #
-# Copyright 2021, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/autest-site/client.test.ext
+++ b/tests/autests/gold_tests/autest-site/client.test.ext
@@ -3,7 +3,7 @@ Implement the Proxy Verifier client extensions.
 '''
 # @file
 #
-# Copyright 2026, Verizon Media
+# Copyright 2021-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/autest-site/client.test.ext
+++ b/tests/autests/gold_tests/autest-site/client.test.ext
@@ -3,7 +3,7 @@ Implement the Proxy Verifier client extensions.
 '''
 # @file
 #
-# Copyright 2021, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/autest-site/directive_engine.py
+++ b/tests/autests/gold_tests/autest-site/directive_engine.py
@@ -3,7 +3,7 @@ Implement X-Proxy-Directive behavior.
 '''
 # @file
 #
-# Copyright 2026, Verizon Media
+# Copyright 2021-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/autest-site/directive_engine.py
+++ b/tests/autests/gold_tests/autest-site/directive_engine.py
@@ -3,7 +3,7 @@ Implement X-Proxy-Directive behavior.
 '''
 # @file
 #
-# Copyright 2021, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/autest-site/proxy.test.ext
+++ b/tests/autests/gold_tests/autest-site/proxy.test.ext
@@ -3,7 +3,7 @@ Implement Proxy Verifier test proxy logic
 '''
 # @file
 #
-# Copyright 2026, Verizon Media
+# Copyright 2021-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/autest-site/proxy.test.ext
+++ b/tests/autests/gold_tests/autest-site/proxy.test.ext
@@ -3,7 +3,7 @@ Implement Proxy Verifier test proxy logic
 '''
 # @file
 #
-# Copyright 2021, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/autest-site/proxy_protocol_context.py
+++ b/tests/autests/gold_tests/autest-site/proxy_protocol_context.py
@@ -3,7 +3,7 @@ Implement the PROXY protocol utility class and the socket wrapper class.
 '''
 # @file
 #
-# Copyright 2026, Verizon Media
+# Copyright 2023-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/autest-site/proxy_protocol_context.py
+++ b/tests/autests/gold_tests/autest-site/proxy_protocol_context.py
@@ -3,7 +3,7 @@ Implement the PROXY protocol utility class and the socket wrapper class.
 '''
 # @file
 #
-# Copyright 2023, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/autest-site/replay_gen.test.ext
+++ b/tests/autests/gold_tests/autest-site/replay_gen.test.ext
@@ -3,7 +3,7 @@ Implement the replay-gen.py extension.
 '''
 # @file
 #
-# Copyright 2026, Verizon Media
+# Copyright 2021-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/autest-site/replay_gen.test.ext
+++ b/tests/autests/gold_tests/autest-site/replay_gen.test.ext
@@ -3,7 +3,7 @@ Implement the replay-gen.py extension.
 '''
 # @file
 #
-# Copyright 2021, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/autest-site/server.test.ext
+++ b/tests/autests/gold_tests/autest-site/server.test.ext
@@ -3,7 +3,7 @@ Implement the Proxy Verifier test server extension.
 '''
 # @file
 #
-# Copyright 2026, Verizon Media
+# Copyright 2023-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/autest-site/server.test.ext
+++ b/tests/autests/gold_tests/autest-site/server.test.ext
@@ -3,7 +3,7 @@ Implement the Proxy Verifier test server extension.
 '''
 # @file
 #
-# Copyright 2023, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/autest-site/socket_util.py
+++ b/tests/autests/gold_tests/autest-site/socket_util.py
@@ -3,7 +3,7 @@ Implement socket manipulation helper functions.
 '''
 # @file
 #
-# Copyright 2020, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/autest-site/socket_util.py
+++ b/tests/autests/gold_tests/autest-site/socket_util.py
@@ -3,7 +3,7 @@ Implement socket manipulation helper functions.
 '''
 # @file
 #
-# Copyright 2026, Verizon Media
+# Copyright 2020-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/autest-site/test_proxy.py
+++ b/tests/autests/gold_tests/autest-site/test_proxy.py
@@ -3,7 +3,7 @@ Implement the common test proxy logic.
 '''
 # @file
 #
-# Copyright 2021, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/autest-site/test_proxy.py
+++ b/tests/autests/gold_tests/autest-site/test_proxy.py
@@ -3,7 +3,7 @@ Implement the common test proxy logic.
 '''
 # @file
 #
-# Copyright 2026, Verizon Media
+# Copyright 2021-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/await/await.replay.yaml
+++ b/tests/autests/gold_tests/await/await.replay.yaml
@@ -1,6 +1,6 @@
 # @file
 #
-# Copyright 2022, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/await/await.replay.yaml
+++ b/tests/autests/gold_tests/await/await.replay.yaml
@@ -1,6 +1,6 @@
 # @file
 #
-# Copyright 2026, Verizon Media
+# Copyright 2022-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/await/await.test.py
+++ b/tests/autests/gold_tests/await/await.test.py
@@ -3,7 +3,7 @@ Verify correct handling of the transaction await directive.
 '''
 # @file
 #
-# Copyright 2022, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/await/await.test.py
+++ b/tests/autests/gold_tests/await/await.test.py
@@ -3,7 +3,7 @@ Verify correct handling of the transaction await directive.
 '''
 # @file
 #
-# Copyright 2026, Verizon Media
+# Copyright 2022-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/body/body.test.py
+++ b/tests/autests/gold_tests/body/body.test.py
@@ -3,7 +3,7 @@ Verify basic body reading functionality.
 '''
 # @file
 #
-# Copyright 2021, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/body/body.test.py
+++ b/tests/autests/gold_tests/body/body.test.py
@@ -3,7 +3,7 @@ Verify basic body reading functionality.
 '''
 # @file
 #
-# Copyright 2026, Verizon Media
+# Copyright 2021-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/body_verification/body_verification.test.py
+++ b/tests/autests/gold_tests/body_verification/body_verification.test.py
@@ -3,7 +3,7 @@ Verify basic body verification functionality.
 '''
 # @file
 #
-# Copyright 2022, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/body_verification/body_verification.test.py
+++ b/tests/autests/gold_tests/body_verification/body_verification.test.py
@@ -3,7 +3,7 @@ Verify basic body verification functionality.
 '''
 # @file
 #
-# Copyright 2026, Verizon Media
+# Copyright 2022-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/delay/delay.test.py
+++ b/tests/autests/gold_tests/delay/delay.test.py
@@ -3,7 +3,7 @@ Verify correct handling of session and transaction delay.
 '''
 # @file
 #
-# Copyright 2026, Verizon Media
+# Copyright 2021-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/delay/delay.test.py
+++ b/tests/autests/gold_tests/delay/delay.test.py
@@ -3,7 +3,7 @@ Verify correct handling of session and transaction delay.
 '''
 # @file
 #
-# Copyright 2021, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/delay/verify_duration.py
+++ b/tests/autests/gold_tests/delay/verify_duration.py
@@ -4,7 +4,7 @@ Verify client output recorded an expected replay duration.
 '''
 # @file
 #
-# Copyright 2026, Verizon Media
+# Copyright 2021-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/delay/verify_duration.py
+++ b/tests/autests/gold_tests/delay/verify_duration.py
@@ -4,7 +4,7 @@ Verify client output recorded an expected replay duration.
 '''
 # @file
 #
-# Copyright 2021, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/doctest/doctest.test.py
+++ b/tests/autests/gold_tests/doctest/doctest.test.py
@@ -3,7 +3,7 @@ Verify the example replay file from the README.
 '''
 # @file
 #
-# Copyright 2021, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/doctest/doctest.test.py
+++ b/tests/autests/gold_tests/doctest/doctest.test.py
@@ -3,7 +3,7 @@ Verify the example replay file from the README.
 '''
 # @file
 #
-# Copyright 2026, Verizon Media
+# Copyright 2021-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/doctest/verify_example_replay_contents.py
+++ b/tests/autests/gold_tests/doctest/verify_example_replay_contents.py
@@ -4,7 +4,7 @@ Verify that one file is contained in another
 '''
 # @file
 #
-# Copyright 2026, Verizon Media
+# Copyright 2021-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/doctest/verify_example_replay_contents.py
+++ b/tests/autests/gold_tests/doctest/verify_example_replay_contents.py
@@ -4,7 +4,7 @@ Verify that one file is contained in another
 '''
 # @file
 #
-# Copyright 2021, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/field_parsing/duplicate_fields.test.py
+++ b/tests/autests/gold_tests/field_parsing/duplicate_fields.test.py
@@ -3,7 +3,7 @@ Verify correct handling of duplicate fields in a message.
 '''
 # @file
 #
-# Copyright 2020, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/field_parsing/duplicate_fields.test.py
+++ b/tests/autests/gold_tests/field_parsing/duplicate_fields.test.py
@@ -3,7 +3,7 @@ Verify correct handling of duplicate fields in a message.
 '''
 # @file
 #
-# Copyright 2026, Verizon Media
+# Copyright 2020-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/field_parsing/empty_field.test.py
+++ b/tests/autests/gold_tests/field_parsing/empty_field.test.py
@@ -3,7 +3,7 @@ Verify correct handling of malformed replay files.
 '''
 # @file
 #
-# Copyright 2021, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/field_parsing/empty_field.test.py
+++ b/tests/autests/gold_tests/field_parsing/empty_field.test.py
@@ -3,7 +3,7 @@ Verify correct handling of malformed replay files.
 '''
 # @file
 #
-# Copyright 2026, Verizon Media
+# Copyright 2021-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/field_parsing/empty_proxy.test.py
+++ b/tests/autests/gold_tests/field_parsing/empty_proxy.test.py
@@ -3,7 +3,7 @@ Verify correct handling of empty proxy nodes.
 '''
 # @file
 #
-# Copyright 2020, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/field_parsing/empty_proxy.test.py
+++ b/tests/autests/gold_tests/field_parsing/empty_proxy.test.py
@@ -3,7 +3,7 @@ Verify correct handling of empty proxy nodes.
 '''
 # @file
 #
-# Copyright 2026, Verizon Media
+# Copyright 2020-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/field_parsing/parse_yaml.test.py
+++ b/tests/autests/gold_tests/field_parsing/parse_yaml.test.py
@@ -3,7 +3,7 @@ Verify correct parsing of YAML replay files.
 '''
 # @file
 #
-# Copyright 2020, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/field_parsing/parse_yaml.test.py
+++ b/tests/autests/gold_tests/field_parsing/parse_yaml.test.py
@@ -3,7 +3,7 @@ Verify correct parsing of YAML replay files.
 '''
 # @file
 #
-# Copyright 2026, Verizon Media
+# Copyright 2020-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/http/http.test.py
+++ b/tests/autests/gold_tests/http/http.test.py
@@ -3,7 +3,7 @@ Verify basic HTTP/1.x functionality.
 '''
 # @file
 #
-# Copyright 2021, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/http/http.test.py
+++ b/tests/autests/gold_tests/http/http.test.py
@@ -3,7 +3,7 @@ Verify basic HTTP/1.x functionality.
 '''
 # @file
 #
-# Copyright 2026, Verizon Media
+# Copyright 2021-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/http/replay_files/multiple_transactions/file3.yaml
+++ b/tests/autests/gold_tests/http/replay_files/multiple_transactions/file3.yaml
@@ -1,6 +1,6 @@
 # @file
 #
-# Copyright 2022, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/http/replay_files/multiple_transactions/file3.yaml
+++ b/tests/autests/gold_tests/http/replay_files/multiple_transactions/file3.yaml
@@ -1,6 +1,6 @@
 # @file
 #
-# Copyright 2026, Verizon Media
+# Copyright 2022-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/http2/http2.test.py
+++ b/tests/autests/gold_tests/http2/http2.test.py
@@ -3,7 +3,7 @@ Verify basic HTTP/2 functionality.
 '''
 # @file
 #
-# Copyright 2022, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/http2/http2.test.py
+++ b/tests/autests/gold_tests/http2/http2.test.py
@@ -3,7 +3,7 @@ Verify basic HTTP/2 functionality.
 '''
 # @file
 #
-# Copyright 2026, Verizon Media
+# Copyright 2022-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/http2_abort/http2_abort.test.py
+++ b/tests/autests/gold_tests/http2_abort/http2_abort.test.py
@@ -3,7 +3,7 @@ Abort HTTP/2 connection.
 '''
 # @file
 #
-# Copyright 2023, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/http2_abort/http2_abort.test.py
+++ b/tests/autests/gold_tests/http2_abort/http2_abort.test.py
@@ -3,7 +3,7 @@ Abort HTTP/2 connection.
 '''
 # @file
 #
-# Copyright 2026, Verizon Media
+# Copyright 2023-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/http2_abort/replay_files/server_goaway_after_headers.yaml
+++ b/tests/autests/gold_tests/http2_abort/replay_files/server_goaway_after_headers.yaml
@@ -1,6 +1,6 @@
 # @file
 #
-# Copyright 2023, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/http2_abort/replay_files/server_goaway_after_headers.yaml
+++ b/tests/autests/gold_tests/http2_abort/replay_files/server_goaway_after_headers.yaml
@@ -1,6 +1,6 @@
 # @file
 #
-# Copyright 2026, Verizon Media
+# Copyright 2023-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/http2_abort/replay_files/server_rst_stream_after_headers.yaml
+++ b/tests/autests/gold_tests/http2_abort/replay_files/server_rst_stream_after_headers.yaml
@@ -1,6 +1,6 @@
 # @file
 #
-# Copyright 2023, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/http2_abort/replay_files/server_rst_stream_after_headers.yaml
+++ b/tests/autests/gold_tests/http2_abort/replay_files/server_rst_stream_after_headers.yaml
@@ -1,6 +1,6 @@
 # @file
 #
-# Copyright 2026, Verizon Media
+# Copyright 2023-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/http2_close_on_goaway/http2_close_on_goaway.test.py
+++ b/tests/autests/gold_tests/http2_close_on_goaway/http2_close_on_goaway.test.py
@@ -3,7 +3,7 @@ GOAWAY frame tests.
 '''
 # @file
 #
-# Copyright 2026, Verizon Media
+# Copyright 2024-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 Test.Summary = '''

--- a/tests/autests/gold_tests/http2_close_on_goaway/http2_close_on_goaway.test.py
+++ b/tests/autests/gold_tests/http2_close_on_goaway/http2_close_on_goaway.test.py
@@ -3,7 +3,7 @@ GOAWAY frame tests.
 '''
 # @file
 #
-# Copyright 2024, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 Test.Summary = '''

--- a/tests/autests/gold_tests/http2_close_on_goaway/http2_close_on_goaway.yaml
+++ b/tests/autests/gold_tests/http2_close_on_goaway/http2_close_on_goaway.yaml
@@ -1,6 +1,6 @@
 # @file
 #
-# Copyright 2026, Verizon Media
+# Copyright 2024-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/http2_close_on_goaway/http2_close_on_goaway.yaml
+++ b/tests/autests/gold_tests/http2_close_on_goaway/http2_close_on_goaway.yaml
@@ -1,6 +1,6 @@
 # @file
 #
-# Copyright 2024, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/http2_frames/http2_frames.test.py
+++ b/tests/autests/gold_tests/http2_frames/http2_frames.test.py
@@ -3,7 +3,7 @@ Specify h2 frame sequence.
 '''
 # @file
 #
-# Copyright 2026, Verizon Media
+# Copyright 2022-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/http2_frames/http2_frames.test.py
+++ b/tests/autests/gold_tests/http2_frames/http2_frames.test.py
@@ -3,7 +3,7 @@ Specify h2 frame sequence.
 '''
 # @file
 #
-# Copyright 2022, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/http2_frames/http2_multi_data_frames.test.py
+++ b/tests/autests/gold_tests/http2_frames/http2_multi_data_frames.test.py
@@ -3,7 +3,7 @@ Send multiple data frames.
 '''
 # @file
 #
-# Copyright 2026, Verizon Media
+# Copyright 2023-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/http2_frames/http2_multi_data_frames.test.py
+++ b/tests/autests/gold_tests/http2_frames/http2_multi_data_frames.test.py
@@ -3,7 +3,7 @@ Send multiple data frames.
 '''
 # @file
 #
-# Copyright 2023, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/http2_frames/verify_duration.py
+++ b/tests/autests/gold_tests/http2_frames/verify_duration.py
@@ -4,7 +4,7 @@ Verify client output recorded an expected replay duration.
 '''
 # @file
 #
-# Copyright 2026, Verizon Media
+# Copyright 2021-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/http2_frames/verify_duration.py
+++ b/tests/autests/gold_tests/http2_frames/verify_duration.py
@@ -4,7 +4,7 @@ Verify client output recorded an expected replay duration.
 '''
 # @file
 #
-# Copyright 2021, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/http3/http3.test.py
+++ b/tests/autests/gold_tests/http3/http3.test.py
@@ -3,7 +3,7 @@ Verify basic HTTP/3 functionality.
 '''
 # @file
 #
-# Copyright 2021, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/http3/http3.test.py
+++ b/tests/autests/gold_tests/http3/http3.test.py
@@ -3,7 +3,7 @@ Verify basic HTTP/3 functionality.
 '''
 # @file
 #
-# Copyright 2026, Verizon Media
+# Copyright 2021-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/https/https.test.py
+++ b/tests/autests/gold_tests/https/https.test.py
@@ -3,7 +3,7 @@ Verify basic HTTPS functionality.
 '''
 # @file
 #
-# Copyright 2026, Verizon Media
+# Copyright 2021-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/https/https.test.py
+++ b/tests/autests/gold_tests/https/https.test.py
@@ -3,7 +3,7 @@ Verify basic HTTPS functionality.
 '''
 # @file
 #
-# Copyright 2021, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/https/mtls.test.py
+++ b/tests/autests/gold_tests/https/mtls.test.py
@@ -3,7 +3,7 @@ Verify correct TLS client and server verification behavior.
 '''
 # @file
 #
-# Copyright 2026, Verizon Media
+# Copyright 2021-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/https/mtls.test.py
+++ b/tests/autests/gold_tests/https/mtls.test.py
@@ -3,7 +3,7 @@ Verify correct TLS client and server verification behavior.
 '''
 # @file
 #
-# Copyright 2021, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/ipv6/ipv6.test.py
+++ b/tests/autests/gold_tests/ipv6/ipv6.test.py
@@ -3,7 +3,7 @@ Verify basic IPv6 support.
 '''
 # @file
 #
-# Copyright 2021, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/ipv6/ipv6.test.py
+++ b/tests/autests/gold_tests/ipv6/ipv6.test.py
@@ -3,7 +3,7 @@ Verify basic IPv6 support.
 '''
 # @file
 #
-# Copyright 2026, Verizon Media
+# Copyright 2021-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/no_proxy/no_proxy.test.py
+++ b/tests/autests/gold_tests/no_proxy/no_proxy.test.py
@@ -3,7 +3,7 @@ Verify basic --no-proxy functionality.
 '''
 # @file
 #
-# Copyright 2026, Verizon Media
+# Copyright 2022-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/no_proxy/no_proxy.test.py
+++ b/tests/autests/gold_tests/no_proxy/no_proxy.test.py
@@ -3,7 +3,7 @@ Verify basic --no-proxy functionality.
 '''
 # @file
 #
-# Copyright 2022, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/proxy-protocol/proxy_protocol.test.py
+++ b/tests/autests/gold_tests/proxy-protocol/proxy_protocol.test.py
@@ -3,7 +3,7 @@ Verify basic PROXY protocol functionality.
 '''
 # @file
 #
-# Copyright 2023, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/proxy-protocol/proxy_protocol.test.py
+++ b/tests/autests/gold_tests/proxy-protocol/proxy_protocol.test.py
@@ -3,7 +3,7 @@ Verify basic PROXY protocol functionality.
 '''
 # @file
 #
-# Copyright 2026, Verizon Media
+# Copyright 2023-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/proxy-protocol/replay_files/http_pp_v1_with_address.replay.yaml
+++ b/tests/autests/gold_tests/proxy-protocol/replay_files/http_pp_v1_with_address.replay.yaml
@@ -1,6 +1,6 @@
 # @file
 #
-# Copyright 2023, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/proxy-protocol/replay_files/http_pp_v1_with_address.replay.yaml
+++ b/tests/autests/gold_tests/proxy-protocol/replay_files/http_pp_v1_with_address.replay.yaml
@@ -1,6 +1,6 @@
 # @file
 #
-# Copyright 2026, Verizon Media
+# Copyright 2023-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/proxy-protocol/replay_files/http_single_transaction_no_pp.replay.yaml
+++ b/tests/autests/gold_tests/proxy-protocol/replay_files/http_single_transaction_no_pp.replay.yaml
@@ -1,6 +1,6 @@
 # @file
 #
-# Copyright 2023, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/proxy-protocol/replay_files/http_single_transaction_no_pp.replay.yaml
+++ b/tests/autests/gold_tests/proxy-protocol/replay_files/http_single_transaction_no_pp.replay.yaml
@@ -1,6 +1,6 @@
 # @file
 #
-# Copyright 2026, Verizon Media
+# Copyright 2023-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/proxy-protocol/replay_files/http_single_transaction_pp_v1.replay.yaml
+++ b/tests/autests/gold_tests/proxy-protocol/replay_files/http_single_transaction_pp_v1.replay.yaml
@@ -1,6 +1,6 @@
 # @file
 #
-# Copyright 2023, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/proxy-protocol/replay_files/http_single_transaction_pp_v1.replay.yaml
+++ b/tests/autests/gold_tests/proxy-protocol/replay_files/http_single_transaction_pp_v1.replay.yaml
@@ -1,6 +1,6 @@
 # @file
 #
-# Copyright 2026, Verizon Media
+# Copyright 2023-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/proxy-protocol/replay_files/http_single_transaction_pp_v2.replay.yaml
+++ b/tests/autests/gold_tests/proxy-protocol/replay_files/http_single_transaction_pp_v2.replay.yaml
@@ -1,6 +1,6 @@
 # @file
 #
-# Copyright 2023, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/proxy-protocol/replay_files/http_single_transaction_pp_v2.replay.yaml
+++ b/tests/autests/gold_tests/proxy-protocol/replay_files/http_single_transaction_pp_v2.replay.yaml
@@ -1,6 +1,6 @@
 # @file
 #
-# Copyright 2026, Verizon Media
+# Copyright 2023-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/proxy-protocol/replay_files/https_single_transaction_pp_v1.replay.yaml
+++ b/tests/autests/gold_tests/proxy-protocol/replay_files/https_single_transaction_pp_v1.replay.yaml
@@ -1,6 +1,6 @@
 # @file
 #
-# Copyright 2023, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 ---

--- a/tests/autests/gold_tests/proxy-protocol/replay_files/https_single_transaction_pp_v1.replay.yaml
+++ b/tests/autests/gold_tests/proxy-protocol/replay_files/https_single_transaction_pp_v1.replay.yaml
@@ -1,6 +1,6 @@
 # @file
 #
-# Copyright 2026, Verizon Media
+# Copyright 2023-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 ---

--- a/tests/autests/gold_tests/proxy-protocol/replay_files/https_single_transaction_pp_v2.replay.yaml
+++ b/tests/autests/gold_tests/proxy-protocol/replay_files/https_single_transaction_pp_v2.replay.yaml
@@ -1,6 +1,6 @@
 # @file
 #
-# Copyright 2023, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 ---

--- a/tests/autests/gold_tests/proxy-protocol/replay_files/https_single_transaction_pp_v2.replay.yaml
+++ b/tests/autests/gold_tests/proxy-protocol/replay_files/https_single_transaction_pp_v2.replay.yaml
@@ -1,6 +1,6 @@
 # @file
 #
-# Copyright 2026, Verizon Media
+# Copyright 2023-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 ---

--- a/tests/autests/gold_tests/proxy-protocol/replay_files/single_transaction_ipv6_pp_v1.replay.yaml
+++ b/tests/autests/gold_tests/proxy-protocol/replay_files/single_transaction_ipv6_pp_v1.replay.yaml
@@ -1,6 +1,6 @@
 # @file
 #
-# Copyright 2023, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/proxy-protocol/replay_files/single_transaction_ipv6_pp_v1.replay.yaml
+++ b/tests/autests/gold_tests/proxy-protocol/replay_files/single_transaction_ipv6_pp_v1.replay.yaml
@@ -1,6 +1,6 @@
 # @file
 #
-# Copyright 2026, Verizon Media
+# Copyright 2023-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/proxy-protocol/replay_files/single_transaction_ipv6_pp_v2.replay.yaml
+++ b/tests/autests/gold_tests/proxy-protocol/replay_files/single_transaction_ipv6_pp_v2.replay.yaml
@@ -1,6 +1,6 @@
 # @file
 #
-# Copyright 2023, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/proxy-protocol/replay_files/single_transaction_ipv6_pp_v2.replay.yaml
+++ b/tests/autests/gold_tests/proxy-protocol/replay_files/single_transaction_ipv6_pp_v2.replay.yaml
@@ -1,6 +1,6 @@
 # @file
 #
-# Copyright 2026, Verizon Media
+# Copyright 2023-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/replay_gen/replay_gen.test.py
+++ b/tests/autests/gold_tests/replay_gen/replay_gen.test.py
@@ -3,7 +3,7 @@ Verify replay-gen.py can generate parsable replay files.
 '''
 # @file
 #
-# Copyright 2026, Verizon Media
+# Copyright 2021-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/replay_gen/replay_gen.test.py
+++ b/tests/autests/gold_tests/replay_gen/replay_gen.test.py
@@ -3,7 +3,7 @@ Verify replay-gen.py can generate parsable replay files.
 '''
 # @file
 #
-# Copyright 2021, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/status_verification/replay_files/status_verification.yaml
+++ b/tests/autests/gold_tests/status_verification/replay_files/status_verification.yaml
@@ -1,6 +1,6 @@
 # @file
 #
-# Copyright 2023, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/status_verification/replay_files/status_verification.yaml
+++ b/tests/autests/gold_tests/status_verification/replay_files/status_verification.yaml
@@ -1,6 +1,6 @@
 # @file
 #
-# Copyright 2026, Verizon Media
+# Copyright 2023-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/status_verification/status_verification.test.py
+++ b/tests/autests/gold_tests/status_verification/status_verification.test.py
@@ -3,7 +3,7 @@ Verify correct response status(status code and reason) verification behavior.
 '''
 # @file
 #
-# Copyright 2026, Verizon Media
+# Copyright 2023-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/status_verification/status_verification.test.py
+++ b/tests/autests/gold_tests/status_verification/status_verification.test.py
@@ -3,7 +3,7 @@ Verify correct response status(status code and reason) verification behavior.
 '''
 # @file
 #
-# Copyright 2023, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/strict_mode/strict_mode.test.py
+++ b/tests/autests/gold_tests/strict_mode/strict_mode.test.py
@@ -3,7 +3,7 @@ Verify strict mode functionality.
 '''
 # @file
 #
-# Copyright 2026, Verizon Media
+# Copyright 2021-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/strict_mode/strict_mode.test.py
+++ b/tests/autests/gold_tests/strict_mode/strict_mode.test.py
@@ -3,7 +3,7 @@ Verify strict mode functionality.
 '''
 # @file
 #
-# Copyright 2021, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/url_verification/url_verification.test.py
+++ b/tests/autests/gold_tests/url_verification/url_verification.test.py
@@ -3,7 +3,7 @@ Verify correct URL verification behavior.
 '''
 # @file
 #
-# Copyright 2026, Verizon Media
+# Copyright 2021-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/gold_tests/url_verification/url_verification.test.py
+++ b/tests/autests/gold_tests/url_verification/url_verification.test.py
@@ -3,7 +3,7 @@ Verify correct URL verification behavior.
 '''
 # @file
 #
-# Copyright 2021, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/test-env-check.sh
+++ b/tests/autests/test-env-check.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2026, Verizon Media
+# Copyright 2020-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/autests/test-env-check.sh
+++ b/tests/autests/test-env-check.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2020, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tests/unit_tests/test_chunk_parsing.cc
+++ b/tests/unit_tests/test_chunk_parsing.cc
@@ -1,7 +1,7 @@
 /** @file
  * Unit tests for HttpReplay.h.
  *
- * Copyright 2020, Verizon Media
+ * Copyright 2026, Verizon Media
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/tests/unit_tests/test_chunk_parsing.cc
+++ b/tests/unit_tests/test_chunk_parsing.cc
@@ -1,7 +1,7 @@
 /** @file
  * Unit tests for HttpReplay.h.
  *
- * Copyright 2026, Verizon Media
+ * Copyright 2020-2026, Verizon Media
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/tools/clang-format.sh
+++ b/tools/clang-format.sh
@@ -2,7 +2,7 @@
 #
 #  Simple wrapper to run clang-format on a bunch of files
 #
-# Copyright 2021, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tools/clang-format.sh
+++ b/tools/clang-format.sh
@@ -2,7 +2,7 @@
 #
 #  Simple wrapper to run clang-format on a bunch of files
 #
-# Copyright 2026, Verizon Media
+# Copyright 2021-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tools/copyright-update.sh
+++ b/tools/copyright-update.sh
@@ -1,7 +1,7 @@
 #! /usr/bin/env bash
 #
-# Given a commit, update all the Copyrights of the changed files.
-# If no commit is provided, update the currently changed files in the worktree.
+# Update Copyrights to the year of each file's most recent commit.
+# If a commit is provided, limit the update to files changed by that commit.
 #
 # Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
@@ -11,31 +11,67 @@ usage="$(basename "$0") [git_commit]"
 
 fail()
 {
-  echo -e $1
+  printf '%b\n' "$1" >&2
   exit 1
 }
 [ $# -le 1 ] || fail "Provide at most one git commit.\n\n${usage}"
 commit=${1:-}
+copyright_owners='(Verizon Media|Yahoo)'
+copyright_range='(Copyright [[:digit:]]{4}-)[[:digit:]]{4}'
 tools_dir=$(dirname "$0")
 git_root=$(dirname "${tools_dir}")
-cd "${git_root}"
-current_year=$(date +%Y)
+cd "${git_root}" || fail "Could not enter the git worktree: ${git_root}"
 
-while IFS= read -r -d '' changed_file; do
-  [ -f "${changed_file}" ] || continue
-  grep -q "Copyright " "${changed_file}" || continue
-  sed -i'.sedbak' \
-    "s/Copyright 20[[:digit:]][[:digit:]]/Copyright ${current_year}/g" \
-    "${changed_file}"
-done < <(
-  if [ -n "${commit}" ]; then
-    git diff-tree --no-commit-id --name-only --diff-filter=ACMRTUXB -r -z "${commit}"
-  else
-    {
-      git diff --name-only --diff-filter=ACMRTUXB -z HEAD --
-      git ls-files --others --exclude-standard -z
-    } | awk 'BEGIN { RS = "\0"; ORS = "\0" } !seen[$0]++'
-  fi
-)
+if [ -n "${commit}" ]; then
+  git rev-parse --verify "${commit}^{commit}" >/dev/null 2>&1 || \
+    fail "Could not resolve git commit: ${commit}\n\n${usage}"
+fi
+[ "$(git rev-parse --is-shallow-repository)" = "false" ] || \
+  fail "A complete git history is required to determine copyright years."
 
-find . -name '*.sedbak' -delete
+selected_files=$(mktemp "${TMPDIR:-/tmp}/copyright-update.XXXXXX") || \
+  fail "Could not create a temporary file."
+cleanup()
+{
+  rm -f -- "${selected_files}"
+}
+trap cleanup EXIT
+trap 'exit 1' HUP INT TERM
+
+if [ -n "${commit}" ]; then
+  git diff-tree --no-commit-id --name-only --diff-filter=ACMRTUXB -r \
+    "${commit}" > "${selected_files}"
+else
+  git ls-files > "${selected_files}"
+fi
+
+# A single history traversal avoids invoking git once for every tracked file.
+git log --format='CopyrightYear:%cd' --date=format:%Y --name-only \
+  --diff-filter=ACMRTUXB HEAD -- |
+  awk '
+    NR == FNR {
+      selected[$0] = 1
+      next
+    }
+    /^CopyrightYear:[[:digit:]]{4}$/ {
+      year = substr($0, 15)
+      next
+    }
+    year != "" && $0 in selected && !seen[$0]++ {
+      print year "\t" $0
+    }
+  ' "${selected_files}" - |
+  while IFS="$(printf '\t')" read -r last_commit_year tracked_file; do
+    [ -f "${tracked_file}" ] || continue
+    # Do not alter copyrights embedded in vendored sources.
+    grep -Eq "Copyright [[:digit:]]{4}(-[[:digit:]]{4})?, ${copyright_owners}" \
+      "${tracked_file}" || continue
+
+    backup_suffix=".copyright-update.$$"
+    # A range retains its starting year; only its ending year changes.
+    sed -E -i"${backup_suffix}" \
+      -e "s/${copyright_range}(, ${copyright_owners})/\\1${last_commit_year}\\2/g" \
+      -e "s/Copyright [[:digit:]]{4}(, ${copyright_owners})/Copyright ${last_commit_year}\\1/g" \
+      "${tracked_file}"
+    rm -f -- "${tracked_file}${backup_suffix}"
+  done

--- a/tools/copyright-update.sh
+++ b/tools/copyright-update.sh
@@ -18,6 +18,8 @@ fail()
 commit=${1:-}
 copyright_owners='(Verizon Media|Yahoo)'
 copyright_range='(Copyright [[:digit:]]{4}-)[[:digit:]]{4}'
+copyright_single='(Copyright [[:digit:]]{4})'
+copyright_pattern="Copyright ([[:digit:]]{4})(-([[:digit:]]{4}))?, ${copyright_owners}"
 tools_dir=$(dirname "$0")
 git_root=$(dirname "${tools_dir}")
 cd "${git_root}" || fail "Could not enter the git worktree: ${git_root}"
@@ -64,14 +66,24 @@ git log --format='CopyrightYear:%cd' --date=format:%Y --name-only \
   while IFS="$(printf '\t')" read -r last_commit_year tracked_file; do
     [ -f "${tracked_file}" ] || continue
     # Do not alter copyrights embedded in vendored sources.
-    grep -Eq "Copyright [[:digit:]]{4}(-[[:digit:]]{4})?, ${copyright_owners}" \
-      "${tracked_file}" || continue
+    copyright=$(grep -Em1 "${copyright_pattern}" "${tracked_file}") || continue
+    [[ "${copyright}" =~ ${copyright_pattern} ]] || continue
+    first_year=${BASH_REMATCH[1]}
+    last_header_year=${BASH_REMATCH[3]}
 
     backup_suffix=".copyright-update.$$"
-    # A range retains its starting year; only its ending year changes.
-    sed -E -i"${backup_suffix}" \
-      -e "s/${copyright_range}(, ${copyright_owners})/\\1${last_commit_year}\\2/g" \
-      -e "s/Copyright [[:digit:]]{4}(, ${copyright_owners})/Copyright ${last_commit_year}\\1/g" \
-      "${tracked_file}"
+    if [ -n "${last_header_year}" ]; then
+      [ "${last_header_year}" != "${last_commit_year}" ] || continue
+      # A range retains its starting year; only its ending year changes.
+      sed -E -i"${backup_suffix}" \
+        -e "s/${copyright_range}(, ${copyright_owners})/\\1${last_commit_year}\\2/g" \
+        "${tracked_file}"
+    else
+      [ "${first_year}" != "${last_commit_year}" ] || continue
+      # Preserve the first year by extending a single year into a range.
+      sed -E -i"${backup_suffix}" \
+        -e "s/${copyright_single}(, ${copyright_owners})/\\1-${last_commit_year}\\2/g" \
+        "${tracked_file}"
+    fi
     rm -f -- "${tracked_file}${backup_suffix}"
   done

--- a/tools/pr-prep.sh
+++ b/tools/pr-prep.sh
@@ -1,0 +1,14 @@
+#! /usr/bin/env bash
+#
+# Prepare the worktree for a pull request.
+#
+# Copyright 2026, Verizon Media
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -e
+
+tools_dir=$(dirname -- "$0")
+
+bash -e "${tools_dir}/format.sh"
+bash -e "${tools_dir}/copyright-update.sh"

--- a/tools/remap-config-to-url-list.py
+++ b/tools/remap-config-to-url-list.py
@@ -2,7 +2,7 @@
 
 # @file
 #
-# Copyright 2026, Verizon Media
+# Copyright 2021-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tools/remap-config-to-url-list.py
+++ b/tools/remap-config-to-url-list.py
@@ -2,7 +2,7 @@
 
 # @file
 #
-# Copyright 2021, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tools/replay-gen.py
+++ b/tools/replay-gen.py
@@ -2,7 +2,7 @@
 
 # @file
 #
-# Copyright 2026, Verizon Media
+# Copyright 2022-2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/tools/replay-gen.py
+++ b/tools/replay-gen.py
@@ -2,7 +2,7 @@
 
 # @file
 #
-# Copyright 2022, Verizon Media
+# Copyright 2026, Verizon Media
 # SPDX-License-Identifier: Apache-2.0
 #
 


### PR DESCRIPTION
Derive each tracked file's copyright year from its most recent
commit instead of applying the current calendar year only to changed
files. Traverse history once, preserve ranges, and avoid third-party
copyrights.

Normalize existing project headers so a subsequent CI check starts
clean.