### PR TITLE
Publish Ubuntu CI image to GHCR

### DIFF
--- a/.github/workflows/publish-ci-image.yml
+++ b/.github/workflows/publish-ci-image.yml
@@ -1,0 +1,67 @@
+#
+# @file
+#
+# Copyright 2026, Verizon Media
+# SPDX-License-Identifier: Apache-2.0
+#
+
+name: Publish Ubuntu CI image
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - .github/workflows/publish-ci-image.yml
+      - docker/ubuntu_26.04/Dockerfile
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: publish-ubuntu-ci-image
+  cancel-in-progress: true
+
+env:
+  IMAGE: ghcr.io/yahoo/proxy-verifier/ubuntu:26.04
+
+jobs:
+  publish:
+    name: Build and publish Ubuntu 26.04
+    if: github.repository == 'yahoo/proxy-verifier'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and publish image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/ubuntu_26.04/Dockerfile
+          target: dev
+          platforms: linux/amd64,linux/arm64
+          pull: true
+          no-cache: true
+          provenance: false
+          push: true
+          tags: ${{ env.IMAGE }}
+
+      - name: Inspect published image
+        run: docker buildx imagetools inspect "${IMAGE}"

--- a/README.md
+++ b/README.md
@@ -1877,7 +1877,8 @@ images. Each installs OpenSSL, nghttp2, and nghttp3 from its distribution along
 with the Proxy Verifier build, formatting, license-audit, and AuTest toolchains.
 GitHub Actions uses only the Ubuntu 26.04 image. Alpine 3.24 is used to build
 the portable Linux release binaries, while Fedora 44 provides an additional
-current-distribution development environment.
+current-distribution development environment. Users who prefer Alpine or
+Fedora can build those Dockerfiles for their local build environment.
 
 For deployment, using the statically linked binaries associated with the GitHub
 releases is the easiest path for most people.
@@ -1885,9 +1886,10 @@ releases is the easiest path for most people.
 Tooling for the dev image lives in the `/opt/pv-venv` virtual environment and
 is added to the `PATH` by the Dockerfile `ENV` configuration.
 
-See [`tools/CI-IMAGES.md`](tools/CI-IMAGES.md) for instructions to build,
-verify, and publish the amd64 and arm64 images and their combined multi-platform
-tags. Build the images from the repository root. For example:
+See [`tools/CI-IMAGES.md`](tools/CI-IMAGES.md) for details about automated
+Ubuntu image publication to GitHub Container Registry and instructions to
+build and verify Alpine and Fedora images locally. Build the images from the
+repository root. For example:
 
 ```bash
 docker build -f docker/ubuntu_26.04/Dockerfile -t pv-dev:ubuntu26.04 .

--- a/docker/ubuntu_26.04/Dockerfile
+++ b/docker/ubuntu_26.04/Dockerfile
@@ -7,6 +7,9 @@
 
 FROM docker.io/library/ubuntu:26.04 AS dev
 
+LABEL org.opencontainers.image.source="https://github.com/yahoo/proxy-verifier" \
+      org.opencontainers.image.licenses="Apache-2.0"
+
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/tools/CI-IMAGES.md
+++ b/tools/CI-IMAGES.md
@@ -7,63 +7,51 @@
 
 # Proxy Verifier Build Images
 
-Proxy Verifier provides Alpine 3.24, Fedora 44, and Ubuntu 26.04 build images.
-GitHub Actions uses only Ubuntu 26.04. Alpine is the portable Linux release
-environment, and Fedora is an additional development environment. Each image
-installs its distribution's OpenSSL, nghttp2, and nghttp3 development packages,
-along with compilers, CMake, Ninja, `uv`, formatting tools, and a
-checksum-verified Apache RAT JAR. The Ubuntu image includes both GCC and Clang
-for the CI test jobs.
+Proxy Verifier provides Dockerfiles for Alpine 3.24, Fedora 44, and Ubuntu
+26.04 build environments. GitHub Actions uses only Ubuntu 26.04. The Alpine
+and Fedora Dockerfiles are available for users who prefer those distributions
+for their local build environment. Alpine is also the portable Linux release
+environment. Each Dockerfile installs its distribution's OpenSSL, nghttp2, and
+nghttp3 development packages, along with compilers, CMake, Ninja, `uv`,
+formatting tools, and a checksum-verified Apache RAT JAR. The Ubuntu image
+includes both GCC and Clang for the CI test jobs.
 
 These images are for development, release builds, and CI workflows, not
 deployment. Use the statically linked binaries attached to Proxy Verifier
 releases for deployment.
 
-## Image Tags
+## Build Environments
 
-| Distribution | Dockerfile | Multi-platform image tag |
+| Distribution | Dockerfile | Usage |
 | --- | --- | --- |
-| Alpine 3.24 | `docker/alpine_3.24/Dockerfile` | `ci.trafficserver.apache.org:5000/proxy-verifier/alpine:3.24` |
-| Fedora 44 | `docker/fedora_44/Dockerfile` | `ci.trafficserver.apache.org:5000/proxy-verifier/fedora:44` |
-| Ubuntu 26.04 | `docker/ubuntu_26.04/Dockerfile` | `ci.trafficserver.apache.org:5000/proxy-verifier/ubuntu:26.04` |
+| Alpine 3.24 | `docker/alpine_3.24/Dockerfile` | Optional local and release build environment |
+| Fedora 44 | `docker/fedora_44/Dockerfile` | Optional local build environment |
+| Ubuntu 26.04 | `docker/ubuntu_26.04/Dockerfile` | Published CI and local build environment |
 
-The architecture-specific inputs append `-amd64` or `-arm64` to the tag. For
-example, the Ubuntu inputs are `ubuntu:26.04-amd64` and
-`ubuntu:26.04-arm64`.
+The Ubuntu image is built for `linux/amd64` and `linux/arm64` and published to
+GitHub Container Registry by the `Publish Ubuntu CI image` workflow. The
+workflow runs whenever its Dockerfile or workflow definition changes on
+`master`, and it can also be started manually from GitHub Actions.
 
-## Prerequisites
+Users who prefer Alpine or Fedora can build those Dockerfiles locally. GitHub
+Actions does not publish images for those environments.
+
+## Build And Verify A Local Image
 
 Build from an up-to-date Proxy Verifier checkout with Docker and the Docker
 Buildx plugin installed. Run every build command from the repository root.
-Prefer native builders because CPU emulation is significantly slower:
+Prefer a native platform because CPU emulation is significantly slower:
 
 * Build `linux/amd64` on an x86_64 Linux host.
 * Build `linux/arm64` on an arm64 Linux host or an Apple Silicon Mac.
 
-Confirm the platforms supported by the active builder and authenticate before
-pushing:
+This example builds Alpine for AMD64. Substitute the Fedora Dockerfile and a
+different local tag to use Fedora instead.
 
 ```bash
-docker buildx ls
-docker login ci.trafficserver.apache.org:5000
-```
-
-The commands below disable Buildx's default provenance attestation. The CI
-registry's `docker manifest create` workflow requires each architecture tag to
-resolve directly to an image manifest rather than another image index.
-
-## Build And Verify An Architecture
-
-Choose one row from the image table and one platform. This example builds the
-Ubuntu AMD64 image; substitute the Dockerfile, image name, version, platform,
-and suffix for the other combinations.
-
-```bash
-dockerfile=docker/ubuntu_26.04/Dockerfile
-image=ci.trafficserver.apache.org:5000/proxy-verifier/ubuntu
-version=26.04
+dockerfile=docker/alpine_3.24/Dockerfile
+image=pv-dev:alpine3.24
 platform=linux/amd64
-suffix=amd64
 
 docker buildx build \
   --load \
@@ -71,7 +59,7 @@ docker buildx build \
   --provenance=false \
   --platform "${platform}" \
   --file "${dockerfile}" \
-  --tag "${image}:${version}-${suffix}" \
+  --tag "${image}" \
   --progress plain \
   .
 ```
@@ -79,11 +67,11 @@ docker buildx build \
 Verify the image's architecture and the system dependency toolchain:
 
 ```bash
-docker image inspect "${image}:${version}-${suffix}" \
+docker image inspect "${image}" \
   --format '{{.Os}}/{{.Architecture}}'
 
 docker run --rm --platform "${platform}" \
-  "${image}:${version}-${suffix}" bash -lc '
+  "${image}" bash -lc '
     set -euo pipefail
     cmake --version
     ninja --version
@@ -97,52 +85,13 @@ docker run --rm --platform "${platform}" \
   '
 ```
 
-The inspect command should print the requested platform. Push the verified
-architecture-specific image and confirm that the remote reference is a direct
-image manifest:
-
-```bash
-docker push "${image}:${version}-${suffix}"
-docker manifest inspect --insecure "${image}:${version}-${suffix}"
-```
-
-Repeat this process for AMD64 and ARM64 for each image in the table.
-
-## Publish A Multi-platform Tag
-
-After both architecture tags for one distribution are present, create its
-multi-platform tag. Continue with the Ubuntu example variables from above:
-
-```bash
-docker manifest rm "${image}:${version}" || true
-
-docker manifest create --insecure \
-  "${image}:${version}" \
-  "${image}:${version}-amd64" \
-  "${image}:${version}-arm64"
-
-docker manifest push --insecure "${image}:${version}"
-docker manifest inspect --insecure "${image}:${version}"
-```
-
-Do not push if `docker manifest create` fails. A failed create can leave a
-partial local manifest, so remove it before correcting the architecture tags
-and retrying. The final inspection must list both `linux/amd64` and
-`linux/arm64`.
-
-Repeat the manifest steps for Alpine, Fedora, and Ubuntu. The GitHub Actions
-workflow pulls only the multi-platform Ubuntu tag without choosing an
-architecture explicitly.
-
 ## Rebuilding Images
 
-Rebuild and republish both architectures whenever one of these Dockerfiles
-changes:
+Rebuild a local Alpine or Fedora image whenever its Dockerfile changes or when
+you want current distribution packages. The `--pull` option refreshes the base
+image, while `--no-cache` can be added to refresh every installed package.
 
-* `docker/alpine_3.24/Dockerfile`
-* `docker/fedora_44/Dockerfile`
-* `docker/ubuntu_26.04/Dockerfile`
-
-Images should also be rebuilt periodically so `--pull` incorporates security
-and bug-fix updates from each distribution. Recreate and verify the
-multi-platform tag after pushing both architecture-specific images.
+The `Publish Ubuntu CI image` workflow rebuilds and publishes the Ubuntu
+image automatically when `docker/ubuntu_26.04/Dockerfile` changes. Run the
+workflow manually to refresh its base image and installed packages without a
+Dockerfile change.


### PR DESCRIPTION
Build and publish the Ubuntu 26.04 development image for AMD64 and
ARM64 whenever its Dockerfile changes. Allow manual dispatches for
periodic dependency refreshes.

Keep Alpine and Fedora on their existing manual publication workflow
and document Ubuntu's GHCR destination.