### PR TITLE
Check copyright years in RAT job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,16 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Trust the container workspace
+        run: git config --global --add safe.directory "${GITHUB_WORKSPACE}"
+
+      - name: Verify copyright years
+        run: |
+          bash tools/copyright-update.sh
+          git diff --exit-code
 
       - name: Run Apache RAT
         run: |


### PR DESCRIPTION
Run the history-based copyright updater in the RAT job and fail when
it changes the worktree. Fetch full history so each file's most recent
commit year can be determined reliably.

Depends on #396.